### PR TITLE
Fix O365 sender-filter ordering, query+sender 400, and whatsnew 200-cap

### DIFF
--- a/src/ts4k/adapters/base.py
+++ b/src/ts4k/adapters/base.py
@@ -59,6 +59,7 @@ class BaseAdapter(ABC):
         since: str | None = None,
         sender: str | None = None,
         domain: str | None = None,
+        count: int = 200,
     ) -> list[dict]:
         """Return new activity since *since* (ISO-8601 timestamp).
 
@@ -68,6 +69,10 @@ class BaseAdapter(ABC):
         *sender* filters to an exact email address; *domain* filters to
         all addresses at that domain.  Both are optional and adapter-
         specific (some adapters may ignore them).
+
+        *count* is the fetch target — adapters that paginate should keep
+        fetching pages until they have *count* results or run out. Best
+        effort; adapters with hard platform caps may return fewer.
 
         Each item in the returned list is a normalised header dict with at
         least: ``id``, ``thread_id``, ``from``, ``subject``, ``date``.

--- a/src/ts4k/adapters/gcal.py
+++ b/src/ts4k/adapters/gcal.py
@@ -117,7 +117,8 @@ class GcalAdapter(BaseAdapter):
 
     async def whatsnew(self, since: str | None = None,
                        sender: str | None = None,
-                       domain: str | None = None) -> list[dict]:
+                       domain: str | None = None,
+                       count: int = 200) -> list[dict]:
         return []
 
     async def list_messages(self, query: str | None = None,

--- a/src/ts4k/adapters/gmail.py
+++ b/src/ts4k/adapters/gmail.py
@@ -324,6 +324,7 @@ class GmailAdapter(BaseAdapter):
         since: str | None = None,
         sender: str | None = None,
         domain: str | None = None,
+        count: int = 200,
     ) -> list[dict]:
         """Search for recent messages.
 
@@ -334,7 +335,9 @@ class GmailAdapter(BaseAdapter):
             query = f"after:{since}"
         else:
             query = "newer_than:1d"
-        return await self.list_messages(query=query, sender=sender, domain=domain)
+        return await self.list_messages(
+            query=query, count=count, sender=sender, domain=domain
+        )
 
     async def list_messages(
         self,

--- a/src/ts4k/adapters/o365.py
+++ b/src/ts4k/adapters/o365.py
@@ -295,11 +295,14 @@ class O365Adapter(BaseAdapter):
         since: str | None = None,
         sender: str | None = None,
         domain: str | None = None,
+        count: int = 200,
     ) -> list[dict]:
         since_specified = since is not None
         if not since:
             yesterday = datetime.now(timezone.utc) - timedelta(days=1)
             since = yesterday.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        page_size = str(min(count, 200))
 
         # Domain filtering requires $search which can't combine with $filter.
         # When domain is used, do time filtering client-side.
@@ -308,13 +311,16 @@ class O365Adapter(BaseAdapter):
             params: dict[str, str] = {
                 "$search": domain_search,
                 "$select": _LIST_SELECT,
-                "$top": "200",
+                "$top": page_size,
             }
             headers = {"ConsistencyLevel": "eventual"}
             data = await self._get(
                 f"{self._base_url()}/messages", params, headers=headers
             )
             results = _list_response_to_dicts(data, self.source_prefix)
+            results.extend(
+                await self._follow_next_links(data, count - len(results), headers)
+            )
             # Client-side time filter only when caller specified a since value
             if since_specified:
                 results = [m for m in results if m.get("date", "") >= since]
@@ -331,11 +337,40 @@ class O365Adapter(BaseAdapter):
             "$filter": " and ".join(filter_parts),
             "$select": _LIST_SELECT,
             "$orderby": "receivedDateTime desc",
-            "$top": "200",
+            "$top": page_size,
         }
 
         data = await self._get(f"{self._base_url()}/messages", params)
-        return _list_response_to_dicts(data, self.source_prefix)
+        results = _list_response_to_dicts(data, self.source_prefix)
+        results.extend(await self._follow_next_links(data, count - len(results)))
+        return results
+
+    async def _follow_next_links(
+        self,
+        data: dict | list,
+        needed: int,
+        headers: dict[str, str] | None = None,
+    ) -> list[dict]:
+        """Follow ``@odata.nextLink`` pages until *needed* more results
+        are collected or the server runs out of pages."""
+        extra: list[dict] = []
+        client = self._require_client()
+        while needed > 0 and isinstance(data, dict):
+            next_link = data.get("@odata.nextLink")
+            if not next_link:
+                break
+            if headers:
+                resp = await client.get(next_link, headers=headers)
+            else:
+                resp = await client.get(next_link)
+            resp.raise_for_status()
+            data = resp.json()
+            page = _list_response_to_dicts(data, self.source_prefix)
+            if not page:
+                break
+            extra.extend(page)
+            needed -= len(page)
+        return extra
 
     async def list_messages(
         self,

--- a/src/ts4k/adapters/o365.py
+++ b/src/ts4k/adapters/o365.py
@@ -365,33 +365,40 @@ class O365Adapter(BaseAdapter):
             if page_token:
                 params["$skip"] = page_token
 
-            # Sender filter via $filter (exact match).
-            # Filtering on from/emailAddress/address requires ConsistencyLevel
-            # header and is incompatible with $orderby.
+            # Sender-only filter via $filter (exact match). Graph permits
+            # $orderby alongside a from-filter only when the orderby property
+            # leads the $filter, so anchor it with a date floor — dropping
+            # $orderby instead returns oldest-first and small $top values
+            # truncate to the wrong end.
             sender_filter = _build_sender_filter(sender)
-            if sender_filter:
-                params["$filter"] = sender_filter
-                params.pop("$orderby", None)
+            if sender_filter and not query:
+                params["$filter"] = (
+                    f"receivedDateTime ge 1900-01-01T00:00:00Z and {sender_filter}"
+                )
 
             headers_dict: dict[str, str] | None = None
 
             # Domain filter via $search (endsWith not supported on from address)
             domain_search = _build_domain_search(domain)
 
-            # Any use of $filter on from or $search requires ConsistencyLevel
-            needs_consistency = bool(sender_filter or domain_search or query)
-            if needs_consistency:
-                headers_dict = {"ConsistencyLevel": "eventual"}
-                params.pop("$orderby", None)
-                # $skip is incompatible with $search — use @odata.nextLink instead
-                params.pop("$skip", None)
-
-            if query and domain_search:
+            # $search cannot combine with $filter or $orderby (400), and
+            # requires the ConsistencyLevel header. A sender combined with a
+            # free-text query therefore folds into the KQL string instead of
+            # using $filter.
+            if query and sender:
+                params["$search"] = f'"from:{sender} {query}"'
+            elif query and domain_search:
                 params["$search"] = f'"from:@{domain} {query}"'
             elif query:
                 params["$search"] = f'"{query}"'
             elif domain_search:
                 params["$search"] = domain_search
+
+            if "$search" in params:
+                headers_dict = {"ConsistencyLevel": "eventual"}
+                params.pop("$orderby", None)
+                # $skip is incompatible with $search — use @odata.nextLink instead
+                params.pop("$skip", None)
 
             data = await self._get(
                 f"{self._base_url()}/messages", params, headers=headers_dict
@@ -399,10 +406,9 @@ class O365Adapter(BaseAdapter):
 
         results = _list_response_to_dicts(data, self.source_prefix)
 
-        # Client-side sort when $orderby was removed
-        needs_sort = use_next_link or bool(
-            _build_sender_filter(sender) or _build_domain_search(domain) or query
-        )
+        # Client-side sort when $orderby was removed ($search paths only —
+        # the sender-only $filter path keeps server-side ordering)
+        needs_sort = use_next_link or bool(query or _build_domain_search(domain))
         if needs_sort:
             results.sort(key=lambda m: m.get("date", ""), reverse=True)
 

--- a/src/ts4k/adapters/o365cal.py
+++ b/src/ts4k/adapters/o365cal.py
@@ -151,7 +151,8 @@ class O365CalAdapter(BaseAdapter):
 
     async def whatsnew(self, since: str | None = None,
                        sender: str | None = None,
-                       domain: str | None = None) -> list[dict]:
+                       domain: str | None = None,
+                       count: int = 200) -> list[dict]:
         return []
 
     async def list_messages(self, query: str | None = None,

--- a/src/ts4k/adapters/whatsapp.py
+++ b/src/ts4k/adapters/whatsapp.py
@@ -260,7 +260,9 @@ class WhatsAppAdapter(BaseAdapter):
         since: str | None = None,
         sender: str | None = None,
         domain: str | None = None,
+        count: int = 200,
     ) -> list[dict]:
+        # count is accepted for interface parity; the bridge caps at 50.
         args: dict[str, Any] = {"limit": 50, "include_context": False}
         if since:
             args["after"] = since

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -371,12 +371,15 @@ async def _fetch_for_source(
     provider = cfg.get("provider", "").lower()
     try:
         async with adapter:
+            # Over-fetch past count so the aggregation layer can see
+            # truncation (has_more / watermark direction). Everything
+            # fetched is returned; _fetch_messages truncates to count.
             if provider == "gmail":
                 query = _utc_to_gmail_query(since)
-                listing = await adapter.list_messages(query=query, count=count, sender=sender, domain=domain)
+                listing = await adapter.list_messages(
+                    query=query, count=count + 1, sender=sender, domain=domain
+                )
             else:
-                # Over-fetch (count+1, floor 200) so truncation detection
-                # still sees "more available" past the requested count.
                 listing = await adapter.whatsnew(
                     since=since, sender=sender, domain=domain,
                     count=max(count + 1, 200),
@@ -385,7 +388,7 @@ async def _fetch_for_source(
             if not listing:
                 return []
             messages = []
-            for entry in listing[:count]:
+            for entry in listing:
                 msg = _normalize_message(entry)
                 msg.setdefault("source", prefix)
                 cache.store_message(msg.get("id", ""), msg)

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -375,7 +375,12 @@ async def _fetch_for_source(
                 query = _utc_to_gmail_query(since)
                 listing = await adapter.list_messages(query=query, count=count, sender=sender, domain=domain)
             else:
-                listing = await adapter.whatsnew(since=since, sender=sender, domain=domain)
+                # Over-fetch (count+1, floor 200) so truncation detection
+                # still sees "more available" past the requested count.
+                listing = await adapter.whatsnew(
+                    since=since, sender=sender, domain=domain,
+                    count=max(count + 1, 200),
+                )
 
             if not listing:
                 return []

--- a/tests/test_gcal_adapter.py
+++ b/tests/test_gcal_adapter.py
@@ -42,6 +42,11 @@ class TestMessagingStubs:
         result = await adapter.whatsnew(since="2026-01-01")
         assert result == []
 
+    async def test_whatsnew_accepts_count(self, adapter: GcalAdapter):
+        """The command layer passes count= to every non-Gmail source."""
+        result = await adapter.whatsnew(since="2026-01-01", count=200)
+        assert result == []
+
     async def test_list_messages_returns_empty(self, adapter: GcalAdapter):
         result = await adapter.list_messages()
         assert result == []

--- a/tests/test_integration_whatsnew.py
+++ b/tests/test_integration_whatsnew.py
@@ -224,6 +224,66 @@ class TestWatermarkDoesNotSkip:
         assert "T21:" in wm_o
 
 
+class _StubAdapter:
+    """Minimal adapter stub for exercising the real _fetch_for_source."""
+
+    def __init__(self, msgs):
+        self._msgs = msgs
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def whatsnew(self, since=None, sender=None, domain=None, count=200):
+        return self._msgs[:count]
+
+    async def list_messages(self, query=None, count=20, page_token=None,
+                            sender=None, domain=None):
+        return self._msgs[:count]
+
+
+class TestSingleSourceTruncationVisible:
+    """PR #50 review: _fetch_for_source must not pre-slice to count, or a
+    single source with more than count new messages looks fully returned —
+    has_more stays False and the watermark skips the rest permanently."""
+
+    @pytest.mark.asyncio
+    async def test_single_source_over_count_sets_has_more(self, monkeypatch):
+        msgs = _fake_messages("o", 10, base_hour=1)
+
+        def fake_make_adapter(prefix, cfg):
+            return _StubAdapter(list(reversed(msgs))) if prefix == "o" else None
+
+        monkeypatch.setattr(commands, "_make_adapter", fake_make_adapter)
+
+        result = await commands.whatsnew(key="single_trunc", source="o", count=3)
+        assert result.has_more is True
+        assert result.messages_processed == 3
+
+        # Truncated source → watermark at oldest returned, not newest.
+        # 10 messages at hours 1-10, top 3 = T10, T09, T08.
+        wm_o = kwm.get("single_trunc", "o")
+        assert wm_o is not None
+        assert "T08:" in wm_o
+
+    @pytest.mark.asyncio
+    async def test_single_gmail_source_over_count_sets_has_more(self, monkeypatch):
+        msgs = _fake_messages("g", 10, base_hour=1)
+
+        def fake_make_adapter(prefix, cfg):
+            return _StubAdapter(list(reversed(msgs))) if prefix == "g" else None
+
+        monkeypatch.setattr(commands, "_make_adapter", fake_make_adapter)
+
+        result = await commands.whatsnew(key="single_trunc_g", source="g", count=3)
+        assert result.has_more is True
+        wm_g = kwm.get("single_trunc_g", "g")
+        assert wm_g is not None
+        assert "T08:" in wm_g
+
+
 class TestFilterBeforeCount:
     """Bug #25: filters must apply before count truncation."""
 

--- a/tests/test_o365_adapter.py
+++ b/tests/test_o365_adapter.py
@@ -716,6 +716,22 @@ class TestO365AdapterSenderFilter:
         assert "alice@contoso.com" in filt
 
     @pytest.mark.asyncio
+    async def test_sender_filter_keeps_newest_first_order(self):
+        """Graph allows $orderby with a from-filter only when the orderby
+        property leads the $filter — without it, results come back
+        oldest-first and small -n truncates to the wrong end."""
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            return_value=_mock_response(LIST_RESPONSE_EMPTY)
+        )
+        await adapter.list_messages(sender="alice@contoso.com")
+
+        call_args = adapter._client.get.call_args
+        params = call_args[1]["params"]
+        assert params["$orderby"] == "receivedDateTime desc"
+        assert params["$filter"].startswith("receivedDateTime ge ")
+
+    @pytest.mark.asyncio
     async def test_domain_filter_on_list(self):
         adapter = _make_adapter()
         adapter._client.get = AsyncMock(
@@ -732,7 +748,8 @@ class TestO365AdapterSenderFilter:
 
     @pytest.mark.asyncio
     async def test_sender_filter_with_query(self):
-        """Sender filter + free-text query should both be present."""
+        """Graph rejects $search + $filter on messages (400), so sender must
+        fold into the KQL search string like the domain path does."""
         adapter = _make_adapter()
         adapter._client.get = AsyncMock(
             return_value=_mock_response(LIST_RESPONSE_EMPTY)
@@ -741,9 +758,8 @@ class TestO365AdapterSenderFilter:
 
         call_args = adapter._client.get.call_args
         params = call_args[1]["params"]
-        assert "$search" in params
-        assert "$filter" in params
-        assert "alice@contoso.com" in params["$filter"]
+        assert "$filter" not in params
+        assert params["$search"] == '"from:alice@contoso.com budget"'
 
 
 class TestStripPrefix:

--- a/tests/test_o365_adapter.py
+++ b/tests/test_o365_adapter.py
@@ -449,6 +449,56 @@ class TestO365AdapterWhatsnew:
         call_args = adapter._client.get.call_args
         assert "receivedDateTime ge" in call_args[1]["params"]["$filter"]
 
+    @pytest.mark.asyncio
+    async def test_count_below_page_size_caps_top(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            return_value=_mock_response(LIST_RESPONSE_EMPTY)
+        )
+        await adapter.whatsnew(since="2026-02-20T00:00:00Z", count=50)
+
+        call_args = adapter._client.get.call_args
+        assert call_args[1]["params"]["$top"] == "50"
+
+    @pytest.mark.asyncio
+    async def test_follows_next_link_past_page_cap(self):
+        adapter = _make_adapter()
+        next_url = "https://graph.microsoft.com/v1.0/me/messages?$skiptoken=abc"
+        page1 = {
+            "value": LIST_RESPONSE_DATA["value"],
+            "@odata.nextLink": next_url,
+        }
+        page2 = {
+            "value": [
+                {
+                    "id": "AAMkAGQ0Zjg0MDEzLWI4",
+                    "subject": "Older message",
+                    "receivedDateTime": "2026-02-19T09:00:00Z",
+                }
+            ]
+        }
+        adapter._client.get = AsyncMock(
+            side_effect=[_mock_response(page1), _mock_response(page2)]
+        )
+        results = await adapter.whatsnew(since="2026-01-01T00:00:00Z", count=300)
+
+        assert adapter._client.get.call_count == 2
+        assert adapter._client.get.call_args_list[1][0][0] == next_url
+        assert len(results) == 3
+
+    @pytest.mark.asyncio
+    async def test_stops_following_when_count_reached(self):
+        adapter = _make_adapter()
+        page1 = {
+            "value": LIST_RESPONSE_DATA["value"],
+            "@odata.nextLink": "https://graph.microsoft.com/v1.0/next",
+        }
+        adapter._client.get = AsyncMock(return_value=_mock_response(page1))
+        results = await adapter.whatsnew(since="2026-01-01T00:00:00Z", count=2)
+
+        assert adapter._client.get.call_count == 1
+        assert len(results) == 2
+
 
 class TestO365AdapterListMessages:
     """Test O365Adapter.list_messages() with mocked httpx client."""

--- a/tests/test_o365cal_adapter.py
+++ b/tests/test_o365cal_adapter.py
@@ -54,6 +54,10 @@ class TestMessagingStubs:
     async def test_whatsnew_returns_empty(self, adapter: O365CalAdapter):
         assert await adapter.whatsnew() == []
 
+    async def test_whatsnew_accepts_count(self, adapter: O365CalAdapter):
+        """The command layer passes count= to every non-Gmail source."""
+        assert await adapter.whatsnew(since="2026-01-01", count=200) == []
+
     async def test_list_messages_returns_empty(self, adapter: O365CalAdapter):
         assert await adapter.list_messages() == []
 


### PR DESCRIPTION
## Summary
Closes #15. Most of that issue (search 400 fix, `--from`/`--domain` flags, skill guidance) already landed in v0.1.16–0.1.19 — this PR fixes the three gaps found by live-testing against a real O365 mailbox:

- **`--from` returned oldest mail first** — the sender path dropped `$orderby` (Graph rejects it alongside a from-filter unless the orderby property leads the `$filter`), so `-n 3` returned 2020 messages. Now anchors the filter with a `receivedDateTime ge` floor and keeps server-side `$orderby receivedDateTime desc`.
- **`-q` + `--from` was a hard 400** — Graph doesn't allow `$search` + `$filter` on messages. The sender now folds into the KQL search string (`$search="from:alice@x.com budget"`), matching the existing domain path.
- **`whatsnew`/`--since` silently capped at 200** — added a `count` param to the whatsnew interface and `@odata.nextLink` pagination; the command layer over-fetches (count+1, floor 200) to preserve more-available detection.

The remaining #15 criterion (overview drill-down to listings) is superseded: `list --from X --since T` covers that workflow directly.

## Test plan
- [x] 4 new adapter tests (ordering, KQL fold, pagination follow/stop)
- [x] Full suite: 785 passed
- [x] Live-verified against real Graph API: newest-first `--from`, working `-q --from`, 250 results past the old 200 cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)