### PR TITLE
feat: generic CalDAV calendar adapter with Apple/iCloud preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ Notes:
 - Levels gate writes like the other calendar providers: `level=modify` allows editing and RSVP, `level=draft` also allows creating events, `level=send` also allows creating events with attendee invites (`ts4k src add cc apple email=... calendar_id=... level=draft`, or edit the source after adding).
 - RSVP is best-effort: iCloud often blocks programmatic replies to external
   invites — ts4k reports this cleanly and you respond in the Calendar app.
-- Free-text event search is filtered client-side (CalDAV limitation).
 
 ### Managing messages
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,25 @@ ts4k cal range --from 2026-04-01 --to 2026-04-07
 ts4k cal event 3                 # Full detail for ref #3
 ```
 
+### Apple / iCloud Calendar (CalDAV)
+
+iCloud calendars connect over CalDAV with an app-specific password — no OAuth setup.
+
+1. Generate an app-specific password at https://account.apple.com
+   (Sign-In and Security → App-Specific Passwords; requires 2FA).
+2. Add the source and pick calendars interactively:
+
+    ts4k src add cc apple email=you@icloud.com
+
+The same provider works for any CalDAV server (Fastmail, Nextcloud, ...):
+pass `server_url=https://your-server/` instead of the `apple` preset.
+
+Notes:
+- Levels gate writes like the other calendar providers: `level=modify` allows editing and RSVP, `level=draft` also allows creating events, `level=send` also allows creating events with attendee invites (`ts4k src add cc apple email=... calendar_id=... level=draft`, or edit the source after adding).
+- RSVP is best-effort: iCloud often blocks programmatic replies to external
+  invites — ts4k reports this cleanly and you respond in the Calendar app.
+- Free-text event search is filtered client-side (CalDAV limitation).
+
 ### Managing messages
 
 Requires `modify` [access level](#access-levels) or higher. All actions are non-destructive and reversible.

--- a/docs/superpowers/plans/2026-07-30-caldav-calendar-adapter.md
+++ b/docs/superpowers/plans/2026-07-30-caldav-calendar-adapter.md
@@ -1,0 +1,1825 @@
+# CalDAV Calendar Adapter (Apple/iCloud) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a generic CalDAV calendar adapter (Apple/iCloud preset) so ts4k's `cal` commands work against iCloud alongside Google Calendar and O365 Calendar.
+
+**Architecture:** New `CaldavAdapter` mirrors `GcalAdapter`'s surface and normalized event shape, built on the synchronous `caldav` PyPI library wrapped in `asyncio.to_thread`. Credentials are an Apple app-specific password stored as 0600 JSON under the config dir (no OAuth). Registration follows the existing pattern: a `provider` branch in `commands._make_adapter`, gate-list extension, and CLI `src add` support with `apple`/`icloud` aliases.
+
+**Tech Stack:** Python 3.12+, `caldav` (new dep; pulls `icalendar`, `lxml`, `vobject`), pytest + pytest-asyncio (`asyncio_mode = "auto"` — no decorator needed on async tests).
+
+**Spec:** `docs/superpowers/specs/2026-07-30-caldav-calendar-adapter-design.md`
+
+## Global Constraints
+
+- Python 3.12+, managed with `uv`. Run tests with `uv run pytest tests/<file> -v`.
+- Only new dependency allowed: `caldav` (add via `uv add caldav`).
+- Provider key: `caldav`. Default/suggested prefix: `cc`. Apple preset server URL: `https://caldav.icloud.com` (constant `ICLOUD_CALDAV_URL`).
+- Normalized event dicts must use the **exact same keys** as `GcalAdapter._normalize_event` (`src/ts4k/adapters/gcal.py:178`): `id, source, title, start, end, all_day, duration_minutes, location, organizer, attendees_summary, status, your_status, recurring_event_id`.
+- Match existing style: dataclass configs, `logger = logging.getLogger(__name__)`, `from __future__ import annotations`, level checks via `ts4k.core.levels.check_level`.
+- Never log or print the app-specific password.
+- Work on a feature branch (e.g. `feature/caldav-adapter`) created at execution time; commit after every green task.
+- Test isolation: use the `ts4k_config` fixture from `tests/conftest.py` (sets `TS4K_CONFIG_DIR` + `state.set_config_dir`) whenever a test touches sources/state; plain `tmp_path` suffices for adapter/auth unit tests that take an explicit `config_dir`.
+
+---
+
+### Task 1: CalDAV credential storage
+
+**Files:**
+- Create: `src/ts4k/auth/caldav.py`
+- Test: `tests/test_caldav_auth.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `ICLOUD_CALDAV_URL: str`; `credentials_path(email: str, config_dir: Path | None = None) -> Path`; `save_credentials(email: str, *, username: str, app_password: str, server_url: str, config_dir: Path | None = None) -> Path`; `load_credentials(email: str, config_dir: Path | None = None) -> dict | None`. Later tasks (adapter `connect()`, CLI `src add`, `_token_health`) rely on these exact names.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Tests for CalDAV credential storage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ts4k.auth.caldav import (
+    ICLOUD_CALDAV_URL,
+    credentials_path,
+    load_credentials,
+    save_credentials,
+)
+
+
+def test_path_layout(tmp_path: Path):
+    p = credentials_path("a@icloud.com", config_dir=tmp_path)
+    assert p == tmp_path / "caldav" / "a@icloud.com" / "credentials.json"
+
+
+def test_save_and_load_roundtrip(tmp_path: Path):
+    save_credentials(
+        "a@icloud.com",
+        username="a@icloud.com",
+        app_password="abcd-efgh-ijkl-mnop",
+        server_url=ICLOUD_CALDAV_URL,
+        config_dir=tmp_path,
+    )
+    creds = load_credentials("a@icloud.com", config_dir=tmp_path)
+    assert creds == {
+        "username": "a@icloud.com",
+        "app_password": "abcd-efgh-ijkl-mnop",
+        "server_url": ICLOUD_CALDAV_URL,
+    }
+
+
+def test_file_permissions_0600(tmp_path: Path):
+    path = save_credentials(
+        "a@icloud.com",
+        username="a@icloud.com",
+        app_password="x",
+        server_url=ICLOUD_CALDAV_URL,
+        config_dir=tmp_path,
+    )
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_load_missing_returns_none(tmp_path: Path):
+    assert load_credentials("nobody@icloud.com", config_dir=tmp_path) is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_caldav_auth.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'ts4k.auth.caldav'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+"""CalDAV credential storage — Apple app-specific passwords, no OAuth.
+
+Credentials live at ``~/.config/ts4k/caldav/<email>/credentials.json``
+(0600).  Generate an app-specific password at https://account.apple.com
+(Sign-In and Security → App-Specific Passwords; requires 2FA).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+ICLOUD_CALDAV_URL = "https://caldav.icloud.com"
+
+
+def _default_config_dir() -> Path:
+    """Resolve auth config dir: env var → global default (mirrors auth/google.py)."""
+    env = os.environ.get("TS4K_CONFIG_DIR")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".config" / "ts4k"
+
+
+def credentials_path(email: str, config_dir: Path | None = None) -> Path:
+    base = Path(config_dir) if config_dir else _default_config_dir()
+    return base / "caldav" / email / "credentials.json"
+
+
+def save_credentials(
+    email: str,
+    *,
+    username: str,
+    app_password: str,
+    server_url: str,
+    config_dir: Path | None = None,
+) -> Path:
+    path = credentials_path(email, config_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(
+        {"username": username, "app_password": app_password, "server_url": server_url},
+        indent=2,
+    ))
+    path.chmod(0o600)
+    return path
+
+
+def load_credentials(email: str, config_dir: Path | None = None) -> dict | None:
+    path = credentials_path(email, config_dir)
+    if not path.exists():
+        return None
+    return json.loads(path.read_text())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_caldav_auth.py -v`
+Expected: 4 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ts4k/auth/caldav.py tests/test_caldav_auth.py
+git commit -m "feat: CalDAV credential storage (app-specific password, 0600 JSON)"
+```
+
+---
+
+### Task 2: Adapter skeleton — config, connect, stubs, level gates
+
+**Files:**
+- Create: `src/ts4k/adapters/caldav_cal.py`
+- Modify: `pyproject.toml` (via `uv add caldav`)
+- Test: `tests/test_caldav_adapter.py`
+
+**Interfaces:**
+- Consumes: `load_credentials` from Task 1; `BaseAdapter` (`src/ts4k/adapters/base.py`); `AccessLevel, check_level, parse_level` from `ts4k.core.levels`.
+- Produces: `CaldavAdapterConfig(email, server_url, calendar_id, calendar_name="", timezone="UTC", config_dir=None, level="readonly")` and `CaldavAdapter(config, prefix="cc")` with `connect/disconnect/__aenter__/__aexit__`, message stubs, `_check_modify/_check_draft/_check_send`, `_strip_prefix`, and `self._client/self._principal/self._calendar` attributes that Tasks 3–6 build on. `_get_calendar()` returns the resolved `caldav.Calendar` for `config.calendar_id`.
+
+- [ ] **Step 1: Add the dependency**
+
+Run: `uv add caldav`
+Expected: `caldav` appears in `[project] dependencies` in `pyproject.toml`; `uv run python -c "import caldav; print(caldav.__version__)"` prints a version.
+
+- [ ] **Step 2: Write the failing tests**
+
+```python
+"""Tests for the CalDAV calendar adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from ts4k.adapters.caldav_cal import CaldavAdapter, CaldavAdapterConfig
+from ts4k.auth.caldav import ICLOUD_CALDAV_URL, save_credentials
+from ts4k.core.levels import AccessLevel
+
+
+@pytest.fixture
+def caldav_config(tmp_path: Path) -> CaldavAdapterConfig:
+    save_credentials(
+        "test@icloud.com",
+        username="test@icloud.com",
+        app_password="abcd-efgh",
+        server_url=ICLOUD_CALDAV_URL,
+        config_dir=tmp_path,
+    )
+    return CaldavAdapterConfig(
+        email="test@icloud.com",
+        server_url=ICLOUD_CALDAV_URL,
+        calendar_id="https://caldav.icloud.com/123/calendars/home/",
+        calendar_name="Home",
+        timezone="Europe/Amsterdam",
+        config_dir=tmp_path,
+        level="readonly",
+    )
+
+
+@pytest.fixture
+def adapter(caldav_config: CaldavAdapterConfig) -> CaldavAdapter:
+    a = CaldavAdapter(caldav_config, prefix="cc")
+    # Bypass network: tests install mocks where connect() would put real objects
+    a._principal = MagicMock()
+    a._calendar = MagicMock()
+    return a
+
+
+class TestConstruction:
+    def test_prefix(self, adapter: CaldavAdapter):
+        assert adapter.source_prefix == "cc"
+
+    def test_access_level(self, adapter: CaldavAdapter):
+        assert adapter.access_level == AccessLevel.READONLY
+
+
+class TestConnect:
+    async def test_connect_without_credentials_raises_actionable(self, tmp_path: Path):
+        config = CaldavAdapterConfig(
+            email="nobody@icloud.com",
+            server_url=ICLOUD_CALDAV_URL,
+            calendar_id="x",
+            config_dir=tmp_path,
+        )
+        a = CaldavAdapter(config, prefix="cc")
+        with pytest.raises(RuntimeError, match="app-specific password"):
+            await a.connect()
+
+
+class TestMessagingStubs:
+    """Messaging methods return empty results (not raise) for --source all safety."""
+
+    async def test_whatsnew_returns_empty(self, adapter: CaldavAdapter):
+        assert await adapter.whatsnew(since="2026-01-01") == []
+
+    async def test_list_messages_returns_empty(self, adapter: CaldavAdapter):
+        assert await adapter.list_messages() == []
+
+    async def test_read_message_raises(self, adapter: CaldavAdapter):
+        with pytest.raises(NotImplementedError):
+            await adapter.read_message("cc:123")
+
+    async def test_read_thread_raises(self, adapter: CaldavAdapter):
+        with pytest.raises(NotImplementedError):
+            await adapter.read_thread("cc:t123")
+
+
+class TestStripPrefix:
+    def test_strips_own_prefix(self, adapter: CaldavAdapter):
+        assert adapter._strip_prefix("cc:abc123") == "abc123"
+
+    def test_leaves_bare_id(self, adapter: CaldavAdapter):
+        assert adapter._strip_prefix("abc123") == "abc123"
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_caldav_adapter.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'ts4k.adapters.caldav_cal'`
+
+- [ ] **Step 4: Write the implementation**
+
+```python
+"""CalDAV calendar adapter — generic RFC 4791, Apple/iCloud preset.
+
+Wraps the synchronous ``caldav`` library in ``asyncio.to_thread`` (same
+wrap-a-sync-client pattern as the Google adapter).  Auth is HTTP Basic
+with an app-specific password loaded from
+``~/.config/ts4k/caldav/<email>/credentials.json``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from ts4k.adapters.base import BaseAdapter
+from ts4k.auth.caldav import load_credentials
+from ts4k.core.levels import AccessLevel, check_level, parse_level
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CaldavAdapterConfig:
+    """Configuration for a CalDAV calendar source."""
+
+    email: str            # account identity (Apple ID)
+    server_url: str       # e.g. https://caldav.icloud.com
+    calendar_id: str      # CalDAV calendar URL
+    calendar_name: str = ""
+    timezone: str = "UTC"
+    config_dir: Path | None = None
+    level: str = "readonly"
+
+
+class CaldavAdapter(BaseAdapter):
+    """Generic CalDAV calendar adapter (iCloud, Fastmail, Nextcloud, ...)."""
+
+    def __init__(self, config: CaldavAdapterConfig, prefix: str = "cc") -> None:
+        self._config = config
+        self._prefix = prefix
+        self._access_level = parse_level(config.level)
+        self._client: Any = None
+        self._principal: Any = None
+        self._calendar: Any = None
+
+    @property
+    def source_prefix(self) -> str:
+        return self._prefix
+
+    # -- Connection ------------------------------------------------------------
+
+    async def connect(self) -> None:
+        import caldav
+        from caldav.lib.error import AuthorizationError
+
+        email = self._config.email
+        creds = load_credentials(email, self._config.config_dir)
+        if creds is None:
+            raise RuntimeError(
+                f"No CalDAV credentials for {email} — an app-specific password is "
+                f"required (generate at https://account.apple.com, then run: "
+                f"ts4k src add <prefix> apple email={email})"
+            )
+
+        def _connect() -> tuple[Any, Any]:
+            client = caldav.DAVClient(
+                url=creds.get("server_url") or self._config.server_url,
+                username=creds["username"],
+                password=creds["app_password"],
+            )
+            return client, client.principal()
+
+        try:
+            self._client, self._principal = await asyncio.to_thread(_connect)
+        except AuthorizationError as e:
+            raise RuntimeError(
+                f"CalDAV auth failed for {email} — the app-specific password may be "
+                f"revoked (they expire when the Apple ID password changes). Generate "
+                f"a new one at https://account.apple.com, delete "
+                f"~/.config/ts4k/caldav/{email}/credentials.json, and re-run "
+                f"ts4k src add."
+            ) from e
+
+    async def disconnect(self) -> None:
+        if self._client is not None:
+            await asyncio.to_thread(self._client.close)
+        self._client = None
+        self._principal = None
+        self._calendar = None
+
+    async def __aenter__(self) -> CaldavAdapter:
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.disconnect()
+
+    async def _get_calendar(self) -> Any:
+        """Resolve and cache the configured calendar by URL."""
+        if self._calendar is None:
+            wanted = self._config.calendar_id.rstrip("/")
+
+            def _find() -> Any:
+                for c in self._principal.calendars():
+                    if str(c.url).rstrip("/") == wanted:
+                        return c
+                raise RuntimeError(
+                    f"Calendar {self._config.calendar_id!r} not found for "
+                    f"{self._config.email}"
+                )
+
+            self._calendar = await asyncio.to_thread(_find)
+        return self._calendar
+
+    # -- Messaging stubs (calendar sources have no messages) -------------------
+
+    async def whatsnew(self, since: str | None = None,
+                       sender: str | None = None,
+                       domain: str | None = None) -> list[dict]:
+        return []
+
+    async def list_messages(self, query: str | None = None,
+                            count: int = 20,
+                            page_token: str | None = None,
+                            sender: str | None = None,
+                            domain: str | None = None) -> list[dict]:
+        return []
+
+    async def read_message(self, msg_id: str) -> dict:
+        raise NotImplementedError("CaldavAdapter does not support read_message")
+
+    async def read_thread(self, thread_id: str) -> dict:
+        raise NotImplementedError("CaldavAdapter does not support read_thread")
+
+    # -- Level checks ----------------------------------------------------------
+
+    def _check_modify(self, operation: str) -> None:
+        check_level(self._access_level, AccessLevel.MODIFY, operation, provider="caldav")
+
+    def _check_draft(self, operation: str) -> None:
+        check_level(self._access_level, AccessLevel.DRAFT, operation, provider="caldav")
+
+    def _check_send(self, operation: str) -> None:
+        check_level(self._access_level, AccessLevel.SEND, operation, provider="caldav")
+
+    # -- Helpers ---------------------------------------------------------------
+
+    def _strip_prefix(self, prefixed_id: str) -> str:
+        if prefixed_id.startswith(f"{self._prefix}:"):
+            return prefixed_id[len(self._prefix) + 1:]
+        return prefixed_id
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_caldav_adapter.py -v`
+Expected: all pass
+
+- [ ] **Step 6: Run the full suite to catch regressions**
+
+Run: `uv run pytest`
+Expected: no new failures
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pyproject.toml uv.lock src/ts4k/adapters/caldav_cal.py tests/test_caldav_adapter.py
+git commit -m "feat: CalDAV adapter skeleton — config, connect, stubs, level gates"
+```
+
+---
+
+### Task 3: VEVENT normalization + list_events
+
+**Files:**
+- Modify: `src/ts4k/adapters/caldav_cal.py`
+- Test: `tests/test_caldav_adapter.py` (append)
+
+**Interfaces:**
+- Consumes: `_get_calendar()`, `self._config.timezone`, `self._prefix` from Task 2. The `caldav` calendar object's `search(start=datetime, end=datetime, event=True, expand=True)` returning objects with an `.icalendar_component` property (an `icalendar` VEVENT).
+- Produces: `_normalize_component(comp) -> dict` (gcal-shaped dict; instance IDs are `uid::<recurrence-id-iso>`, master IDs are bare `uid`) and `async list_events(time_min: str, time_max: str, count: int = 250) -> list[dict]`. Tasks 4–7 reuse `_normalize_component`.
+
+- [ ] **Step 1: Write the failing tests** (append to `tests/test_caldav_adapter.py`)
+
+```python
+from icalendar import Calendar as IcsCalendar
+
+
+def _mk_caldav_event(ics: str) -> MagicMock:
+    """Build a fake caldav Event exposing .icalendar_component."""
+    comp = IcsCalendar.from_ical(ics).walk("VEVENT")[0]
+    obj = MagicMock()
+    obj.icalendar_component = comp
+    return obj
+
+
+TIMED_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:abc123@icloud.com
+SUMMARY:Dentist
+DTSTART;TZID=Europe/Amsterdam:20260730T140000
+DTEND;TZID=Europe/Amsterdam:20260730T150000
+ORGANIZER:mailto:org@example.com
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:test@icloud.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:other@example.com
+STATUS:CONFIRMED
+LOCATION:Main St 1
+END:VEVENT
+END:VCALENDAR
+"""
+
+ALLDAY_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:allday1
+SUMMARY:Holiday
+DTSTART;VALUE=DATE:20260730
+DTEND;VALUE=DATE:20260731
+END:VEVENT
+END:VCALENDAR
+"""
+
+FLOATING_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:float1
+SUMMARY:Floating
+DTSTART:20260730T090000
+DTEND:20260730T093000
+END:VEVENT
+END:VCALENDAR
+"""
+
+INSTANCE_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:rec1@icloud.com
+SUMMARY:Standup
+DTSTART;TZID=Europe/Amsterdam:20260806T140000
+DTEND;TZID=Europe/Amsterdam:20260806T141500
+RECURRENCE-ID;TZID=Europe/Amsterdam:20260806T140000
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+class TestNormalization:
+    def test_timed_event(self, adapter: CaldavAdapter):
+        e = adapter._normalize_component(_mk_caldav_event(TIMED_ICS).icalendar_component)
+        assert e["id"] == "cc:abc123@icloud.com"
+        assert e["source"] == "cc"
+        assert e["title"] == "Dentist"
+        assert e["start"].startswith("2026-07-30T14:00:00")
+        assert e["all_day"] is False
+        assert e["duration_minutes"] == 60
+        assert e["location"] == "Main St 1"
+        assert e["organizer"] == "org@example.com"
+        assert e["attendees_summary"] == "2 people"
+        assert e["status"] == "confirmed"
+        assert e["your_status"] == "accepted"
+        assert e["recurring_event_id"] is None
+
+    def test_all_day_event(self, adapter: CaldavAdapter):
+        e = adapter._normalize_component(_mk_caldav_event(ALLDAY_ICS).icalendar_component)
+        assert e["all_day"] is True
+        assert e["start"] == "2026-07-30"
+        assert e["end"] == "2026-07-31"
+        assert e["duration_minutes"] is None
+
+    def test_floating_time_gets_config_timezone(self, adapter: CaldavAdapter):
+        e = adapter._normalize_component(_mk_caldav_event(FLOATING_ICS).icalendar_component)
+        # Europe/Amsterdam on 2026-07-30 is UTC+2
+        assert e["start"] == "2026-07-30T09:00:00+02:00"
+        assert e["duration_minutes"] == 30
+
+    def test_recurring_instance_ids(self, adapter: CaldavAdapter):
+        e = adapter._normalize_component(_mk_caldav_event(INSTANCE_ICS).icalendar_component)
+        assert e["recurring_event_id"] == "cc:rec1@icloud.com"
+        assert e["id"].startswith("cc:rec1@icloud.com::2026-08-06T14:00:00")
+
+
+class TestListEvents:
+    async def test_search_called_with_expand_and_sorted(self, adapter: CaldavAdapter):
+        adapter._calendar.search.return_value = [
+            _mk_caldav_event(ALLDAY_ICS),   # starts 2026-07-30 (date sorts first)
+            _mk_caldav_event(TIMED_ICS),    # starts 2026-07-30T14:00
+        ]
+        events = await adapter.list_events(
+            "2026-07-30T00:00:00+02:00", "2026-07-31T00:00:00+02:00"
+        )
+        assert [e["title"] for e in events] == ["Holiday", "Dentist"]
+        kwargs = adapter._calendar.search.call_args.kwargs
+        assert kwargs["event"] is True
+        assert kwargs["expand"] is True
+
+    async def test_count_caps_results(self, adapter: CaldavAdapter):
+        adapter._calendar.search.return_value = [
+            _mk_caldav_event(TIMED_ICS) for _ in range(5)
+        ]
+        events = await adapter.list_events(
+            "2026-07-30T00:00:00", "2026-07-31T00:00:00", count=2
+        )
+        assert len(events) == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_caldav_adapter.py -v`
+Expected: new tests FAIL with `AttributeError: ... has no attribute '_normalize_component'`
+
+- [ ] **Step 3: Write the implementation** (add to `CaldavAdapter`, plus module-level map)
+
+```python
+_PARTSTAT_MAP = {
+    "ACCEPTED": "accepted",
+    "DECLINED": "declined",
+    "TENTATIVE": "tentative",
+    "NEEDS-ACTION": "needsAction",
+    "DELEGATED": "delegated",
+}
+
+
+def _strip_mailto(value: Any) -> str:
+    s = str(value)
+    return s[7:] if s.lower().startswith("mailto:") else s
+```
+
+```python
+    # -- Calendar methods ------------------------------------------------------
+
+    async def list_events(
+        self,
+        time_min: str,
+        time_max: str,
+        count: int = 250,
+    ) -> list[dict]:
+        """Fetch events in a time range, expanded to instances, sorted by start."""
+        cal = await self._get_calendar()
+        start = datetime.fromisoformat(time_min)
+        end = datetime.fromisoformat(time_max)
+        results = await asyncio.to_thread(
+            lambda: cal.search(start=start, end=end, event=True, expand=True)
+        )
+        events = [self._normalize_component(r.icalendar_component) for r in results]
+        events.sort(key=lambda e: e.get("start", ""))
+        return events[:count]
+
+    def _normalize_component(self, comp: Any) -> dict:
+        """Convert an icalendar VEVENT to the ts4k normalized event dict.
+
+        Same keys as GcalAdapter._normalize_event so format.py needs no changes.
+        """
+        uid = str(comp.get("UID", ""))
+        tzinfo = self._tzinfo()
+
+        dtstart = comp.get("DTSTART")
+        start_dt = dtstart.dt if dtstart is not None else None
+        all_day = isinstance(start_dt, date) and not isinstance(start_dt, datetime)
+
+        dtend = comp.get("DTEND")
+        if dtend is not None:
+            end_dt = dtend.dt
+        elif comp.get("DURATION") is not None and start_dt is not None:
+            end_dt = start_dt + comp.get("DURATION").dt
+        else:
+            end_dt = start_dt
+
+        if isinstance(start_dt, datetime) and start_dt.tzinfo is None:
+            start_dt = start_dt.replace(tzinfo=tzinfo)
+        if isinstance(end_dt, datetime) and end_dt.tzinfo is None:
+            end_dt = end_dt.replace(tzinfo=tzinfo)
+
+        start = start_dt.isoformat() if start_dt is not None else ""
+        end = end_dt.isoformat() if end_dt is not None else start
+        if all_day:
+            duration_minutes = None
+        elif start_dt is not None and end_dt is not None:
+            duration_minutes = max(0, int((end_dt - start_dt).total_seconds() / 60))
+        else:
+            duration_minutes = None
+
+        raw_attendees = comp.get("ATTENDEE")
+        if raw_attendees is None:
+            attendees = []
+        elif isinstance(raw_attendees, list):
+            attendees = raw_attendees
+        else:
+            attendees = [raw_attendees]
+
+        your_status = None
+        my_email = self._config.email.lower()
+        for a in attendees:
+            if _strip_mailto(a).lower() == my_email:
+                partstat = str(a.params.get("PARTSTAT", "NEEDS-ACTION")).upper()
+                your_status = _PARTSTAT_MAP.get(partstat, partstat.lower())
+                break
+
+        organizer_prop = comp.get("ORGANIZER")
+        organizer = _strip_mailto(organizer_prop) if organizer_prop is not None else ""
+
+        recurrence_id = comp.get("RECURRENCE-ID")
+        if recurrence_id is not None:
+            rid = recurrence_id.dt
+            if isinstance(rid, datetime) and rid.tzinfo is None:
+                rid = rid.replace(tzinfo=tzinfo)
+            event_id = f"{uid}::{rid.isoformat()}"
+            recurring_event_id = f"{self._prefix}:{uid}"
+        else:
+            event_id = uid
+            recurring_event_id = None
+
+        summary = comp.get("SUMMARY")
+        status_prop = comp.get("STATUS")
+        location_prop = comp.get("LOCATION")
+
+        return {
+            "id": f"{self._prefix}:{event_id}",
+            "source": self._prefix,
+            "title": str(summary) if summary else "(No title)",
+            "start": start,
+            "end": end,
+            "all_day": all_day,
+            "duration_minutes": duration_minutes,
+            "location": str(location_prop) if location_prop else "",
+            "organizer": organizer,
+            "attendees_summary": f"{len(attendees)} people" if attendees else "",
+            "status": str(status_prop).lower() if status_prop else "confirmed",
+            "your_status": your_status,
+            "recurring_event_id": recurring_event_id,
+        }
+
+    def _tzinfo(self) -> ZoneInfo | timezone:
+        try:
+            return ZoneInfo(self._config.timezone)
+        except Exception:
+            return timezone.utc
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_caldav_adapter.py -v`
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ts4k/adapters/caldav_cal.py tests/test_caldav_adapter.py
+git commit -m "feat: CalDAV VEVENT normalization and list_events with expansion"
+```
+
+---
+
+### Task 4: read_event + list_calendars
+
+**Files:**
+- Modify: `src/ts4k/adapters/caldav_cal.py`
+- Test: `tests/test_caldav_adapter.py` (append)
+
+**Interfaces:**
+- Consumes: `_normalize_component`, `_get_calendar`, `_strip_prefix` from Tasks 2–3; `rrule_to_human` from `ts4k.adapters.gcal` (module-level at `gcal.py:23`). The caldav calendar's `event_by_uid(uid)` method (fallback `object_by_uid(uid)` if the installed version lacks the alias — check at implementation time with `uv run python -c "import caldav; print(hasattr(caldav.Calendar, 'event_by_uid'))"`).
+- Produces: `async read_event(event_id: str) -> dict` (base dict + `attendees` (list of `{name,email,status}`), `description`, `meeting_link`, `recurrence`, `recurrence_summary`, `created`, `updated` — matching gcal's `read_event` extras at `gcal.py:240`); `async list_calendars() -> list[dict]` with keys `id, summary, access_role, timezone, primary` (matching `gcal.py:284`).
+
+- [ ] **Step 1: Write the failing tests** (append)
+
+```python
+DETAIL_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:det1@icloud.com
+SUMMARY:Planning
+DTSTART;TZID=Europe/Amsterdam:20260730T100000
+DTEND;TZID=Europe/Amsterdam:20260730T110000
+DESCRIPTION:Quarterly planning session
+URL:https://meet.example.com/xyz
+ATTENDEE;CN=Alice;PARTSTAT=ACCEPTED:mailto:alice@example.com
+ATTENDEE;PARTSTAT=DECLINED:mailto:test@icloud.com
+RRULE:FREQ=WEEKLY;BYDAY=TH
+CREATED:20260101T000000Z
+LAST-MODIFIED:20260615T120000Z
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+class TestReadEvent:
+    async def test_full_detail(self, adapter: CaldavAdapter):
+        adapter._calendar.event_by_uid.return_value = _mk_caldav_event(DETAIL_ICS)
+        e = await adapter.read_event("cc:det1@icloud.com")
+        assert e["title"] == "Planning"
+        assert e["description"] == "Quarterly planning session"
+        assert e["meeting_link"] == "https://meet.example.com/xyz"
+        assert e["recurrence"] == "FREQ=WEEKLY;BYDAY=TH"
+        assert e["recurrence_summary"] == "weekly on Thu"
+        assert e["attendees"] == [
+            {"name": "Alice", "email": "alice@example.com", "status": "accepted"},
+            {"name": "test@icloud.com", "email": "test@icloud.com", "status": "declined"},
+        ]
+        assert e["created"] == "2026-01-01T00:00:00+00:00"
+        assert e["updated"] == "2026-06-15T12:00:00+00:00"
+        adapter._calendar.event_by_uid.assert_called_once_with("det1@icloud.com")
+
+    async def test_instance_id_fetches_master(self, adapter: CaldavAdapter):
+        adapter._calendar.event_by_uid.return_value = _mk_caldav_event(DETAIL_ICS)
+        await adapter.read_event("cc:det1@icloud.com::2026-08-06T10:00:00+02:00")
+        adapter._calendar.event_by_uid.assert_called_once_with("det1@icloud.com")
+
+
+class TestListCalendars:
+    async def test_lists_principal_calendars(self, adapter: CaldavAdapter):
+        c1 = MagicMock()
+        c1.url = "https://caldav.icloud.com/123/calendars/home/"
+        c1.name = "Home"
+        c2 = MagicMock()
+        c2.url = "https://caldav.icloud.com/123/calendars/work/"
+        c2.name = "Work"
+        adapter._principal.calendars.return_value = [c1, c2]
+        cals = await adapter.list_calendars()
+        assert cals == [
+            {"id": "https://caldav.icloud.com/123/calendars/home/", "summary": "Home",
+             "access_role": "owner", "timezone": "Europe/Amsterdam", "primary": False},
+            {"id": "https://caldav.icloud.com/123/calendars/work/", "summary": "Work",
+             "access_role": "owner", "timezone": "Europe/Amsterdam", "primary": False},
+        ]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_caldav_adapter.py -v`
+Expected: new tests FAIL (`read_event`/`list_calendars` missing — note the base class has no default; AttributeError or TypeError acceptable)
+
+- [ ] **Step 3: Write the implementation** (add to `CaldavAdapter`)
+
+```python
+    async def _fetch_by_uid(self, uid: str) -> Any:
+        cal = await self._get_calendar()
+        return await asyncio.to_thread(lambda: cal.event_by_uid(uid))
+
+    async def read_event(self, event_id: str) -> dict:
+        """Fetch full detail for a single event by UID.
+
+        Instance IDs (``uid::<recurrence-id>``) resolve to the series master.
+        """
+        raw = self._strip_prefix(event_id)
+        uid = raw.split("::")[0]
+        obj = await self._fetch_by_uid(uid)
+        comp = obj.icalendar_component
+        base = self._normalize_component(comp)
+
+        attendees_full = []
+        raw_attendees = comp.get("ATTENDEE")
+        if raw_attendees is None:
+            raw_attendees = []
+        elif not isinstance(raw_attendees, list):
+            raw_attendees = [raw_attendees]
+        for a in raw_attendees:
+            email = _strip_mailto(a)
+            partstat = str(a.params.get("PARTSTAT", "NEEDS-ACTION")).upper()
+            attendees_full.append({
+                "name": str(a.params.get("CN", email)),
+                "email": email,
+                "status": _PARTSTAT_MAP.get(partstat, partstat.lower()),
+            })
+        base["attendees"] = attendees_full
+
+        desc = comp.get("DESCRIPTION")
+        base["description"] = str(desc) if desc else ""
+        url = comp.get("URL")
+        base["meeting_link"] = str(url) if url else ""
+
+        from ts4k.adapters.gcal import rrule_to_human
+
+        rrule_prop = comp.get("RRULE")
+        rrule = rrule_prop.to_ical().decode() if rrule_prop is not None else ""
+        base["recurrence"] = rrule
+        base["recurrence_summary"] = rrule_to_human(rrule) if rrule else ""
+
+        created = comp.get("CREATED")
+        base["created"] = created.dt.isoformat() if created is not None else ""
+        updated = comp.get("LAST-MODIFIED")
+        base["updated"] = updated.dt.isoformat() if updated is not None else ""
+        return base
+
+    async def list_calendars(self) -> list[dict]:
+        """List calendars on the principal (used by setup; adapter may have empty calendar_id)."""
+
+        def _list() -> list[dict]:
+            out = []
+            for c in self._principal.calendars():
+                out.append({
+                    "id": str(c.url),
+                    "summary": c.name or str(c.url),
+                    "access_role": "owner",
+                    "timezone": self._config.timezone,
+                    "primary": False,
+                })
+            return out
+
+        return await asyncio.to_thread(_list)
+```
+
+Note: `RRULE:FREQ=WEEKLY;BYDAY=TH` may serialize from icalendar as `FREQ=WEEKLY;BYDAY=TH` — if the test fails on key order (e.g. `BYDAY=TH;FREQ=WEEKLY`), relax the assertion to check both parts are present, and pass the same string through `rrule_to_human` in the assertion instead of hardcoding.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_caldav_adapter.py -v`
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ts4k/adapters/caldav_cal.py tests/test_caldav_adapter.py
+git commit -m "feat: CalDAV read_event and list_calendars"
+```
+
+---
+
+### Task 5: create_event + update_event (level-gated)
+
+**Files:**
+- Modify: `src/ts4k/adapters/caldav_cal.py`
+- Test: `tests/test_caldav_write.py` (new file, mirrors `tests/test_gcal_write.py` structure)
+
+**Interfaces:**
+- Consumes: `_check_draft/_check_send/_check_modify`, `_get_calendar`, `_fetch_by_uid`, `_normalize_component` from earlier tasks; caldav calendar's `save_event(ics_string)` returning the saved object; caldav object's `save()`.
+- Produces: `async create_event(title, start, end, description=None, location=None, attendees=None) -> dict` and `async update_event(event_id, **fields) -> dict` accepting `title, description, location, start, end` — same signatures as `gcal.py:313` and `gcal.py:358` (Task 7's `cal_create`/`cal_update` call these polymorphically).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Tests for CalDAV create/update/level gating."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from icalendar import Calendar as IcsCalendar
+
+from ts4k.adapters.caldav_cal import CaldavAdapter, CaldavAdapterConfig
+from ts4k.auth.caldav import ICLOUD_CALDAV_URL, save_credentials
+
+
+def _adapter(tmp_path: Path, level: str) -> CaldavAdapter:
+    save_credentials("test@icloud.com", username="test@icloud.com",
+                     app_password="x", server_url=ICLOUD_CALDAV_URL,
+                     config_dir=tmp_path)
+    config = CaldavAdapterConfig(
+        email="test@icloud.com", server_url=ICLOUD_CALDAV_URL,
+        calendar_id="https://caldav.icloud.com/123/calendars/home/",
+        timezone="Europe/Amsterdam", config_dir=tmp_path, level=level,
+    )
+    a = CaldavAdapter(config, prefix="cc")
+    a._principal = MagicMock()
+    a._calendar = MagicMock()
+    return a
+
+
+def _echo_save_event(ics: str) -> MagicMock:
+    """Fake caldav save_event: parse the ICS we were given and echo it back."""
+    obj = MagicMock()
+    obj.icalendar_component = IcsCalendar.from_ical(ics).walk("VEVENT")[0]
+    return obj
+
+
+class TestLevelGating:
+    async def test_readonly_blocks_create(self, tmp_path: Path):
+        a = _adapter(tmp_path, "readonly")
+        with pytest.raises(PermissionError):
+            await a.create_event("X", "2026-07-30T10:00:00", "2026-07-30T11:00:00")
+
+    async def test_readonly_blocks_update(self, tmp_path: Path):
+        a = _adapter(tmp_path, "readonly")
+        with pytest.raises(PermissionError):
+            await a.update_event("cc:uid1", title="Y")
+
+    async def test_readonly_blocks_rsvp(self, tmp_path: Path):
+        a = _adapter(tmp_path, "readonly")
+        with pytest.raises(PermissionError):
+            await a.rsvp("cc:uid1", "accepted")
+
+
+class TestCreateEvent:
+    async def test_timed_event(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        a._calendar.save_event.side_effect = _echo_save_event
+        e = await a.create_event(
+            "Dinner", "2026-07-30T19:00:00", "2026-07-30T21:00:00",
+            description="Birthday", location="Cafe",
+        )
+        assert e["title"] == "Dinner"
+        assert e["start"] == "2026-07-30T19:00:00+02:00"
+        assert e["duration_minutes"] == 120
+        sent_ics = a._calendar.save_event.call_args.args[0]
+        assert "SUMMARY:Dinner" in sent_ics
+        assert "DESCRIPTION:Birthday" in sent_ics
+        assert "UID:" in sent_ics
+
+    async def test_all_day_inclusive_end_becomes_exclusive(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        a._calendar.save_event.side_effect = _echo_save_event
+        e = await a.create_event("Trip", "2026-08-01", "2026-08-03")
+        assert e["all_day"] is True
+        assert e["start"] == "2026-08-01"
+        assert e["end"] == "2026-08-04"  # exclusive, mirrors gcal convention
+
+    async def test_attendees_require_send_level(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")  # modify < send
+        with pytest.raises(PermissionError):
+            await a.create_event("X", "2026-07-30T10:00:00", "2026-07-30T11:00:00",
+                                 attendees=["a@example.com"])
+
+
+class TestUpdateEvent:
+    async def test_update_title_and_start(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        ics = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:up1
+SUMMARY:Old
+DTSTART;TZID=Europe/Amsterdam:20260730T100000
+DTEND;TZID=Europe/Amsterdam:20260730T110000
+END:VEVENT
+END:VCALENDAR
+"""
+        obj = MagicMock()
+        obj.icalendar_component = IcsCalendar.from_ical(ics).walk("VEVENT")[0]
+        a._calendar.event_by_uid.return_value = obj
+        e = await a.update_event("cc:up1", title="New", start="2026-07-30T12:00:00")
+        obj.save.assert_called_once()
+        assert e["title"] == "New"
+        assert e["start"] == "2026-07-30T12:00:00+02:00"
+```
+
+Note on `PermissionError`: before writing these tests, check what `check_level` raises (`src/ts4k/core/levels.py:38`) — if it raises a different exception type (e.g. a custom error), assert that type instead. Mirror whatever `tests/test_gcal_write.py` / `tests/test_o365cal_levels.py` assert.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_caldav_write.py -v`
+Expected: FAIL (`create_event` not defined on `CaldavAdapter`; gating tests fail with AttributeError, not PermissionError — that's expected at this stage)
+
+- [ ] **Step 3: Write the implementation** (add to `CaldavAdapter`)
+
+```python
+    # -- Write methods ---------------------------------------------------------
+
+    async def create_event(
+        self,
+        title: str,
+        start: str,
+        end: str,
+        description: str | None = None,
+        location: str | None = None,
+        attendees: list[str] | None = None,
+    ) -> dict:
+        """Create a calendar event with level-gated attendee support."""
+        if attendees:
+            self._check_send("create_event")
+        else:
+            self._check_draft("create_event")
+
+        import uuid
+
+        from icalendar import Calendar as IcsCalendar
+        from icalendar import Event as IcsEvent
+        from icalendar import vCalAddress
+
+        vevent = IcsEvent()
+        vevent.add("UID", str(uuid.uuid4()))
+        vevent.add("SUMMARY", title)
+        vevent.add("DTSTAMP", datetime.now(timezone.utc))
+
+        tzinfo = self._tzinfo()
+        if "T" not in start:
+            # All-day: user provides inclusive end, iCal DTEND is exclusive
+            end_date = date.fromisoformat(end) + timedelta(days=1)
+            vevent.add("DTSTART", date.fromisoformat(start))
+            vevent.add("DTEND", end_date)
+        else:
+            start_dt = datetime.fromisoformat(start)
+            end_dt = datetime.fromisoformat(end)
+            if start_dt.tzinfo is None:
+                start_dt = start_dt.replace(tzinfo=tzinfo)
+            if end_dt.tzinfo is None:
+                end_dt = end_dt.replace(tzinfo=tzinfo)
+            vevent.add("DTSTART", start_dt)
+            vevent.add("DTEND", end_dt)
+
+        if description:
+            vevent.add("DESCRIPTION", description)
+        if location:
+            vevent.add("LOCATION", location)
+        for email in attendees or []:
+            att = vCalAddress(f"mailto:{email}")
+            att.params["PARTSTAT"] = "NEEDS-ACTION"
+            att.params["ROLE"] = "REQ-PARTICIPANT"
+            vevent.add("ATTENDEE", att, encode=0)
+
+        ics = IcsCalendar()
+        ics.add("VERSION", "2.0")
+        ics.add("PRODID", "-//ts4k//caldav//EN")
+        ics.add_component(vevent)
+
+        cal = await self._get_calendar()
+        saved = await asyncio.to_thread(
+            lambda: cal.save_event(ics.to_ical().decode())
+        )
+        return self._normalize_component(saved.icalendar_component)
+
+    async def update_event(self, event_id: str, **fields: Any) -> dict:
+        """Update an existing event. Requires MODIFY level."""
+        self._check_modify("update_event")
+        raw = self._strip_prefix(event_id)
+        uid = raw.split("::")[0]
+        obj = await self._fetch_by_uid(uid)
+        comp = obj.icalendar_component
+        tzinfo = self._tzinfo()
+
+        def _set(key: str, value: Any) -> None:
+            comp.pop(key, None)
+            comp.add(key, value)
+
+        if "title" in fields:
+            _set("SUMMARY", fields["title"])
+        if "description" in fields:
+            _set("DESCRIPTION", fields["description"])
+        if "location" in fields:
+            _set("LOCATION", fields["location"])
+        if "start" in fields:
+            s = fields["start"]
+            if "T" not in s:
+                _set("DTSTART", date.fromisoformat(s))
+            else:
+                dt = datetime.fromisoformat(s)
+                _set("DTSTART", dt.replace(tzinfo=tzinfo) if dt.tzinfo is None else dt)
+        if "end" in fields:
+            e = fields["end"]
+            if "T" not in e:
+                _set("DTEND", date.fromisoformat(e))
+            else:
+                dt = datetime.fromisoformat(e)
+                _set("DTEND", dt.replace(tzinfo=tzinfo) if dt.tzinfo is None else dt)
+
+        await asyncio.to_thread(obj.save)
+        return self._normalize_component(comp)
+```
+
+(The `rsvp` gating test stays red until Task 6 — if running tests file-wide here, add the minimal `async def rsvp(self, event_id: str, status: str) -> dict: self._check_modify("rsvp"); raise NotImplementedError` stub now and replace it in Task 6.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_caldav_write.py -v`
+Expected: all pass (with the `rsvp` stub in place for the gating test)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ts4k/adapters/caldav_cal.py tests/test_caldav_write.py
+git commit -m "feat: CalDAV create_event and update_event with level gating"
+```
+
+---
+
+### Task 6: rsvp with graceful degradation
+
+**Files:**
+- Modify: `src/ts4k/adapters/caldav_cal.py` (replace Task 5's stub)
+- Modify: `src/ts4k/commands.py` — `cal_rsvp` (~line 2385): wrap the adapter call so clean errors return as strings
+- Test: `tests/test_caldav_write.py` (append)
+
+**Interfaces:**
+- Consumes: `_fetch_by_uid`, `_normalize_component`, `_check_modify`, `_PARTSTAT_MAP`, `_strip_mailto`.
+- Produces: `async rsvp(event_id: str, status: str) -> dict` where `status ∈ {"accepted", "declined", "tentative"}` (the values `cal rsvp --status` passes). Raises `ValueError` (bad status / not an attendee) or `RuntimeError` (server rejected) with actionable messages. `cal_rsvp` catches both and returns `f"Error: {e}"`.
+
+- [ ] **Step 1: Write the failing tests** (append to `tests/test_caldav_write.py`)
+
+```python
+INVITE_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:inv1
+SUMMARY:Party
+DTSTART;TZID=Europe/Amsterdam:20260730T190000
+DTEND;TZID=Europe/Amsterdam:20260730T230000
+ORGANIZER:mailto:org@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:test@icloud.com
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:other@example.com
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+def _invite_obj():
+    obj = MagicMock(spec=["icalendar_component", "save"])  # no accept_invite → manual path
+    obj.icalendar_component = IcsCalendar.from_ical(INVITE_ICS).walk("VEVENT")[0]
+    return obj
+
+
+class TestRsvp:
+    async def test_manual_partstat_path(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        obj = _invite_obj()
+        a._calendar.event_by_uid.return_value = obj
+        e = await a.rsvp("cc:inv1", "accepted")
+        obj.save.assert_called_once()
+        assert e["your_status"] == "accepted"
+
+    async def test_invite_helper_preferred_when_available(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        obj = MagicMock()  # has accept_invite (MagicMock auto-attrs)
+        obj.icalendar_component = IcsCalendar.from_ical(INVITE_ICS).walk("VEVENT")[0]
+        a._calendar.event_by_uid.return_value = obj
+        await a.rsvp("cc:inv1", "accepted")
+        obj.accept_invite.assert_called_once()
+        obj.save.assert_not_called()
+
+    async def test_invite_helper_failure_falls_back_to_manual(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        obj = MagicMock()
+        obj.icalendar_component = IcsCalendar.from_ical(INVITE_ICS).walk("VEVENT")[0]
+        obj.accept_invite.side_effect = Exception("scheduling not supported")
+        a._calendar.event_by_uid.return_value = obj
+        e = await a.rsvp("cc:inv1", "accepted")
+        obj.save.assert_called_once()
+        assert e["your_status"] == "accepted"
+
+    async def test_server_rejection_raises_actionable_runtimeerror(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        obj = _invite_obj()
+        obj.save.side_effect = Exception("403 Forbidden")
+        a._calendar.event_by_uid.return_value = obj
+        with pytest.raises(RuntimeError, match="Calendar app"):
+            await a.rsvp("cc:inv1", "accepted")
+
+    async def test_not_an_attendee_raises_valueerror(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        ics = INVITE_ICS.replace("mailto:test@icloud.com", "mailto:someoneelse@x.com")
+        obj = MagicMock(spec=["icalendar_component", "save"])
+        obj.icalendar_component = IcsCalendar.from_ical(ics).walk("VEVENT")[0]
+        a._calendar.event_by_uid.return_value = obj
+        with pytest.raises(ValueError, match="not an attendee"):
+            await a.rsvp("cc:inv1", "accepted")
+
+    async def test_bad_status_raises_valueerror(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        with pytest.raises(ValueError, match="status"):
+            await a.rsvp("cc:inv1", "maybe")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_caldav_write.py -v`
+Expected: new tests FAIL (stub raises NotImplementedError)
+
+- [ ] **Step 3: Write the implementation** (replace the stub)
+
+```python
+    async def rsvp(self, event_id: str, status: str) -> dict:
+        """RSVP to an event. Requires MODIFY level.
+
+        Prefers the caldav library's scheduling helpers (accept_invite etc.)
+        when present; falls back to editing PARTSTAT directly.  iCloud often
+        rejects scheduling writes on externally-organized invites — surfaced
+        as a clean RuntimeError, never a stack trace.
+        """
+        self._check_modify("rsvp")
+
+        helper_names = {
+            "accepted": "accept_invite",
+            "declined": "decline_invite",
+            "tentative": "tentatively_accept_invite",
+        }
+        partstat_values = {
+            "accepted": "ACCEPTED",
+            "declined": "DECLINED",
+            "tentative": "TENTATIVE",
+        }
+        if status not in partstat_values:
+            raise ValueError(
+                f"Invalid RSVP status {status!r} — use accepted, declined, or tentative"
+            )
+
+        raw = self._strip_prefix(event_id)
+        uid = raw.split("::")[0]
+        obj = await self._fetch_by_uid(uid)
+        comp = obj.icalendar_component
+
+        my_email = self._config.email.lower()
+        raw_attendees = comp.get("ATTENDEE")
+        if raw_attendees is None:
+            raw_attendees = []
+        elif not isinstance(raw_attendees, list):
+            raw_attendees = [raw_attendees]
+        me = next(
+            (a for a in raw_attendees if _strip_mailto(a).lower() == my_email), None
+        )
+        if me is None:
+            raise ValueError(
+                f"{self._config.email} is not an attendee on this event — "
+                f"cannot RSVP"
+            )
+
+        helper = getattr(obj, helper_names[status], None)
+        if callable(helper):
+            try:
+                await asyncio.to_thread(helper)
+                return self._normalize_component(comp)
+            except Exception:
+                logger.info("caldav invite helper failed; falling back to PARTSTAT edit")
+
+        me.params["PARTSTAT"] = partstat_values[status]
+        try:
+            await asyncio.to_thread(obj.save)
+        except Exception as e:
+            raise RuntimeError(
+                f"RSVP not accepted by the server ({e}) — iCloud often blocks "
+                f"programmatic replies to external invites; respond in the "
+                f"Calendar app instead"
+            ) from e
+        return self._normalize_component(comp)
+```
+
+Mock-interaction note: with a bare `MagicMock` object, `getattr(obj, "accept_invite")` is auto-created and callable — that's why the helper-path test uses a plain MagicMock and the manual-path test uses `spec=["icalendar_component", "save"]` to make the helper absent. After the helper succeeds we normalize the *unmodified* component, so `your_status` in that test would still be `needsAction` — the test deliberately only asserts the helper was called, not the returned status.
+
+- [ ] **Step 4: Wrap cal_rsvp errors in commands.py**
+
+In `src/ts4k/commands.py`, `cal_rsvp` currently ends with:
+
+```python
+    async with adapter:
+        event = await adapter.rsvp(event_id, status=status)
+
+    return f"RSVP {status}: {event['title']} ({event['id']})"
+```
+
+Change to:
+
+```python
+    try:
+        async with adapter:
+            event = await adapter.rsvp(event_id, status=status)
+    except (ValueError, RuntimeError) as e:
+        return f"Error: {e}"
+
+    return f"RSVP {status}: {event['title']} ({event['id']})"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_caldav_write.py tests/test_cal_commands.py -v`
+Expected: all pass, no regressions in cal command tests
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ts4k/adapters/caldav_cal.py src/ts4k/commands.py tests/test_caldav_write.py
+git commit -m "feat: CalDAV rsvp with invite-helper preference and clean fallback errors"
+```
+
+---
+
+### Task 7: Register provider in commands.py
+
+**Files:**
+- Modify: `src/ts4k/commands.py` — imports, `_make_adapter` (~line 74), `_resolve_prefixes` provider_map (~line 172), `_provider_labels` (~line 901), stats skip tuple (~line 917), `_token_health` (~line 1930), all `("gcal", "o365cal")` gate tuples (~lines 2149, 2194, 2289, 2338, 2366, 2391 and `_get_cal_timezone`), new `cal_list_caldav_calendars`
+- Test: `tests/test_caldav_commands.py`
+
+**Interfaces:**
+- Consumes: `CaldavAdapter`, `CaldavAdapterConfig` (Task 2), `ICLOUD_CALDAV_URL`, `load_credentials` (Task 1).
+- Produces: `_make_adapter` builds `CaldavAdapter` for `provider == "caldav"`; module constant `_CAL_PROVIDERS = ("gcal", "o365cal", "caldav")`; `async cal_list_caldav_calendars(email: str, config_dir: Path | None = None) -> list[dict]` (Task 8's CLI calls this exact name).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Tests for CalDAV provider registration in commands.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ts4k import commands
+from ts4k.adapters.caldav_cal import CaldavAdapter
+
+CALDAV_CFG = {
+    "provider": "caldav",
+    "email": "a@icloud.com",
+    "server_url": "https://caldav.icloud.com",
+    "calendar_id": "https://caldav.icloud.com/123/calendars/home/",
+    "calendar_name": "Home",
+    "timezone": "UTC",
+    "level": "modify",
+}
+
+
+class TestMakeAdapter:
+    def test_builds_caldav_adapter(self):
+        a = commands._make_adapter("cc", dict(CALDAV_CFG))
+        assert isinstance(a, CaldavAdapter)
+        assert a.source_prefix == "cc"
+
+    def test_missing_email_returns_none(self):
+        cfg = dict(CALDAV_CFG)
+        del cfg["email"]
+        assert commands._make_adapter("cc", cfg) is None
+
+    def test_missing_calendar_id_returns_none(self):
+        cfg = dict(CALDAV_CFG)
+        del cfg["calendar_id"]
+        assert commands._make_adapter("cc", cfg) is None
+
+
+class TestResolvePrefixes:
+    def test_apple_alias_resolves_to_caldav_sources(self, monkeypatch):
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"cc": dict(CALDAV_CFG)}
+        )
+        assert commands._resolve_prefixes("apple") == ["cc"]
+        assert commands._resolve_prefixes("icloud") == ["cc"]
+        assert commands._resolve_prefixes("caldav") == ["cc"]
+
+
+class TestCalGates:
+    async def test_cal_create_accepts_caldav_source(self, monkeypatch):
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"cc": dict(CALDAV_CFG)}
+        )
+        fake = MagicMock()
+        fake.__aenter__ = AsyncMock(return_value=fake)
+        fake.__aexit__ = AsyncMock(return_value=None)
+        fake.create_event = AsyncMock(return_value={"title": "X", "id": "cc:1"})
+        monkeypatch.setattr(commands, "_make_adapter", lambda p, c: fake)
+        out = await commands.cal_create(
+            "cc", "X", "2026-07-30T10:00:00", "2026-07-30T11:00:00",
+            None, None, None,
+        )
+        assert out == "Created: X (cc:1)"
+
+
+class TestTokenHealth:
+    def test_caldav_with_credentials_is_ok(self, tmp_path: Path, monkeypatch):
+        from ts4k.auth.caldav import ICLOUD_CALDAV_URL, save_credentials
+
+        monkeypatch.setenv("TS4K_CONFIG_DIR", str(tmp_path))
+        save_credentials("a@icloud.com", username="a@icloud.com",
+                         app_password="x", server_url=ICLOUD_CALDAV_URL)
+        th = commands._token_health(dict(CALDAV_CFG))
+        assert th.status == "ok"
+
+    def test_caldav_without_credentials_is_na(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("TS4K_CONFIG_DIR", str(tmp_path))
+        th = commands._token_health(dict(CALDAV_CFG))
+        assert th.status == "na"
+```
+
+Note: `_token_health` is the private helper around `commands.py:1930` that returns `TokenHealth` — confirm its exact name with `grep -n "def _token_health\|TokenHealth(" src/ts4k/commands.py` before writing the test, and use whatever it's actually called.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_caldav_commands.py -v`
+Expected: FAIL — `_make_adapter` logs "Unknown provider 'caldav'" and returns None
+
+- [ ] **Step 3: Implement the registration changes**
+
+In `src/ts4k/commands.py`:
+
+1. Add imports next to the existing adapter imports (~line 21):
+
+```python
+from ts4k.adapters.caldav_cal import CaldavAdapter, CaldavAdapterConfig
+```
+
+2. Define the gate constant near the other module-level helpers (above `_make_adapter`):
+
+```python
+_CAL_PROVIDERS = ("gcal", "o365cal", "caldav")
+```
+
+3. Add the factory branch in `_make_adapter` (after the `o365cal` branch), and add `CaldavAdapter` to the return-type union:
+
+```python
+    if provider == "caldav":
+        email = cfg.get("email")
+        calendar_id = cfg.get("calendar_id")
+        if not email or not calendar_id:
+            return None
+        from ts4k.auth.caldav import ICLOUD_CALDAV_URL
+        config = CaldavAdapterConfig(
+            email=email,
+            server_url=cfg.get("server_url", ICLOUD_CALDAV_URL),
+            calendar_id=calendar_id,
+            calendar_name=cfg.get("calendar_name", ""),
+            timezone=cfg.get("timezone", "UTC"),
+            config_dir=Path(cfg["config_dir"]) if cfg.get("config_dir") else None,
+            level=cfg.get("level", "readonly"),
+        )
+        return CaldavAdapter(config, prefix=prefix)
+```
+
+4. Extend the provider alias map in `_resolve_prefixes`:
+
+```python
+        "apple": "caldav", "icloud": "caldav", "apple-calendar": "caldav",
+```
+
+5. `_provider_labels` (~line 901): add `"caldav": "CalDAV"`.
+
+6. Replace every `("gcal", "o365cal")` tuple in commands.py with `_CAL_PROVIDERS` — find them all with `grep -n '"gcal", "o365cal"' src/ts4k/commands.py` (expect ~7: stats skip, event-fetch filter, `_get_cal_timezone`, `cal_read`, `cal_create`, `cal_update`, `cal_rsvp`).
+
+7. Add a `caldav` branch to the token-health helper (before the final unknown-provider return):
+
+```python
+    if provider == "caldav":
+        from ts4k.auth.caldav import load_credentials
+        email = cfg.get("email", "")
+        if not email:
+            return TokenHealth(status="na", expiry=None, scopes=[], detail="no email configured")
+        if load_credentials(email) is None:
+            return TokenHealth(status="na", expiry=None, scopes=[],
+                               detail="no credentials — run: ts4k src add <prefix> apple email=" + email)
+        return TokenHealth(status="ok", expiry=None, scopes=[], detail="app-specific password")
+```
+
+8. Add the setup helper next to `cal_list_calendars` / `cal_list_o365_calendars` (~line 2303):
+
+```python
+async def cal_list_caldav_calendars(
+    email: str, config_dir: Path | None = None,
+) -> list[dict]:
+    """List available calendars for a CalDAV account (non-interactive, for setup)."""
+    from ts4k.auth.caldav import ICLOUD_CALDAV_URL
+
+    config = CaldavAdapterConfig(
+        email=email, server_url=ICLOUD_CALDAV_URL, calendar_id="",
+        calendar_name="", timezone="UTC", config_dir=config_dir,
+        level="readonly",
+    )
+    adapter = CaldavAdapter(config, prefix="_setup")
+    async with adapter:
+        return await adapter.list_calendars()
+```
+
+(`connect()` prefers the `server_url` stored in the credentials file, so the iCloud default here is only a fallback.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_caldav_commands.py -v`
+Expected: all pass
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `uv run pytest`
+Expected: no regressions (the `_CAL_PROVIDERS` sweep touches shared code paths)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ts4k/commands.py tests/test_caldav_commands.py
+git commit -m "feat: register caldav provider — factory, gates, aliases, token health"
+```
+
+---
+
+### Task 8: CLI `src add` support with Apple preset
+
+**Files:**
+- Modify: `src/ts4k/cli.py` — `_cmd_sources` add-branch (~line 257), `_suggest_cal_prefix` (~line 844), `sr_add` parser epilog (~line 1203)
+- Test: `tests/test_caldav_cli.py`
+
+**Interfaces:**
+- Consumes: `commands.cal_list_caldav_calendars` (Task 7), `save_credentials`/`load_credentials`/`ICLOUD_CALDAV_URL` (Task 1), `sources.add`, `_suggest_cal_prefix`.
+- Produces: `ts4k src add <prefix> apple email=you@icloud.com` — prompts for the app-specific password (getpass) if credentials are missing, validates by listing calendars, then interactive calendar selection; first selected calendar gets `<prefix>`, others get suggested `cc*` prefixes. `calendar_id=...` in params skips the picker and adds directly.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Tests for CalDAV source-add CLI flow."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import AsyncMock, patch
+
+from ts4k import cli
+from ts4k.state import sources
+
+
+def _args(provider: str, params: list[str]) -> argparse.Namespace:
+    return argparse.Namespace(
+        action="add", prefix="cc", provider=provider, params=params,
+    )
+
+
+CALS = [
+    {"id": "https://caldav.icloud.com/1/calendars/home/", "summary": "Home",
+     "access_role": "owner", "timezone": "UTC", "primary": False},
+    {"id": "https://caldav.icloud.com/1/calendars/work/", "summary": "Work",
+     "access_role": "owner", "timezone": "UTC", "primary": False},
+]
+
+
+class TestSrcAddApple:
+    def test_apple_alias_prompts_saves_and_adds_selected(self, ts4k_config, monkeypatch):
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "abcd-efgh")
+        monkeypatch.setattr("builtins.input", lambda prompt="": "1")
+        with patch.object(cli.commands, "cal_list_caldav_calendars",
+                          new=AsyncMock(return_value=CALS)):
+            cli._cmd_sources(_args("apple", ["email=a@icloud.com"]))
+
+        from ts4k.auth.caldav import load_credentials
+        creds = load_credentials("a@icloud.com")
+        assert creds is not None and creds["app_password"] == "abcd-efgh"
+        assert creds["server_url"] == "https://caldav.icloud.com"
+
+        cfg = sources.list_all()["cc"]
+        assert cfg["provider"] == "caldav"
+        assert cfg["calendar_id"] == "https://caldav.icloud.com/1/calendars/home/"
+        assert cfg["calendar_name"] == "Home"
+        assert cfg["level"] == "readonly"
+
+    def test_explicit_calendar_id_skips_picker(self, ts4k_config, monkeypatch):
+        from ts4k.auth.caldav import ICLOUD_CALDAV_URL, save_credentials
+
+        save_credentials("a@icloud.com", username="a@icloud.com",
+                         app_password="x", server_url=ICLOUD_CALDAV_URL)
+        cli._cmd_sources(_args("apple", [
+            "email=a@icloud.com",
+            "calendar_id=https://caldav.icloud.com/1/calendars/home/",
+            "calendar_name=Home",
+        ]))
+        cfg = sources.list_all()["cc"]
+        assert cfg["provider"] == "caldav"
+        assert cfg["calendar_id"] == "https://caldav.icloud.com/1/calendars/home/"
+
+    def test_missing_email_prints_usage_and_adds_nothing(self, ts4k_config, capsys):
+        cli._cmd_sources(_args("apple", []))
+        assert "email" in capsys.readouterr().out
+        assert "cc" not in sources.list_all()
+
+
+class TestSuggestPrefix:
+    def test_caldav_base_is_cc(self):
+        assert cli._suggest_cal_prefix("Home", {}, provider="caldav").startswith("cc")
+```
+
+Isolation caveat: `sources.py` computes `_CONFIG_DIR` at import time from `TS4K_CONFIG_DIR`. The `ts4k_config` fixture calls `state.set_config_dir` to repoint state modules — confirm `sources.list_all()` respects it by checking how existing tests (e.g. `tests/test_commands.py` or `tests/test_auth_cli.py`) isolate sources, and mirror that mechanism exactly.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_caldav_cli.py -v`
+Expected: FAIL — the apple alias isn't recognized (falls through to generic `sources.add` with provider "apple", so no credential prompt / no caldav entry)
+
+- [ ] **Step 3: Implement the CLI flow**
+
+In `src/ts4k/cli.py`, inside `_cmd_sources` after the params-parsing loop and before the O365 block, add:
+
+```python
+        # Apple/iCloud preset → generic caldav provider
+        from ts4k.auth.caldav import ICLOUD_CALDAV_URL
+        _CALDAV_ALIASES = {"apple": ICLOUD_CALDAV_URL, "icloud": ICLOUD_CALDAV_URL,
+                           "apple-calendar": ICLOUD_CALDAV_URL}
+        if provider in _CALDAV_ALIASES:
+            kwargs.setdefault("server_url", _CALDAV_ALIASES[provider])
+            provider = "caldav"
+
+        if provider == "caldav":
+            email = kwargs.get("email")
+            if not email:
+                print("Error: email is required for CalDAV sources.")
+                print(f"Usage: ts4k src add {prefix} apple email=you@icloud.com")
+                return
+            kwargs.setdefault("server_url", ICLOUD_CALDAV_URL)
+
+            from ts4k.auth.caldav import load_credentials, save_credentials
+            if load_credentials(email) is None:
+                import getpass
+                print("An app-specific password is required "
+                      "(https://account.apple.com → Sign-In and Security → "
+                      "App-Specific Passwords; needs 2FA).")
+                pw = getpass.getpass(f"App-specific password for {email}: ")
+                if not pw:
+                    print("No password entered — aborting.")
+                    return
+                save_credentials(email, username=email, app_password=pw,
+                                 server_url=kwargs["server_url"])
+                print(f"Saved credentials for {email}.")
+
+            if "calendar_id" not in kwargs:
+                print(f"Fetching calendars for {email}...")
+                try:
+                    cals = asyncio.run(commands.cal_list_caldav_calendars(email))
+                except Exception as e:
+                    print(f"Error: could not list calendars — {e}")
+                    return
+                if not cals:
+                    print("No calendars found.")
+                    return
+                for i, cal in enumerate(cals, 1):
+                    print(f"  {i}. {cal['summary']}")
+                choice = input("Which calendars? (comma-separated, or 'all'): ").strip()
+                if choice.lower() == "all":
+                    selected = cals
+                else:
+                    indices = [int(i.strip()) - 1
+                               for i in choice.split(",") if i.strip().isdigit()]
+                    selected = [cals[i] for i in indices if 0 <= i < len(cals)]
+                if not selected:
+                    print("No calendars selected.")
+                    return
+                all_sources = sources.list_all()
+                for n, cal in enumerate(selected):
+                    if n == 0 and prefix not in all_sources:
+                        pfx = prefix
+                    else:
+                        suggested = _suggest_cal_prefix(cal["summary"], all_sources,
+                                                        provider="caldav")
+                        pfx = input(f"Prefix for '{cal['summary']}'? [{suggested}]: ").strip() or suggested
+                    if pfx in all_sources:
+                        print(f"  Prefix '{pfx}' already in use — skipping.")
+                        continue
+                    sources.add(
+                        pfx, provider="caldav", email=email,
+                        server_url=kwargs["server_url"],
+                        calendar_id=cal["id"], calendar_name=cal["summary"],
+                        timezone=cal.get("timezone", "UTC"), level="readonly",
+                    )
+                    all_sources[pfx] = {}
+                    print(f"  Added '{cal['summary']}' as '{pfx}' (readonly)")
+                return
+            # calendar_id given explicitly → fall through to generic sources.add
+```
+
+Then:
+
+1. `_suggest_cal_prefix` (~line 844): change `base = "oc" if provider == "o365cal" else "gc"` to:
+
+```python
+    base = {"o365cal": "oc", "caldav": "cc"}.get(provider, "gc")
+```
+
+2. `sr_add` parser (~line 1203): add to the epilog provider keys — `"  apple/icloud: email (required), calendar_id, calendar_name  → generic caldav provider"` — and an example line `'  ts4k src add cc apple email=you@icloud.com'`; update the provider argument help to `"Provider: gmail, o365, whatsapp, apple/icloud/caldav"`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_caldav_cli.py -v`
+Expected: all pass
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `uv run pytest`
+Expected: no regressions
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ts4k/cli.py tests/test_caldav_cli.py
+git commit -m "feat: ts4k src add apple — credential prompt and calendar picker for caldav"
+```
+
+---
+
+### Task 9: Documentation + manual smoke test
+
+**Files:**
+- Modify: `README.md` (calendar/sources setup section — locate it first; follow its existing structure)
+- Create: nothing else
+
+**Interfaces:** none — docs and verification only.
+
+- [ ] **Step 1: Add README section**
+
+Find the calendar setup docs in `README.md` (`grep -n -i "calendar\|src add" README.md`) and add an Apple/iCloud subsection styled like the neighbors:
+
+```markdown
+### Apple / iCloud Calendar (CalDAV)
+
+iCloud calendars connect over CalDAV with an app-specific password — no OAuth setup.
+
+1. Generate an app-specific password at https://account.apple.com
+   (Sign-In and Security → App-Specific Passwords; requires 2FA).
+2. Add the source and pick calendars interactively:
+
+    ts4k src add cc apple email=you@icloud.com
+
+The same provider works for any CalDAV server (Fastmail, Nextcloud, ...):
+pass `server_url=https://your-server/` instead of the `apple` preset.
+
+Notes:
+- Write access needs `level=modify` (`ts4k src add cc apple email=... level=modify`,
+  or edit the source after adding).
+- RSVP is best-effort: iCloud often blocks programmatic replies to external
+  invites — ts4k reports this cleanly and you respond in the Calendar app.
+- Free-text event search is filtered client-side (CalDAV limitation).
+```
+
+- [ ] **Step 2: Run the full suite one final time**
+
+Run: `uv run pytest`
+Expected: everything green
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: Apple/iCloud CalDAV calendar setup"
+```
+
+- [ ] **Step 4: Manual smoke test against real iCloud (needs Peter's credentials — coordinate with user)**
+
+This step requires a real app-specific password and cannot be automated. Walk through with the user:
+
+1. `ts4k src add cc apple email=<apple-id>` → password prompt → calendar list appears → pick one.
+2. `ts4k src list` → the `cc` source shows provider caldav, level readonly.
+3. `ts4k cal today` (or the equivalent agenda command) → events from iCloud appear alongside gcal/o365cal sources.
+4. `ts4k cal get <ref>` → full detail renders (attendees, recurrence summary).
+5. Set `level=modify` on the source, then `ts4k cal create ...` → event appears in the Calendar app.
+6. `ts4k cal update ...` on that event → change syncs.
+7. `ts4k cal rsvp <ref> --status accepted` on a real invite → either succeeds or prints the clean "respond in the Calendar app" error (both are acceptable outcomes; a stack trace is a failure).
+8. `ts4k status` → the caldav source shows health "ok / app-specific password".
+
+Record any API-shape surprises (e.g. `event_by_uid` missing on the installed caldav version) and fix within the adapter, keeping tests green.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** provider shape/aliases (T7, T8), full surface incl. RSVP (T3–T6), credentials 0600 + interactive prompt (T1, T8), caldav library + to_thread (T2+), normalization parity incl. instance expansion (T3), levels as local gates (T2, T5; `scopes_for` already returns `[]` for unknown providers — no levels.py change needed, verified against `src/ts4k/core/levels.py:120`), actionable auth errors (T2), RSVP degradation (T6), client-side text search (no code change needed — text filtering doesn't pass through adapters' `list_events`; documented in README, T9), platform isolation (existing per-adapter error handling in command layer, unchanged), README docs + smoke test (T9).
+- **Known API-risk points** (all caught by the smoke test, all localized to the adapter): `Calendar.event_by_uid` alias availability, `search(expand=True)` client-side fallback behavior, `DAVClient.close()` availability. Where a check is cheap, the task text says to verify at implementation time.
+- Exception type for level violations must be confirmed in Task 5 Step 1 (mirror `tests/test_o365cal_levels.py`).

--- a/docs/superpowers/plans/2026-07-30-caldav-calendar-adapter.md
+++ b/docs/superpowers/plans/2026-07-30-caldav-calendar-adapter.md
@@ -909,6 +909,7 @@ git commit -m "feat: CalDAV read_event and list_calendars"
 
 **Files:**
 - Modify: `src/ts4k/adapters/caldav_cal.py`
+- Modify: `src/ts4k/core/levels.py:46` — the SEND-level calendar-provider allowlist `("gcal", "o365cal")` becomes `("gcal", "o365cal", "caldav")`. Without this, `check_level` raises `NotImplementedError` for any caldav SEND-level operation before the level comparison runs, and `create_event(attendees=...)` can never be permitted.
 - Test: `tests/test_caldav_write.py` (new file, mirrors `tests/test_gcal_write.py` structure)
 
 **Interfaces:**
@@ -1000,6 +1001,15 @@ class TestCreateEvent:
         with pytest.raises(PermissionError):
             await a.create_event("X", "2026-07-30T10:00:00", "2026-07-30T11:00:00",
                                  attendees=["a@example.com"])
+
+    async def test_attendees_allowed_at_send_level(self, tmp_path: Path):
+        # Requires "caldav" in the SEND calendar-provider allowlist (levels.py:46);
+        # without it check_level raises NotImplementedError regardless of level.
+        a = _adapter(tmp_path, "send")
+        a._calendar.save_event.side_effect = _echo_save_event
+        e = await a.create_event("X", "2026-07-30T10:00:00", "2026-07-30T11:00:00",
+                                 attendees=["a@example.com"])
+        assert e["attendees_summary"] == "1 people"
 
 
 class TestUpdateEvent:
@@ -1820,6 +1830,6 @@ Record any API-shape surprises (e.g. `event_by_uid` missing on the installed cal
 
 ## Self-Review Notes
 
-- **Spec coverage:** provider shape/aliases (T7, T8), full surface incl. RSVP (T3–T6), credentials 0600 + interactive prompt (T1, T8), caldav library + to_thread (T2+), normalization parity incl. instance expansion (T3), levels as local gates (T2, T5; `scopes_for` already returns `[]` for unknown providers — no levels.py change needed, verified against `src/ts4k/core/levels.py:120`), actionable auth errors (T2), RSVP degradation (T6), client-side text search (no code change needed — text filtering doesn't pass through adapters' `list_events`; documented in README, T9), platform isolation (existing per-adapter error handling in command layer, unchanged), README docs + smoke test (T9).
+- **Spec coverage:** provider shape/aliases (T7, T8), full surface incl. RSVP (T3–T6), credentials 0600 + interactive prompt (T1, T8), caldav library + to_thread (T2+), normalization parity incl. instance expansion (T3), levels as local gates (T2, T5; `scopes_for` already returns `[]` for unknown providers, but the SEND calendar allowlist at `src/ts4k/core/levels.py:46` must gain `"caldav"` — done in T5), actionable auth errors (T2), RSVP degradation (T6), client-side text search (no code change needed — text filtering doesn't pass through adapters' `list_events`; documented in README, T9), platform isolation (existing per-adapter error handling in command layer, unchanged), README docs + smoke test (T9).
 - **Known API-risk points** (all caught by the smoke test, all localized to the adapter): `Calendar.event_by_uid` alias availability, `search(expand=True)` client-side fallback behavior, `DAVClient.close()` availability. Where a check is cheap, the task text says to verify at implementation time.
 - Exception type for level violations must be confirmed in Task 5 Step 1 (mirror `tests/test_o365cal_levels.py`).

--- a/docs/superpowers/specs/2026-07-30-caldav-calendar-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-30-caldav-calendar-adapter-design.md
@@ -1,0 +1,154 @@
+# CalDAV Calendar Adapter (Apple/iCloud preset) — Design
+
+**Date:** 2026-07-30
+**Status:** Approved
+
+## Goal
+
+Add Apple Calendar (iCloud) support to ts4k as a generic CalDAV adapter, so
+`cal`-family commands work against iCloud the same way they do against Google
+Calendar and O365 Calendar. Generic CalDAV means the same adapter later serves
+Fastmail, Nextcloud, or any RFC 4791 server with zero new code.
+
+## Decisions Made
+
+- **Generic CalDAV provider** (`caldav`), with an Apple preset — aliases
+  `apple`, `icloud`, `apple-calendar` pre-fill `server_url` with
+  `https://caldav.icloud.com`.
+- **Full surface at launch**: list/read/create/update events, list calendars,
+  and RSVP (with graceful degradation — see RSVP section).
+- **Credentials** stored as plaintext JSON in the config dir, consistent with
+  existing Google/O365 token storage.
+- **Implementation via the `caldav` PyPI library** (not hand-rolled httpx) —
+  it owns principal discovery, REPORT queries, and per-server quirks. This is
+  the "ts4k does not reimplement platform protocols" rule applied to CalDAV.
+
+## Provider & Registration
+
+- Provider key: `caldav`. Default prefix: `cc:` (alongside `gc:` Google cal,
+  `oc:` O365 cal).
+- Registered in the `commands.py` adapter factory next to `gcal`/`o365cal`.
+- Alias map entries: `"apple" | "icloud" | "apple-calendar" → "caldav"`.
+- Every calendar-command gate currently written as
+  `provider in ("gcal", "o365cal")` extends to include `"caldav"`.
+- Provider label for status output: `"CalDAV"`.
+
+## Adapter
+
+New file `src/ts4k/adapters/caldav_cal.py` (named to avoid import collision
+with the `caldav` package).
+
+### Config
+
+```python
+@dataclass
+class CaldavAdapterConfig:
+    email: str            # account identity (Apple ID)
+    server_url: str       # e.g. https://caldav.icloud.com
+    calendar_id: str      # CalDAV calendar URL/path
+    calendar_name: str = ""
+    timezone: str = "UTC"
+    config_dir: Path | None = None
+    level: str = "readonly"
+```
+
+### Class
+
+`CaldavAdapter(BaseAdapter)`, mirroring `GcalAdapter`'s surface:
+
+- `connect()` — build `caldav.DAVClient` from stored credentials, resolve the
+  principal once. `disconnect()` closes it. Async context-manager support like
+  the other adapters.
+- `list_events(...)`, `read_event(...)`, `list_calendars()`,
+  `create_event(...)`, `update_event(...)`, `rsvp(...)`.
+- Message-side methods stubbed exactly like `gcal.py`: `whatsnew`/
+  `list_messages` return `[]`; `read_message`/`read_thread` raise
+  `NotImplementedError`.
+- The `caldav` library is synchronous — every call to it is wrapped in
+  `asyncio.to_thread` (same wrap-a-sync-client pattern as the Google adapter).
+
+### Normalization
+
+Events normalize to the **same dict shape** `GcalAdapter._normalize_event`
+produces — identical keys, so `core/format.py` needs no changes. RRULEs render
+via the existing module-level `rrule_to_human` imported from `gcal.py`.
+VEVENT cases to handle: recurring (RRULE), all-day (DATE values), and floating
+times (no TZID → interpret in the source's configured timezone).
+
+**Recurring events are expanded into instances** within the queried time
+window, matching gcal's `singleEvents=True` behavior. Use the `caldav`
+library's expand support (server-side `CALDAV:expand` where the server honors
+it, client-side expansion as fallback). Each instance carries
+`recurring_event_id` pointing at the master's UID, same as gcal's
+normalized shape. Results sorted by start time.
+
+## Auth & Levels
+
+- Credentials file: `~/.config/ts4k/caldav/<email>/credentials.json`,
+  written with `0600` permissions:
+
+  ```json
+  {"username": "...", "app_password": "...", "server_url": "..."}
+  ```
+
+- No OAuth. `scopes_for("caldav", level)` returns `[]`; access levels act as
+  purely local gates through the existing `check_level` machinery
+  (readonly → list/read only; modify → create/update/RSVP).
+- Setup flow (source-add command): prompt for the app-specific password
+  **interactively** — never as a CLI argument (shell history). Validate by
+  connecting and listing calendars; on success write credentials + source
+  entry. Point the user at appleid.apple.com to mint the app-specific
+  password (requires 2FA on the Apple ID).
+
+## RSVP
+
+Best-effort, honest about outcomes:
+
+1. Locate the `ATTENDEE` property matching the account email; set `PARTSTAT`
+   (ACCEPTED/DECLINED/TENTATIVE) and save the event back.
+2. Where the server advertises CalDAV scheduling support, also send the iTIP
+   REPLY so the organizer is notified.
+3. iCloud frequently rejects scheduling operations for externally-organized
+   invites. On rejection, return an actionable error — e.g. *"RSVP not
+   accepted by server — respond in the Calendar app"* — never a stack trace.
+4. Partial success is reported as such (PARTSTAT updated locally, organizer
+   not notified).
+
+## Errors
+
+- 401 / auth failure → message directing the user to generate a new
+  app-specific password at appleid.apple.com (they expire when the Apple ID
+  password changes).
+- Server down / timeout → per the platform-isolation rule, the failure is
+  contained; other adapters still return results.
+
+## Search
+
+- Time-range filtering happens server-side (CalDAV `calendar-query`).
+- Free-text search is client-side over the fetched window — iCloud's
+  `text-match` support is unreliable. Documented limitation.
+
+## Testing
+
+- Unit tests with a mocked `caldav` client, following the existing
+  mock-adapter pattern (`tmp_path` + `monkeypatch` for state isolation):
+  - VEVENT normalization: recurring, all-day, floating-time, recurrence sets
+  - Level gating (readonly blocks create/update/rsvp)
+  - RSVP fallback paths (server accepts / rejects / partial)
+  - Credential loading and 0600 permission enforcement
+  - Adapter factory: aliases resolve, `caldav` provider builds
+- Manual smoke-test checklist against the real iCloud account (in the
+  implementation plan): list calendars, list/read events, create, update,
+  RSVP attempt on a real invite.
+
+## Dependencies
+
+- Add `caldav` to `pyproject.toml` dependencies (pulls `icalendar`, `lxml`,
+  `vobject`).
+
+## Out of Scope
+
+- Push/webhook notifications (CalDAV has none ts4k can use; polling is fine).
+- Server-side free-text search.
+- Contact/message features for this provider — calendar only.
+- Any Google/O365 adapter changes beyond the shared gate lists.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
 ]
 dependencies = [
     "beautifulsoup4>=4.12",
+    "caldav>=3.2.1",
     "google-api-python-client>=2.100",
     "google-auth-httplib2>=0.2",
     "google-auth-oauthlib>=1.2",

--- a/src/ts4k/adapters/caldav_cal.py
+++ b/src/ts4k/adapters/caldav_cal.py
@@ -444,9 +444,68 @@ class CaldavAdapter(BaseAdapter):
         return self._normalize_component(comp)
 
     async def rsvp(self, event_id: str, status: str) -> dict:
-        """RSVP to an event. Requires MODIFY level."""
+        """RSVP to an event. Requires MODIFY level.
+
+        Prefers the caldav library's scheduling helpers (accept_invite etc.)
+        when present; falls back to editing PARTSTAT directly.  iCloud often
+        rejects scheduling writes on externally-organized invites — surfaced
+        as a clean RuntimeError, never a stack trace.
+        """
         self._check_modify("rsvp")
-        raise NotImplementedError("CalDAV rsvp is implemented in Task 6")
+
+        helper_names = {
+            "accepted": "accept_invite",
+            "declined": "decline_invite",
+            "tentative": "tentatively_accept_invite",
+        }
+        partstat_values = {
+            "accepted": "ACCEPTED",
+            "declined": "DECLINED",
+            "tentative": "TENTATIVE",
+        }
+        if status not in partstat_values:
+            raise ValueError(
+                f"Invalid RSVP status {status!r} — use accepted, declined, or tentative"
+            )
+
+        raw = self._strip_prefix(event_id)
+        uid = raw.split("::")[0]
+        obj = await self._fetch_by_uid(uid)
+        comp = obj.icalendar_component
+
+        my_email = self._config.email.lower()
+        raw_attendees = comp.get("ATTENDEE")
+        if raw_attendees is None:
+            raw_attendees = []
+        elif not isinstance(raw_attendees, list):
+            raw_attendees = [raw_attendees]
+        me = next(
+            (a for a in raw_attendees if _strip_mailto(a).lower() == my_email), None
+        )
+        if me is None:
+            raise ValueError(
+                f"{self._config.email} is not an attendee on this event — "
+                f"cannot RSVP"
+            )
+
+        helper = getattr(obj, helper_names[status], None)
+        if callable(helper):
+            try:
+                await asyncio.to_thread(helper)
+                return self._normalize_component(comp)
+            except Exception:
+                logger.info("caldav invite helper failed; falling back to PARTSTAT edit")
+
+        me.params["PARTSTAT"] = partstat_values[status]
+        try:
+            await asyncio.to_thread(obj.save)
+        except Exception as e:
+            raise RuntimeError(
+                f"RSVP not accepted by the server ({e}) — iCloud often blocks "
+                f"programmatic replies to external invites; respond in the "
+                f"Calendar app instead"
+            ) from e
+        return self._normalize_component(comp)
 
     # -- Helpers ---------------------------------------------------------------
 

--- a/src/ts4k/adapters/caldav_cal.py
+++ b/src/ts4k/adapters/caldav_cal.py
@@ -22,6 +22,19 @@ from ts4k.core.levels import AccessLevel, check_level, parse_level
 
 logger = logging.getLogger(__name__)
 
+_PARTSTAT_MAP = {
+    "ACCEPTED": "accepted",
+    "DECLINED": "declined",
+    "TENTATIVE": "tentative",
+    "NEEDS-ACTION": "needsAction",
+    "DELEGATED": "delegated",
+}
+
+
+def _strip_mailto(value: Any) -> str:
+    s = str(value)
+    return s[7:] if s.lower().startswith("mailto:") else s
+
 
 @dataclass
 class CaldavAdapterConfig:
@@ -115,6 +128,115 @@ class CaldavAdapter(BaseAdapter):
 
             self._calendar = await asyncio.to_thread(_find)
         return self._calendar
+
+    # -- Calendar methods ------------------------------------------------------
+
+    async def list_events(
+        self,
+        time_min: str,
+        time_max: str,
+        count: int = 250,
+    ) -> list[dict]:
+        """Fetch events in a time range, expanded to instances, sorted by start."""
+        cal = await self._get_calendar()
+        start = datetime.fromisoformat(time_min)
+        end = datetime.fromisoformat(time_max)
+        results = await asyncio.to_thread(
+            lambda: cal.search(start=start, end=end, event=True, expand=True)
+        )
+        events = [self._normalize_component(r.icalendar_component) for r in results]
+        events.sort(key=lambda e: e.get("start", ""))
+        return events[:count]
+
+    def _normalize_component(self, comp: Any) -> dict:
+        """Convert an icalendar VEVENT to the ts4k normalized event dict.
+
+        Same keys as GcalAdapter._normalize_event so format.py needs no changes.
+        """
+        uid = str(comp.get("UID", ""))
+        tzinfo = self._tzinfo()
+
+        dtstart = comp.get("DTSTART")
+        start_dt = dtstart.dt if dtstart is not None else None
+        all_day = isinstance(start_dt, date) and not isinstance(start_dt, datetime)
+
+        dtend = comp.get("DTEND")
+        if dtend is not None:
+            end_dt = dtend.dt
+        elif comp.get("DURATION") is not None and start_dt is not None:
+            end_dt = start_dt + comp.get("DURATION").dt
+        else:
+            end_dt = start_dt
+
+        if isinstance(start_dt, datetime) and start_dt.tzinfo is None:
+            start_dt = start_dt.replace(tzinfo=tzinfo)
+        if isinstance(end_dt, datetime) and end_dt.tzinfo is None:
+            end_dt = end_dt.replace(tzinfo=tzinfo)
+
+        start = start_dt.isoformat() if start_dt is not None else ""
+        end = end_dt.isoformat() if end_dt is not None else start
+        if all_day:
+            duration_minutes = None
+        elif start_dt is not None and end_dt is not None:
+            duration_minutes = max(0, int((end_dt - start_dt).total_seconds() / 60))
+        else:
+            duration_minutes = None
+
+        raw_attendees = comp.get("ATTENDEE")
+        if raw_attendees is None:
+            attendees = []
+        elif isinstance(raw_attendees, list):
+            attendees = raw_attendees
+        else:
+            attendees = [raw_attendees]
+
+        your_status = None
+        my_email = self._config.email.lower()
+        for a in attendees:
+            if _strip_mailto(a).lower() == my_email:
+                partstat = str(a.params.get("PARTSTAT", "NEEDS-ACTION")).upper()
+                your_status = _PARTSTAT_MAP.get(partstat, partstat.lower())
+                break
+
+        organizer_prop = comp.get("ORGANIZER")
+        organizer = _strip_mailto(organizer_prop) if organizer_prop is not None else ""
+
+        recurrence_id = comp.get("RECURRENCE-ID")
+        if recurrence_id is not None:
+            rid = recurrence_id.dt
+            if isinstance(rid, datetime) and rid.tzinfo is None:
+                rid = rid.replace(tzinfo=tzinfo)
+            event_id = f"{uid}::{rid.isoformat()}"
+            recurring_event_id = f"{self._prefix}:{uid}"
+        else:
+            event_id = uid
+            recurring_event_id = None
+
+        summary = comp.get("SUMMARY")
+        status_prop = comp.get("STATUS")
+        location_prop = comp.get("LOCATION")
+
+        return {
+            "id": f"{self._prefix}:{event_id}",
+            "source": self._prefix,
+            "title": str(summary) if summary else "(No title)",
+            "start": start,
+            "end": end,
+            "all_day": all_day,
+            "duration_minutes": duration_minutes,
+            "location": str(location_prop) if location_prop else "",
+            "organizer": organizer,
+            "attendees_summary": f"{len(attendees)} people" if attendees else "",
+            "status": str(status_prop).lower() if status_prop else "confirmed",
+            "your_status": your_status,
+            "recurring_event_id": recurring_event_id,
+        }
+
+    def _tzinfo(self) -> ZoneInfo | timezone:
+        try:
+            return ZoneInfo(self._config.timezone)
+        except Exception:
+            return timezone.utc
 
     # -- Messaging stubs (calendar sources have no messages) -------------------
 

--- a/src/ts4k/adapters/caldav_cal.py
+++ b/src/ts4k/adapters/caldav_cal.py
@@ -1,0 +1,155 @@
+"""CalDAV calendar adapter — generic RFC 4791, Apple/iCloud preset.
+
+Wraps the synchronous ``caldav`` library in ``asyncio.to_thread`` (same
+wrap-a-sync-client pattern as the Google adapter).  Auth is HTTP Basic
+with an app-specific password loaded from
+``~/.config/ts4k/caldav/<email>/credentials.json``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from ts4k.adapters.base import BaseAdapter
+from ts4k.auth.caldav import load_credentials
+from ts4k.core.levels import AccessLevel, check_level, parse_level
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CaldavAdapterConfig:
+    """Configuration for a CalDAV calendar source."""
+
+    email: str            # account identity (Apple ID)
+    server_url: str       # e.g. https://caldav.icloud.com
+    calendar_id: str      # CalDAV calendar URL
+    calendar_name: str = ""
+    timezone: str = "UTC"
+    config_dir: Path | None = None
+    level: str = "readonly"
+
+
+class CaldavAdapter(BaseAdapter):
+    """Generic CalDAV calendar adapter (iCloud, Fastmail, Nextcloud, ...)."""
+
+    def __init__(self, config: CaldavAdapterConfig, prefix: str = "cc") -> None:
+        self._config = config
+        self._prefix = prefix
+        self._access_level = parse_level(config.level)
+        self._client: Any = None
+        self._principal: Any = None
+        self._calendar: Any = None
+
+    @property
+    def source_prefix(self) -> str:
+        return self._prefix
+
+    # -- Connection ------------------------------------------------------------
+
+    async def connect(self) -> None:
+        import caldav
+        from caldav.lib.error import AuthorizationError
+
+        email = self._config.email
+        creds = load_credentials(email, self._config.config_dir)
+        if creds is None:
+            raise RuntimeError(
+                f"No CalDAV credentials for {email} — an app-specific password is "
+                f"required (generate at https://account.apple.com, then run: "
+                f"ts4k src add <prefix> apple email={email})"
+            )
+
+        def _connect() -> tuple[Any, Any]:
+            client = caldav.DAVClient(
+                url=creds.get("server_url") or self._config.server_url,
+                username=creds["username"],
+                password=creds["app_password"],
+            )
+            return client, client.principal()
+
+        try:
+            self._client, self._principal = await asyncio.to_thread(_connect)
+        except AuthorizationError as e:
+            raise RuntimeError(
+                f"CalDAV auth failed for {email} — the app-specific password may be "
+                f"revoked (they expire when the Apple ID password changes). Generate "
+                f"a new one at https://account.apple.com, delete "
+                f"~/.config/ts4k/caldav/{email}/credentials.json, and re-run "
+                f"ts4k src add."
+            ) from e
+
+    async def disconnect(self) -> None:
+        if self._client is not None:
+            await asyncio.to_thread(self._client.close)
+        self._client = None
+        self._principal = None
+        self._calendar = None
+
+    async def __aenter__(self) -> CaldavAdapter:
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.disconnect()
+
+    async def _get_calendar(self) -> Any:
+        """Resolve and cache the configured calendar by URL."""
+        if self._calendar is None:
+            wanted = self._config.calendar_id.rstrip("/")
+
+            def _find() -> Any:
+                for c in self._principal.calendars():
+                    if str(c.url).rstrip("/") == wanted:
+                        return c
+                raise RuntimeError(
+                    f"Calendar {self._config.calendar_id!r} not found for "
+                    f"{self._config.email}"
+                )
+
+            self._calendar = await asyncio.to_thread(_find)
+        return self._calendar
+
+    # -- Messaging stubs (calendar sources have no messages) -------------------
+
+    async def whatsnew(self, since: str | None = None,
+                       sender: str | None = None,
+                       domain: str | None = None) -> list[dict]:
+        return []
+
+    async def list_messages(self, query: str | None = None,
+                            count: int = 20,
+                            page_token: str | None = None,
+                            sender: str | None = None,
+                            domain: str | None = None) -> list[dict]:
+        return []
+
+    async def read_message(self, msg_id: str) -> dict:
+        raise NotImplementedError("CaldavAdapter does not support read_message")
+
+    async def read_thread(self, thread_id: str) -> dict:
+        raise NotImplementedError("CaldavAdapter does not support read_thread")
+
+    # -- Level checks ----------------------------------------------------------
+
+    def _check_modify(self, operation: str) -> None:
+        check_level(self._access_level, AccessLevel.MODIFY, operation, provider="caldav")
+
+    def _check_draft(self, operation: str) -> None:
+        check_level(self._access_level, AccessLevel.DRAFT, operation, provider="caldav")
+
+    def _check_send(self, operation: str) -> None:
+        check_level(self._access_level, AccessLevel.SEND, operation, provider="caldav")
+
+    # -- Helpers ---------------------------------------------------------------
+
+    def _strip_prefix(self, prefixed_id: str) -> str:
+        if prefixed_id.startswith(f"{self._prefix}:"):
+            return prefixed_id[len(self._prefix) + 1:]
+        return prefixed_id

--- a/src/ts4k/adapters/caldav_cal.py
+++ b/src/ts4k/adapters/caldav_cal.py
@@ -341,6 +341,113 @@ class CaldavAdapter(BaseAdapter):
     def _check_send(self, operation: str) -> None:
         check_level(self._access_level, AccessLevel.SEND, operation, provider="caldav")
 
+    # -- Write methods ---------------------------------------------------------
+
+    async def create_event(
+        self,
+        title: str,
+        start: str,
+        end: str,
+        description: str | None = None,
+        location: str | None = None,
+        attendees: list[str] | None = None,
+    ) -> dict:
+        """Create a calendar event with level-gated attendee support."""
+        if attendees:
+            self._check_send("create_event")
+        else:
+            self._check_draft("create_event")
+
+        import uuid
+
+        from icalendar import Calendar as IcsCalendar
+        from icalendar import Event as IcsEvent
+        from icalendar import vCalAddress
+
+        vevent = IcsEvent()
+        vevent.add("UID", str(uuid.uuid4()))
+        vevent.add("SUMMARY", title)
+        vevent.add("DTSTAMP", datetime.now(timezone.utc))
+
+        tzinfo = self._tzinfo()
+        if "T" not in start:
+            # All-day: user provides inclusive end, iCal DTEND is exclusive
+            end_date = date.fromisoformat(end) + timedelta(days=1)
+            vevent.add("DTSTART", date.fromisoformat(start))
+            vevent.add("DTEND", end_date)
+        else:
+            start_dt = datetime.fromisoformat(start)
+            end_dt = datetime.fromisoformat(end)
+            if start_dt.tzinfo is None:
+                start_dt = start_dt.replace(tzinfo=tzinfo)
+            if end_dt.tzinfo is None:
+                end_dt = end_dt.replace(tzinfo=tzinfo)
+            vevent.add("DTSTART", start_dt)
+            vevent.add("DTEND", end_dt)
+
+        if description:
+            vevent.add("DESCRIPTION", description)
+        if location:
+            vevent.add("LOCATION", location)
+        for email in attendees or []:
+            att = vCalAddress(f"mailto:{email}")
+            att.params["PARTSTAT"] = "NEEDS-ACTION"
+            att.params["ROLE"] = "REQ-PARTICIPANT"
+            vevent.add("ATTENDEE", att, encode=0)
+
+        ics = IcsCalendar()
+        ics.add("VERSION", "2.0")
+        ics.add("PRODID", "-//ts4k//caldav//EN")
+        ics.add_component(vevent)
+
+        cal = await self._get_calendar()
+        saved = await asyncio.to_thread(
+            lambda: cal.save_event(ics.to_ical().decode())
+        )
+        return self._normalize_component(saved.icalendar_component)
+
+    async def update_event(self, event_id: str, **fields: Any) -> dict:
+        """Update an existing event. Requires MODIFY level."""
+        self._check_modify("update_event")
+        raw = self._strip_prefix(event_id)
+        uid = raw.split("::")[0]
+        obj = await self._fetch_by_uid(uid)
+        comp = obj.icalendar_component
+        tzinfo = self._tzinfo()
+
+        def _set(key: str, value: Any) -> None:
+            comp.pop(key, None)
+            comp.add(key, value)
+
+        if "title" in fields:
+            _set("SUMMARY", fields["title"])
+        if "description" in fields:
+            _set("DESCRIPTION", fields["description"])
+        if "location" in fields:
+            _set("LOCATION", fields["location"])
+        if "start" in fields:
+            s = fields["start"]
+            if "T" not in s:
+                _set("DTSTART", date.fromisoformat(s))
+            else:
+                dt = datetime.fromisoformat(s)
+                _set("DTSTART", dt.replace(tzinfo=tzinfo) if dt.tzinfo is None else dt)
+        if "end" in fields:
+            e = fields["end"]
+            if "T" not in e:
+                _set("DTEND", date.fromisoformat(e))
+            else:
+                dt = datetime.fromisoformat(e)
+                _set("DTEND", dt.replace(tzinfo=tzinfo) if dt.tzinfo is None else dt)
+
+        await asyncio.to_thread(obj.save)
+        return self._normalize_component(comp)
+
+    async def rsvp(self, event_id: str, status: str) -> dict:
+        """RSVP to an event. Requires MODIFY level."""
+        self._check_modify("rsvp")
+        raise NotImplementedError("CalDAV rsvp is implemented in Task 6")
+
     # -- Helpers ---------------------------------------------------------------
 
     def _strip_prefix(self, prefixed_id: str) -> str:

--- a/src/ts4k/adapters/caldav_cal.py
+++ b/src/ts4k/adapters/caldav_cal.py
@@ -244,6 +244,72 @@ class CaldavAdapter(BaseAdapter):
         except Exception:
             return timezone.utc
 
+    async def _fetch_by_uid(self, uid: str) -> Any:
+        cal = await self._get_calendar()
+        return await asyncio.to_thread(lambda: cal.event_by_uid(uid))
+
+    async def read_event(self, event_id: str) -> dict:
+        """Fetch full detail for a single event by UID.
+
+        Instance IDs (``uid::<recurrence-id>``) resolve to the series master.
+        """
+        raw = self._strip_prefix(event_id)
+        uid = raw.split("::")[0]
+        obj = await self._fetch_by_uid(uid)
+        comp = obj.icalendar_component
+        base = self._normalize_component(comp)
+
+        attendees_full = []
+        raw_attendees = comp.get("ATTENDEE")
+        if raw_attendees is None:
+            raw_attendees = []
+        elif not isinstance(raw_attendees, list):
+            raw_attendees = [raw_attendees]
+        for a in raw_attendees:
+            email = _strip_mailto(a)
+            partstat = str(a.params.get("PARTSTAT", "NEEDS-ACTION")).upper()
+            attendees_full.append({
+                "name": str(a.params.get("CN", email)),
+                "email": email,
+                "status": _PARTSTAT_MAP.get(partstat, partstat.lower()),
+            })
+        base["attendees"] = attendees_full
+
+        desc = comp.get("DESCRIPTION")
+        base["description"] = str(desc) if desc else ""
+        url = comp.get("URL")
+        base["meeting_link"] = str(url) if url else ""
+
+        from ts4k.adapters.gcal import rrule_to_human
+
+        rrule_prop = comp.get("RRULE")
+        rrule = rrule_prop.to_ical().decode() if rrule_prop is not None else ""
+        base["recurrence"] = rrule
+        base["recurrence_summary"] = rrule_to_human(rrule) if rrule else ""
+
+        created = comp.get("CREATED")
+        base["created"] = created.dt.isoformat() if created is not None else ""
+        updated = comp.get("LAST-MODIFIED")
+        base["updated"] = updated.dt.isoformat() if updated is not None else ""
+        return base
+
+    async def list_calendars(self) -> list[dict]:
+        """List calendars on the principal (used by setup; adapter may have empty calendar_id)."""
+
+        def _list() -> list[dict]:
+            out = []
+            for c in self._principal.calendars():
+                out.append({
+                    "id": str(c.url),
+                    "summary": c.name or str(c.url),
+                    "access_role": "owner",
+                    "timezone": self._config.timezone,
+                    "primary": False,
+                })
+            return out
+
+        return await asyncio.to_thread(_list)
+
     # -- Messaging stubs (calendar sources have no messages) -------------------
 
     async def whatsnew(self, since: str | None = None,

--- a/src/ts4k/adapters/caldav_cal.py
+++ b/src/ts4k/adapters/caldav_cal.py
@@ -172,6 +172,10 @@ class CaldavAdapter(BaseAdapter):
             start_dt = start_dt.replace(tzinfo=tzinfo)
         if isinstance(end_dt, datetime) and end_dt.tzinfo is None:
             end_dt = end_dt.replace(tzinfo=tzinfo)
+        if isinstance(start_dt, datetime):
+            start_dt = start_dt.astimezone(tzinfo)
+        if isinstance(end_dt, datetime):
+            end_dt = end_dt.astimezone(tzinfo)
 
         start = start_dt.isoformat() if start_dt is not None else ""
         end = end_dt.isoformat() if end_dt is not None else start
@@ -206,6 +210,8 @@ class CaldavAdapter(BaseAdapter):
             rid = recurrence_id.dt
             if isinstance(rid, datetime) and rid.tzinfo is None:
                 rid = rid.replace(tzinfo=tzinfo)
+            if isinstance(rid, datetime):
+                rid = rid.astimezone(tzinfo)
             event_id = f"{uid}::{rid.isoformat()}"
             recurring_event_id = f"{self._prefix}:{uid}"
         else:

--- a/src/ts4k/adapters/caldav_cal.py
+++ b/src/ts4k/adapters/caldav_cal.py
@@ -389,6 +389,18 @@ class CaldavAdapter(BaseAdapter):
             vevent.add("DESCRIPTION", description)
         if location:
             vevent.add("LOCATION", location)
+        if attendees:
+            # RFC 6638 scheduling requires ORGANIZER on invite-bearing events;
+            # without it iCloud stores attendees inertly and never sends invites.
+            org = vCalAddress(f"mailto:{self._config.email}")
+            org.params["CN"] = self._config.email
+            vevent.add("ORGANIZER", org, encode=0)
+
+            self_att = vCalAddress(f"mailto:{self._config.email}")
+            self_att.params["PARTSTAT"] = "ACCEPTED"
+            self_att.params["ROLE"] = "CHAIR"
+            vevent.add("ATTENDEE", self_att, encode=0)
+
         for email in attendees or []:
             att = vCalAddress(f"mailto:{email}")
             att.params["PARTSTAT"] = "NEEDS-ACTION"
@@ -493,8 +505,8 @@ class CaldavAdapter(BaseAdapter):
             try:
                 await asyncio.to_thread(helper)
                 return self._normalize_component(comp)
-            except Exception:
-                logger.info("caldav invite helper failed; falling back to PARTSTAT edit")
+            except Exception as e:
+                logger.info("caldav invite helper failed (%s); falling back to PARTSTAT edit", e)
 
         me.params["PARTSTAT"] = partstat_values[status]
         try:

--- a/src/ts4k/adapters/caldav_cal.py
+++ b/src/ts4k/adapters/caldav_cal.py
@@ -245,7 +245,24 @@ class CaldavAdapter(BaseAdapter):
             return timezone.utc
 
     async def _fetch_by_uid(self, uid: str) -> Any:
+        """Fetch an event by UID.
+
+        iCloud rejects UID-filter REPORT queries with 412 Precondition
+        Failed, but stores events at ``<calendar>/<uid>.ics`` — so try the
+        conventional object URL first (verifying the UID matches) and fall
+        back to the standard REPORT for servers where the resource name
+        differs from the UID.
+        """
+        from urllib.parse import quote
+
         cal = await self._get_calendar()
+        url = f"{str(cal.url).rstrip('/')}/{quote(uid, safe='')}.ics"
+        try:
+            obj = await asyncio.to_thread(lambda: cal.event_by_url(url))
+            if str(obj.icalendar_component.get("UID", "")) == uid:
+                return obj
+        except Exception:
+            pass
         return await asyncio.to_thread(lambda: cal.event_by_uid(uid))
 
     async def read_event(self, event_id: str) -> dict:

--- a/src/ts4k/auth/caldav.py
+++ b/src/ts4k/auth/caldav.py
@@ -1,0 +1,52 @@
+"""CalDAV credential storage — Apple app-specific passwords, no OAuth.
+
+Credentials live at ``~/.config/ts4k/caldav/<email>/credentials.json``
+(0600).  Generate an app-specific password at https://account.apple.com
+(Sign-In and Security → App-Specific Passwords; requires 2FA).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+ICLOUD_CALDAV_URL = "https://caldav.icloud.com"
+
+
+def _default_config_dir() -> Path:
+    """Resolve auth config dir: env var → global default (mirrors auth/google.py)."""
+    env = os.environ.get("TS4K_CONFIG_DIR")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".config" / "ts4k"
+
+
+def credentials_path(email: str, config_dir: Path | None = None) -> Path:
+    base = Path(config_dir) if config_dir else _default_config_dir()
+    return base / "caldav" / email / "credentials.json"
+
+
+def save_credentials(
+    email: str,
+    *,
+    username: str,
+    app_password: str,
+    server_url: str,
+    config_dir: Path | None = None,
+) -> Path:
+    path = credentials_path(email, config_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(
+        {"username": username, "app_password": app_password, "server_url": server_url},
+        indent=2,
+    ))
+    path.chmod(0o600)
+    return path
+
+
+def load_credentials(email: str, config_dir: Path | None = None) -> dict | None:
+    path = credentials_path(email, config_dir)
+    if not path.exists():
+        return None
+    return json.loads(path.read_text())

--- a/src/ts4k/cli.py
+++ b/src/ts4k/cli.py
@@ -29,6 +29,7 @@ import asyncio
 import logging
 import os
 import sys
+from pathlib import Path
 from typing import Any
 
 from ts4k import commands, state
@@ -250,6 +251,28 @@ def _cmd_status(args: argparse.Namespace) -> None:
         print(commands.get_status())
 
 
+def _local_timezone() -> str:
+    """Best-effort IANA name for the system's local timezone; falls back to UTC."""
+    import zoneinfo
+    tz = os.environ.get("TZ")
+    if tz:
+        try:
+            zoneinfo.ZoneInfo(tz)
+            return tz
+        except Exception:
+            pass
+    try:
+        resolved = Path("/etc/localtime").resolve()
+        parts = resolved.parts
+        if "zoneinfo" in parts:
+            name = "/".join(parts[parts.index("zoneinfo") + 1:])
+            zoneinfo.ZoneInfo(name)
+            return name
+    except Exception:
+        pass
+    return "UTC"
+
+
 def _cmd_sources(args: argparse.Namespace) -> None:
     """Handle the src command — manage source config."""
     action = getattr(args, "action", None)
@@ -298,9 +321,11 @@ def _cmd_sources(args: argparse.Namespace) -> None:
                 if not pw:
                     print("No password entered — aborting.")
                     return
-                save_credentials(email, username=email, app_password=pw,
-                                 server_url=kwargs["server_url"])
+                save_credentials(email, username=kwargs.get("username") or email,
+                                 app_password=pw, server_url=kwargs["server_url"])
                 print(f"Saved credentials for {email}.")
+
+            tz_default = kwargs.get("timezone") or _local_timezone()
 
             if "calendar_id" not in kwargs:
                 print(f"Fetching calendars for {email}...")
@@ -339,12 +364,13 @@ def _cmd_sources(args: argparse.Namespace) -> None:
                         pfx, provider="caldav", email=email,
                         server_url=kwargs["server_url"],
                         calendar_id=cal["id"], calendar_name=cal["summary"],
-                        timezone=cal.get("timezone", "UTC"), level="readonly",
+                        timezone=tz_default, level="readonly",
                     )
                     all_sources[pfx] = {}
                     print(f"  Added '{cal['summary']}' as '{pfx}' (readonly)")
                 return
             # calendar_id given explicitly → fall through to generic sources.add
+            kwargs.setdefault("timezone", tz_default)
 
         # For O365: inherit client_id/tenant_id from existing O365 source
         # if not explicitly provided (same app registration for all mailboxes).

--- a/src/ts4k/cli.py
+++ b/src/ts4k/cli.py
@@ -272,6 +272,80 @@ def _cmd_sources(args: argparse.Namespace) -> None:
                 # Bare email address — treat as email=value
                 kwargs["email"] = kv.strip()
 
+        # Apple/iCloud preset → generic caldav provider
+        from ts4k.auth.caldav import ICLOUD_CALDAV_URL
+        _CALDAV_ALIASES = {"apple": ICLOUD_CALDAV_URL, "icloud": ICLOUD_CALDAV_URL,
+                           "apple-calendar": ICLOUD_CALDAV_URL}
+        if provider in _CALDAV_ALIASES:
+            kwargs.setdefault("server_url", _CALDAV_ALIASES[provider])
+            provider = "caldav"
+
+        if provider == "caldav":
+            email = kwargs.get("email")
+            if not email:
+                print("Error: email is required for CalDAV sources.")
+                print(f"Usage: ts4k src add {prefix} apple email=you@icloud.com")
+                return
+            kwargs.setdefault("server_url", ICLOUD_CALDAV_URL)
+
+            from ts4k.auth.caldav import load_credentials, save_credentials
+            if load_credentials(email) is None:
+                import getpass
+                print("An app-specific password is required "
+                      "(https://account.apple.com → Sign-In and Security → "
+                      "App-Specific Passwords; needs 2FA).")
+                pw = getpass.getpass(f"App-specific password for {email}: ")
+                if not pw:
+                    print("No password entered — aborting.")
+                    return
+                save_credentials(email, username=email, app_password=pw,
+                                 server_url=kwargs["server_url"])
+                print(f"Saved credentials for {email}.")
+
+            if "calendar_id" not in kwargs:
+                print(f"Fetching calendars for {email}...")
+                try:
+                    cals = asyncio.run(commands.cal_list_caldav_calendars(email))
+                except Exception as e:
+                    print(f"Error: could not list calendars — {e}")
+                    return
+                if not cals:
+                    print("No calendars found.")
+                    return
+                for i, cal in enumerate(cals, 1):
+                    print(f"  {i}. {cal['summary']}")
+                choice = input("Which calendars? (comma-separated, or 'all'): ").strip()
+                if choice.lower() == "all":
+                    selected = cals
+                else:
+                    indices = [int(i.strip()) - 1
+                               for i in choice.split(",") if i.strip().isdigit()]
+                    selected = [cals[i] for i in indices if 0 <= i < len(cals)]
+                if not selected:
+                    print("No calendars selected.")
+                    return
+                all_sources = sources.list_all()
+                for n, cal in enumerate(selected):
+                    if n == 0 and prefix not in all_sources:
+                        pfx = prefix
+                    else:
+                        suggested = _suggest_cal_prefix(cal["summary"], all_sources,
+                                                        provider="caldav")
+                        pfx = input(f"Prefix for '{cal['summary']}'? [{suggested}]: ").strip() or suggested
+                    if pfx in all_sources:
+                        print(f"  Prefix '{pfx}' already in use — skipping.")
+                        continue
+                    sources.add(
+                        pfx, provider="caldav", email=email,
+                        server_url=kwargs["server_url"],
+                        calendar_id=cal["id"], calendar_name=cal["summary"],
+                        timezone=cal.get("timezone", "UTC"), level="readonly",
+                    )
+                    all_sources[pfx] = {}
+                    print(f"  Added '{cal['summary']}' as '{pfx}' (readonly)")
+                return
+            # calendar_id given explicitly → fall through to generic sources.add
+
         # For O365: inherit client_id/tenant_id from existing O365 source
         # if not explicitly provided (same app registration for all mailboxes).
         if provider == "o365":
@@ -843,7 +917,7 @@ async def _cmd_cal_setup(args: argparse.Namespace) -> None:
 
 def _suggest_cal_prefix(name: str, existing: dict, provider: str = "gcal") -> str:
     """Suggest a short prefix for a calendar name."""
-    base = "oc" if provider == "o365cal" else "gc"
+    base = {"o365cal": "oc", "caldav": "cc"}.get(provider, "gc")
     # Use first letter of each word after base
     words = name.lower().replace("@", " ").replace(".", " ").split()
     if words and words[0] not in ("primary", "my"):
@@ -1209,10 +1283,12 @@ def _build_parser() -> argparse.ArgumentParser:
             "  gmail:    email (required), mcp_url, transport\n"
             "  whatsapp: mcp_cwd (required), server_command\n"
             "  o365:     client_id (required), tenant_id, mailbox\n"
+            "  apple/icloud: email (required), calendar_id, calendar_name  → generic caldav provider\n"
             "\n"
             "examples:\n"
             '  ts4k src add g gmail email=you@gmail.com\n'
             '  ts4k src add w whatsapp mcp_cwd=/path/to/server server_command="uv run python main.py"\n'
+            '  ts4k src add cc apple email=you@icloud.com\n'
             "\n"
             "List fields (server_command) are auto-split on spaces.\n"
             "A bare email (user@example.com) is treated as email=user@example.com."
@@ -1220,7 +1296,7 @@ def _build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     sr_add.add_argument("prefix", help="Source prefix (e.g. g, gn, w)")
-    sr_add.add_argument("provider", help="Provider: gmail, o365, whatsapp")
+    sr_add.add_argument("provider", help="Provider: gmail, o365, whatsapp, apple/icloud/caldav")
     sr_add.add_argument("params", nargs="*", help="key=value pairs or bare email")
 
     sr_rm = sr_sub.add_parser("rm", help="Remove a source",

--- a/src/ts4k/cli.py
+++ b/src/ts4k/cli.py
@@ -28,6 +28,7 @@ import argparse
 import asyncio
 import logging
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -273,6 +274,40 @@ def _local_timezone() -> str:
     return "UTC"
 
 
+def _prompt_password(prompt: str) -> str:
+    """Prompt for a secret, echoing '*' per character; getpass fallback off-TTY."""
+    if not sys.stdin.isatty():
+        import getpass
+        return getpass.getpass(prompt)
+    import termios
+    import tty
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    print(prompt, end="", flush=True)
+    chars: list[str] = []
+    try:
+        tty.setraw(fd)
+        while True:
+            ch = sys.stdin.read(1)
+            if ch in ("\r", "\n"):
+                break
+            if ch == "\x03":
+                raise KeyboardInterrupt
+            if ch in ("\x7f", "\b"):
+                if chars:
+                    chars.pop()
+                    sys.stdout.write("\b \b")
+                    sys.stdout.flush()
+                continue
+            chars.append(ch)
+            sys.stdout.write("*")
+            sys.stdout.flush()
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+        print()
+    return "".join(chars)
+
+
 def _cmd_sources(args: argparse.Namespace) -> None:
     """Handle the src command — manage source config."""
     action = getattr(args, "action", None)
@@ -312,18 +347,33 @@ def _cmd_sources(args: argparse.Namespace) -> None:
             kwargs.setdefault("server_url", ICLOUD_CALDAV_URL)
 
             from ts4k.auth.caldav import load_credentials, save_credentials
+            fresh = False
             if load_credentials(email) is None:
-                import getpass
+                is_icloud = kwargs["server_url"] == ICLOUD_CALDAV_URL
                 print("An app-specific password is required "
                       "(https://account.apple.com → Sign-In and Security → "
                       "App-Specific Passwords; needs 2FA).")
-                pw = getpass.getpass(f"App-specific password for {email}: ")
-                if not pw:
-                    print("No password entered — aborting.")
+                pw = None
+                for _attempt in range(3):
+                    raw = _prompt_password(f"App-specific password for {email}: ")
+                    candidate = "".join(raw.split())
+                    if not candidate:
+                        print("No password entered — aborting.")
+                        return
+                    if is_icloud and not re.fullmatch(r"[a-z]{4}-[a-z]{4}-[a-z]{4}-[a-z]{4}", candidate):
+                        print("That doesn't look like an Apple app-specific password "
+                              f"(expected xxxx-xxxx-xxxx-xxxx, got {len(candidate)} characters) "
+                              "— try again.")
+                        continue
+                    pw = candidate
+                    break
+                if pw is None:
+                    print("Too many failed attempts — aborting.")
                     return
                 save_credentials(email, username=kwargs.get("username") or email,
                                  app_password=pw, server_url=kwargs["server_url"])
                 print(f"Saved credentials for {email}.")
+                fresh = True
 
             tz_default = kwargs.get("timezone") or _local_timezone()
 
@@ -333,6 +383,11 @@ def _cmd_sources(args: argparse.Namespace) -> None:
                     cals = asyncio.run(commands.cal_list_caldav_calendars(email))
                 except Exception as e:
                     print(f"Error: could not list calendars — {e}")
+                    if fresh:
+                        from ts4k.auth.caldav import credentials_path
+                        credentials_path(email).unlink(missing_ok=True)
+                        print("Could not connect with that password — discarded the "
+                              "saved credentials; run the command again to retry.")
                     return
                 if not cals:
                     print("No calendars found.")

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -2188,16 +2188,23 @@ async def _cal_fetch_events(
         return []
 
     all_events: list[dict] = []
+    errors: list[str] = []
+    attempted = 0
     for pfx, cfg in prefixes:
         adapter = _make_adapter(pfx, cfg)
         if adapter is None:
             continue
+        attempted += 1
         try:
             async with adapter:
                 events = await adapter.list_events(time_min=time_min, time_max=time_max, count=count)
                 all_events.extend(events)
         except Exception as exc:
             logger.warning("[%s] calendar adapter failed: %s", pfx, exc)
+            errors.append(f"[{pfx}] {exc}")
+
+    if source and attempted and len(errors) == attempted:
+        raise RuntimeError("; ".join(errors))
 
     # Sort by start time
     all_events.sort(key=lambda e: e.get("start", ""))

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -18,6 +18,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from ts4k.adapters.caldav_cal import CaldavAdapter, CaldavAdapterConfig
 from ts4k.adapters.gcal import GcalAdapter, GcalAdapterConfig
 from ts4k.adapters.o365cal import O365CalAdapter, O365CalAdapterConfig
 from ts4k.adapters.gmail import GmailAdapter, GmailAdapterConfig
@@ -71,9 +72,12 @@ def _ensure_sources() -> dict[str, dict[str, Any]]:
     return sources.list_all()
 
 
+_CAL_PROVIDERS = ("gcal", "o365cal", "caldav")
+
+
 def _make_adapter(
     prefix: str, cfg: dict[str, Any]
-) -> GmailAdapter | WhatsAppAdapter | O365Adapter | GcalAdapter | O365CalAdapter | None:
+) -> GmailAdapter | WhatsAppAdapter | O365Adapter | GcalAdapter | O365CalAdapter | CaldavAdapter | None:
     """Create an adapter instance from a source config entry."""
     provider = cfg.get("provider", "").lower()
 
@@ -151,6 +155,23 @@ def _make_adapter(
         )
         return O365CalAdapter(config, prefix=prefix)
 
+    if provider == "caldav":
+        email = cfg.get("email")
+        calendar_id = cfg.get("calendar_id")
+        if not email or not calendar_id:
+            return None
+        from ts4k.auth.caldav import ICLOUD_CALDAV_URL
+        config = CaldavAdapterConfig(
+            email=email,
+            server_url=cfg.get("server_url", ICLOUD_CALDAV_URL),
+            calendar_id=calendar_id,
+            calendar_name=cfg.get("calendar_name", ""),
+            timezone=cfg.get("timezone", "UTC"),
+            config_dir=Path(cfg["config_dir"]) if cfg.get("config_dir") else None,
+            level=cfg.get("level", "readonly"),
+        )
+        return CaldavAdapter(config, prefix=prefix)
+
     logger.warning("Unknown provider %r for source %r", provider, prefix)
     return None
 
@@ -173,6 +194,7 @@ def _resolve_prefixes(source: str | None) -> list[str]:
         "wa": "whatsapp", "outlook": "o365", "office": "o365", "365": "o365",
         "google-calendar": "gcal", "calendar": "gcal", "cal": "gcal",
         "o365-calendar": "o365cal", "outlook-calendar": "o365cal",
+        "apple": "caldav", "icloud": "caldav", "apple-calendar": "caldav",
     }
     provider = provider_map.get(source, source)
     matches = [
@@ -898,7 +920,7 @@ def get_status(
     total_msgs = st.get("total_messages", 0)
     pct = stats.savings_pct()
 
-    _provider_labels = {"gmail": "Gmail", "whatsapp": "WhatsApp", "o365": "O365", "o365cal": "O365 Cal", "gcal": "GCal"}
+    _provider_labels = {"gmail": "Gmail", "whatsapp": "WhatsApp", "o365": "O365", "o365cal": "O365 Cal", "gcal": "GCal", "caldav": "CalDAV"}
 
     lines.append("")
     lines.append("Stats:")
@@ -914,7 +936,7 @@ def get_status(
         lines.append("  By source:")
         for src in sorted(all_cfg.keys()):
             provider = all_cfg[src].get("provider", "")
-            if provider in ("gcal", "o365cal"):
+            if provider in _CAL_PROVIDERS:
                 continue  # Calendar events tracked separately
             base_label = _provider_labels.get(provider, provider)
             label = base_label if src == provider[0:1] else f"{base_label}({src})"
@@ -1952,6 +1974,16 @@ def check_token_health(prefix: str, cfg: dict[str, Any]) -> "TokenHealth":
         required = scopes_for(provider, parse_level(cfg.get("level")))
         return validate_token(client_id, tenant_id=tenant_id, scopes=required or None, username=username)
 
+    if provider == "caldav":
+        from ts4k.auth.caldav import load_credentials
+        email = cfg.get("email", "")
+        if not email:
+            return TokenHealth(status="na", expiry=None, scopes=[], detail="no email configured")
+        if load_credentials(email) is None:
+            return TokenHealth(status="na", expiry=None, scopes=[],
+                               detail="no credentials — run: ts4k src add <prefix> apple email=" + email)
+        return TokenHealth(status="ok", expiry=None, scopes=[], detail="app-specific password")
+
     return TokenHealth(status="na", expiry=None, scopes=[], detail=f"unknown provider: {provider}")
 
 
@@ -2146,7 +2178,7 @@ async def _cal_fetch_events(
     all_sources = src_mod.list_all()
     prefixes = []
     for pfx, cfg in all_sources.items():
-        if cfg.get("provider") not in ("gcal", "o365cal"):
+        if cfg.get("provider") not in _CAL_PROVIDERS:
             continue
         if source and pfx != source and cfg.get("provider") != source:
             continue
@@ -2191,7 +2223,7 @@ def _get_cal_timezone(source: str | None) -> str:
 
     all_sources = src_mod.list_all()
     for pfx, cfg in all_sources.items():
-        if cfg.get("provider") not in ("gcal", "o365cal"):
+        if cfg.get("provider") not in _CAL_PROVIDERS:
             continue
         if source and pfx != source:
             continue
@@ -2286,7 +2318,7 @@ async def cal_event(
     prefix = event_id.split(":")[0] if ":" in event_id else source
     all_sources = src_mod.list_all()
     cfg = all_sources.get(prefix)
-    if not cfg or cfg.get("provider") not in ("gcal", "o365cal"):
+    if not cfg or cfg.get("provider") not in _CAL_PROVIDERS:
         return f"Error: no calendar source with prefix '{prefix}'"
 
     adapter = _make_adapter(prefix, cfg)
@@ -2325,6 +2357,22 @@ async def cal_list_o365_calendars(
         return await adapter.list_calendars()
 
 
+async def cal_list_caldav_calendars(
+    email: str, config_dir: Path | None = None,
+) -> list[dict]:
+    """List available calendars for a CalDAV account (non-interactive, for setup)."""
+    from ts4k.auth.caldav import ICLOUD_CALDAV_URL
+
+    config = CaldavAdapterConfig(
+        email=email, server_url=ICLOUD_CALDAV_URL, calendar_id="",
+        calendar_name="", timezone="UTC", config_dir=config_dir,
+        level="readonly",
+    )
+    adapter = CaldavAdapter(config, prefix="_setup")
+    async with adapter:
+        return await adapter.list_calendars()
+
+
 async def cal_create(
     source: str, title: str, start: str, end: str,
     description: str | None, location: str | None,
@@ -2335,7 +2383,7 @@ async def cal_create(
     from ts4k.state import sources as src_mod
 
     cfg = src_mod.list_all().get(source)
-    if not cfg or cfg.get("provider") not in ("gcal", "o365cal"):
+    if not cfg or cfg.get("provider") not in _CAL_PROVIDERS:
         return f"Error: '{source}' is not a calendar source"
 
     adapter = _make_adapter(source, cfg)
@@ -2363,7 +2411,7 @@ async def cal_update(ref_or_id: str, source: str | None, ref_table: RefTable | N
 
     prefix = event_id.split(":")[0] if ":" in event_id else source
     cfg = src_mod.list_all().get(prefix)
-    if not cfg or cfg.get("provider") not in ("gcal", "o365cal"):
+    if not cfg or cfg.get("provider") not in _CAL_PROVIDERS:
         return f"Error: no calendar source with prefix '{prefix}'"
 
     adapter = _make_adapter(prefix, cfg)
@@ -2388,7 +2436,7 @@ async def cal_rsvp(ref_or_id: str, source: str | None, status: str, ref_table: R
 
     prefix = event_id.split(":")[0] if ":" in event_id else source
     cfg = src_mod.list_all().get(prefix)
-    if not cfg or cfg.get("provider") not in ("gcal", "o365cal"):
+    if not cfg or cfg.get("provider") not in _CAL_PROVIDERS:
         return f"Error: no calendar source with prefix '{prefix}'"
 
     adapter = _make_adapter(prefix, cfg)

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -2395,7 +2395,10 @@ async def cal_rsvp(ref_or_id: str, source: str | None, status: str, ref_table: R
     if adapter is None:
         return f"Error: could not create adapter for '{prefix}'"
 
-    async with adapter:
-        event = await adapter.rsvp(event_id, status=status)
+    try:
+        async with adapter:
+            event = await adapter.rsvp(event_id, status=status)
+    except (ValueError, RuntimeError) as e:
+        return f"Error: {e}"
 
     return f"RSVP {status}: {event['title']} ({event['id']})"

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -1979,7 +1979,7 @@ def check_token_health(prefix: str, cfg: dict[str, Any]) -> "TokenHealth":
         email = cfg.get("email", "")
         if not email:
             return TokenHealth(status="na", expiry=None, scopes=[], detail="no email configured")
-        if load_credentials(email) is None:
+        if load_credentials(email, Path(cfg["config_dir"]) if cfg.get("config_dir") else None) is None:
             return TokenHealth(status="na", expiry=None, scopes=[],
                                detail="no credentials — run: ts4k src add <prefix> apple email=" + email)
         return TokenHealth(status="ok", expiry=None, scopes=[], detail="app-specific password")
@@ -2192,9 +2192,12 @@ async def _cal_fetch_events(
         adapter = _make_adapter(pfx, cfg)
         if adapter is None:
             continue
-        async with adapter:
-            events = await adapter.list_events(time_min=time_min, time_max=time_max, count=count)
-            all_events.extend(events)
+        try:
+            async with adapter:
+                events = await adapter.list_events(time_min=time_min, time_max=time_max, count=count)
+                all_events.extend(events)
+        except Exception as exc:
+            logger.warning("[%s] calendar adapter failed: %s", pfx, exc)
 
     # Sort by start time
     all_events.sort(key=lambda e: e.get("start", ""))

--- a/src/ts4k/core/levels.py
+++ b/src/ts4k/core/levels.py
@@ -43,7 +43,7 @@ def check_level(current: AccessLevel, required: AccessLevel, operation: str,
     but permitted for calendar providers (invites are a normal workflow).
     """
     if required >= AccessLevel.SEND:
-        if provider not in ("gcal", "o365cal"):
+        if provider not in ("gcal", "o365cal", "caldav"):
             raise NotImplementedError(
                 f"Operation '{operation}' requires level 'send', which is "
                 "intentionally not implemented for messaging. "

--- a/tests/test_caldav_adapter.py
+++ b/tests/test_caldav_adapter.py
@@ -1,0 +1,88 @@
+"""Tests for the CalDAV calendar adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from ts4k.adapters.caldav_cal import CaldavAdapter, CaldavAdapterConfig
+from ts4k.auth.caldav import ICLOUD_CALDAV_URL, save_credentials
+from ts4k.core.levels import AccessLevel
+
+
+@pytest.fixture
+def caldav_config(tmp_path: Path) -> CaldavAdapterConfig:
+    save_credentials(
+        "test@icloud.com",
+        username="test@icloud.com",
+        app_password="abcd-efgh",
+        server_url=ICLOUD_CALDAV_URL,
+        config_dir=tmp_path,
+    )
+    return CaldavAdapterConfig(
+        email="test@icloud.com",
+        server_url=ICLOUD_CALDAV_URL,
+        calendar_id="https://caldav.icloud.com/123/calendars/home/",
+        calendar_name="Home",
+        timezone="Europe/Amsterdam",
+        config_dir=tmp_path,
+        level="readonly",
+    )
+
+
+@pytest.fixture
+def adapter(caldav_config: CaldavAdapterConfig) -> CaldavAdapter:
+    a = CaldavAdapter(caldav_config, prefix="cc")
+    # Bypass network: tests install mocks where connect() would put real objects
+    a._principal = MagicMock()
+    a._calendar = MagicMock()
+    return a
+
+
+class TestConstruction:
+    def test_prefix(self, adapter: CaldavAdapter):
+        assert adapter.source_prefix == "cc"
+
+    def test_access_level(self, adapter: CaldavAdapter):
+        assert adapter.access_level == AccessLevel.READONLY
+
+
+class TestConnect:
+    async def test_connect_without_credentials_raises_actionable(self, tmp_path: Path):
+        config = CaldavAdapterConfig(
+            email="nobody@icloud.com",
+            server_url=ICLOUD_CALDAV_URL,
+            calendar_id="x",
+            config_dir=tmp_path,
+        )
+        a = CaldavAdapter(config, prefix="cc")
+        with pytest.raises(RuntimeError, match="app-specific password"):
+            await a.connect()
+
+
+class TestMessagingStubs:
+    """Messaging methods return empty results (not raise) for --source all safety."""
+
+    async def test_whatsnew_returns_empty(self, adapter: CaldavAdapter):
+        assert await adapter.whatsnew(since="2026-01-01") == []
+
+    async def test_list_messages_returns_empty(self, adapter: CaldavAdapter):
+        assert await adapter.list_messages() == []
+
+    async def test_read_message_raises(self, adapter: CaldavAdapter):
+        with pytest.raises(NotImplementedError):
+            await adapter.read_message("cc:123")
+
+    async def test_read_thread_raises(self, adapter: CaldavAdapter):
+        with pytest.raises(NotImplementedError):
+            await adapter.read_thread("cc:t123")
+
+
+class TestStripPrefix:
+    def test_strips_own_prefix(self, adapter: CaldavAdapter):
+        assert adapter._strip_prefix("cc:abc123") == "abc123"
+
+    def test_leaves_bare_id(self, adapter: CaldavAdapter):
+        assert adapter._strip_prefix("abc123") == "abc123"

--- a/tests/test_caldav_adapter.py
+++ b/tests/test_caldav_adapter.py
@@ -288,3 +288,40 @@ class TestListCalendars:
             {"id": "https://caldav.icloud.com/123/calendars/work/", "summary": "Work",
              "access_role": "owner", "timezone": "Europe/Amsterdam", "primary": False},
         ]
+
+
+class TestFetchByUidUrlFirst:
+    """iCloud rejects UID-filter REPORTs with 412 — URL-first lookup with REPORT fallback."""
+
+    def _obj_with_uid(self, uid: str) -> MagicMock:
+        obj = MagicMock()
+        comp = MagicMock()
+        comp.get.return_value = uid
+        obj.icalendar_component = comp
+        return obj
+
+    async def test_url_hit_with_matching_uid_skips_report(self, adapter: CaldavAdapter):
+        adapter._calendar.url = "https://caldav.icloud.com/123/calendars/home/"
+        adapter._calendar.event_by_url.return_value = self._obj_with_uid("det1@icloud.com")
+        obj = await adapter._fetch_by_uid("det1@icloud.com")
+        adapter._calendar.event_by_url.assert_called_once_with(
+            "https://caldav.icloud.com/123/calendars/home/det1%40icloud.com.ics"
+        )
+        adapter._calendar.event_by_uid.assert_not_called()
+        assert str(obj.icalendar_component.get("UID")) == "det1@icloud.com"
+
+    async def test_url_miss_falls_back_to_report(self, adapter: CaldavAdapter):
+        adapter._calendar.url = "https://caldav.icloud.com/123/calendars/home/"
+        adapter._calendar.event_by_url.side_effect = Exception("404 Not Found")
+        adapter._calendar.event_by_uid.return_value = self._obj_with_uid("det1@icloud.com")
+        obj = await adapter._fetch_by_uid("det1@icloud.com")
+        adapter._calendar.event_by_uid.assert_called_once_with("det1@icloud.com")
+        assert obj is adapter._calendar.event_by_uid.return_value
+
+    async def test_url_uid_mismatch_falls_back_to_report(self, adapter: CaldavAdapter):
+        adapter._calendar.url = "https://caldav.icloud.com/123/calendars/home/"
+        adapter._calendar.event_by_url.return_value = self._obj_with_uid("someone-else")
+        adapter._calendar.event_by_uid.return_value = self._obj_with_uid("det1@icloud.com")
+        obj = await adapter._fetch_by_uid("det1@icloud.com")
+        adapter._calendar.event_by_uid.assert_called_once_with("det1@icloud.com")
+        assert obj is adapter._calendar.event_by_uid.return_value

--- a/tests/test_caldav_adapter.py
+++ b/tests/test_caldav_adapter.py
@@ -227,3 +227,64 @@ class TestListEvents:
             "2026-07-30T00:00:00", "2026-07-31T00:00:00", count=2
         )
         assert len(events) == 2
+
+
+DETAIL_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:det1@icloud.com
+SUMMARY:Planning
+DTSTART;TZID=Europe/Amsterdam:20260730T100000
+DTEND;TZID=Europe/Amsterdam:20260730T110000
+DESCRIPTION:Quarterly planning session
+URL:https://meet.example.com/xyz
+ATTENDEE;CN=Alice;PARTSTAT=ACCEPTED:mailto:alice@example.com
+ATTENDEE;PARTSTAT=DECLINED:mailto:test@icloud.com
+RRULE:FREQ=WEEKLY;BYDAY=TH
+CREATED:20260101T000000Z
+LAST-MODIFIED:20260615T120000Z
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+class TestReadEvent:
+    async def test_full_detail(self, adapter: CaldavAdapter):
+        adapter._calendar.event_by_uid.return_value = _mk_caldav_event(DETAIL_ICS)
+        e = await adapter.read_event("cc:det1@icloud.com")
+        assert e["title"] == "Planning"
+        assert e["description"] == "Quarterly planning session"
+        assert e["meeting_link"] == "https://meet.example.com/xyz"
+        assert e["recurrence"] == "FREQ=WEEKLY;BYDAY=TH"
+        assert e["recurrence_summary"] == "weekly on Thu"
+        assert e["attendees"] == [
+            {"name": "Alice", "email": "alice@example.com", "status": "accepted"},
+            {"name": "test@icloud.com", "email": "test@icloud.com", "status": "declined"},
+        ]
+        assert e["created"] == "2026-01-01T00:00:00+00:00"
+        assert e["updated"] == "2026-06-15T12:00:00+00:00"
+        adapter._calendar.event_by_uid.assert_called_once_with("det1@icloud.com")
+
+    async def test_instance_id_fetches_master(self, adapter: CaldavAdapter):
+        adapter._calendar.event_by_uid.return_value = _mk_caldav_event(DETAIL_ICS)
+        await adapter.read_event("cc:det1@icloud.com::2026-08-06T10:00:00+02:00")
+        adapter._calendar.event_by_uid.assert_called_once_with("det1@icloud.com")
+
+
+class TestListCalendars:
+    async def test_lists_principal_calendars(self, adapter: CaldavAdapter):
+        c1 = MagicMock()
+        c1.url = "https://caldav.icloud.com/123/calendars/home/"
+        c1.name = "Home"
+        c2 = MagicMock()
+        c2.url = "https://caldav.icloud.com/123/calendars/work/"
+        c2.name = "Work"
+        adapter._principal.calendars.return_value = [c1, c2]
+        cals = await adapter.list_calendars()
+        assert cals == [
+            {"id": "https://caldav.icloud.com/123/calendars/home/", "summary": "Home",
+             "access_role": "owner", "timezone": "Europe/Amsterdam", "primary": False},
+            {"id": "https://caldav.icloud.com/123/calendars/work/", "summary": "Work",
+             "access_role": "owner", "timezone": "Europe/Amsterdam", "primary": False},
+        ]

--- a/tests/test_caldav_adapter.py
+++ b/tests/test_caldav_adapter.py
@@ -151,6 +151,18 @@ END:VEVENT
 END:VCALENDAR
 """
 
+FOREIGN_TZ_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:foreign1
+SUMMARY:NY Sync
+DTSTART;TZID=America/New_York:20260730T090000
+DTEND;TZID=America/New_York:20260730T100000
+END:VEVENT
+END:VCALENDAR
+"""
+
 
 class TestNormalization:
     def test_timed_event(self, adapter: CaldavAdapter):
@@ -185,6 +197,12 @@ class TestNormalization:
         e = adapter._normalize_component(_mk_caldav_event(INSTANCE_ICS).icalendar_component)
         assert e["recurring_event_id"] == "cc:rec1@icloud.com"
         assert e["id"].startswith("cc:rec1@icloud.com::2026-08-06T14:00:00")
+
+    def test_foreign_timezone_normalized_to_config_tz(self, adapter: CaldavAdapter):
+        # 09:00 EDT (America/New_York) on 2026-07-30 == 15:00 CEST (Europe/Amsterdam)
+        e = adapter._normalize_component(_mk_caldav_event(FOREIGN_TZ_ICS).icalendar_component)
+        assert e["start"] == "2026-07-30T15:00:00+02:00"
+        assert e["duration_minutes"] == 60
 
 
 class TestListEvents:

--- a/tests/test_caldav_adapter.py
+++ b/tests/test_caldav_adapter.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from icalendar import Calendar as IcsCalendar
 
 from ts4k.adapters.caldav_cal import CaldavAdapter, CaldavAdapterConfig
 from ts4k.auth.caldav import ICLOUD_CALDAV_URL, save_credentials
@@ -86,3 +87,125 @@ class TestStripPrefix:
 
     def test_leaves_bare_id(self, adapter: CaldavAdapter):
         assert adapter._strip_prefix("abc123") == "abc123"
+
+
+def _mk_caldav_event(ics: str) -> MagicMock:
+    """Build a fake caldav Event exposing .icalendar_component."""
+    comp = IcsCalendar.from_ical(ics).walk("VEVENT")[0]
+    obj = MagicMock()
+    obj.icalendar_component = comp
+    return obj
+
+
+TIMED_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:abc123@icloud.com
+SUMMARY:Dentist
+DTSTART;TZID=Europe/Amsterdam:20260730T140000
+DTEND;TZID=Europe/Amsterdam:20260730T150000
+ORGANIZER:mailto:org@example.com
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:test@icloud.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:other@example.com
+STATUS:CONFIRMED
+LOCATION:Main St 1
+END:VEVENT
+END:VCALENDAR
+"""
+
+ALLDAY_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:allday1
+SUMMARY:Holiday
+DTSTART;VALUE=DATE:20260730
+DTEND;VALUE=DATE:20260731
+END:VEVENT
+END:VCALENDAR
+"""
+
+FLOATING_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:float1
+SUMMARY:Floating
+DTSTART:20260730T090000
+DTEND:20260730T093000
+END:VEVENT
+END:VCALENDAR
+"""
+
+INSTANCE_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:rec1@icloud.com
+SUMMARY:Standup
+DTSTART;TZID=Europe/Amsterdam:20260806T140000
+DTEND;TZID=Europe/Amsterdam:20260806T141500
+RECURRENCE-ID;TZID=Europe/Amsterdam:20260806T140000
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+class TestNormalization:
+    def test_timed_event(self, adapter: CaldavAdapter):
+        e = adapter._normalize_component(_mk_caldav_event(TIMED_ICS).icalendar_component)
+        assert e["id"] == "cc:abc123@icloud.com"
+        assert e["source"] == "cc"
+        assert e["title"] == "Dentist"
+        assert e["start"].startswith("2026-07-30T14:00:00")
+        assert e["all_day"] is False
+        assert e["duration_minutes"] == 60
+        assert e["location"] == "Main St 1"
+        assert e["organizer"] == "org@example.com"
+        assert e["attendees_summary"] == "2 people"
+        assert e["status"] == "confirmed"
+        assert e["your_status"] == "accepted"
+        assert e["recurring_event_id"] is None
+
+    def test_all_day_event(self, adapter: CaldavAdapter):
+        e = adapter._normalize_component(_mk_caldav_event(ALLDAY_ICS).icalendar_component)
+        assert e["all_day"] is True
+        assert e["start"] == "2026-07-30"
+        assert e["end"] == "2026-07-31"
+        assert e["duration_minutes"] is None
+
+    def test_floating_time_gets_config_timezone(self, adapter: CaldavAdapter):
+        e = adapter._normalize_component(_mk_caldav_event(FLOATING_ICS).icalendar_component)
+        # Europe/Amsterdam on 2026-07-30 is UTC+2
+        assert e["start"] == "2026-07-30T09:00:00+02:00"
+        assert e["duration_minutes"] == 30
+
+    def test_recurring_instance_ids(self, adapter: CaldavAdapter):
+        e = adapter._normalize_component(_mk_caldav_event(INSTANCE_ICS).icalendar_component)
+        assert e["recurring_event_id"] == "cc:rec1@icloud.com"
+        assert e["id"].startswith("cc:rec1@icloud.com::2026-08-06T14:00:00")
+
+
+class TestListEvents:
+    async def test_search_called_with_expand_and_sorted(self, adapter: CaldavAdapter):
+        adapter._calendar.search.return_value = [
+            _mk_caldav_event(ALLDAY_ICS),   # starts 2026-07-30 (date sorts first)
+            _mk_caldav_event(TIMED_ICS),    # starts 2026-07-30T14:00
+        ]
+        events = await adapter.list_events(
+            "2026-07-30T00:00:00+02:00", "2026-07-31T00:00:00+02:00"
+        )
+        assert [e["title"] for e in events] == ["Holiday", "Dentist"]
+        kwargs = adapter._calendar.search.call_args.kwargs
+        assert kwargs["event"] is True
+        assert kwargs["expand"] is True
+
+    async def test_count_caps_results(self, adapter: CaldavAdapter):
+        adapter._calendar.search.return_value = [
+            _mk_caldav_event(TIMED_ICS) for _ in range(5)
+        ]
+        events = await adapter.list_events(
+            "2026-07-30T00:00:00", "2026-07-31T00:00:00", count=2
+        )
+        assert len(events) == 2

--- a/tests/test_caldav_auth.py
+++ b/tests/test_caldav_auth.py
@@ -1,0 +1,48 @@
+"""Tests for CalDAV credential storage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ts4k.auth.caldav import (
+    ICLOUD_CALDAV_URL,
+    credentials_path,
+    load_credentials,
+    save_credentials,
+)
+
+
+def test_path_layout(tmp_path: Path):
+    p = credentials_path("a@icloud.com", config_dir=tmp_path)
+    assert p == tmp_path / "caldav" / "a@icloud.com" / "credentials.json"
+
+
+def test_save_and_load_roundtrip(tmp_path: Path):
+    save_credentials(
+        "a@icloud.com",
+        username="a@icloud.com",
+        app_password="abcd-efgh-ijkl-mnop",
+        server_url=ICLOUD_CALDAV_URL,
+        config_dir=tmp_path,
+    )
+    creds = load_credentials("a@icloud.com", config_dir=tmp_path)
+    assert creds == {
+        "username": "a@icloud.com",
+        "app_password": "abcd-efgh-ijkl-mnop",
+        "server_url": ICLOUD_CALDAV_URL,
+    }
+
+
+def test_file_permissions_0600(tmp_path: Path):
+    path = save_credentials(
+        "a@icloud.com",
+        username="a@icloud.com",
+        app_password="x",
+        server_url=ICLOUD_CALDAV_URL,
+        config_dir=tmp_path,
+    )
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_load_missing_returns_none(tmp_path: Path):
+    assert load_credentials("nobody@icloud.com", config_dir=tmp_path) is None

--- a/tests/test_caldav_cli.py
+++ b/tests/test_caldav_cli.py
@@ -25,7 +25,7 @@ CALS = [
 
 class TestSrcAddApple:
     def test_apple_alias_prompts_saves_and_adds_selected(self, ts4k_config, monkeypatch):
-        monkeypatch.setattr("getpass.getpass", lambda prompt="": "abcd-efgh")
+        monkeypatch.setattr(cli, "_prompt_password", lambda prompt="": "abcd-efgh-ijkl-mnop")
         monkeypatch.setattr("builtins.input", lambda prompt="": "1")
         with patch.object(cli.commands, "cal_list_caldav_calendars",
                           new=AsyncMock(return_value=CALS)):
@@ -33,7 +33,7 @@ class TestSrcAddApple:
 
         from ts4k.auth.caldav import load_credentials
         creds = load_credentials("a@icloud.com")
-        assert creds is not None and creds["app_password"] == "abcd-efgh"
+        assert creds is not None and creds["app_password"] == "abcd-efgh-ijkl-mnop"
         assert creds["server_url"] == "https://caldav.icloud.com"
 
         cfg = sources.list_all()["cc"]
@@ -80,7 +80,7 @@ class TestLocalTimezone:
 class TestSrcAddTimezone:
     def test_picker_uses_local_timezone(self, ts4k_config, monkeypatch):
         monkeypatch.setenv("TZ", "Europe/Amsterdam")
-        monkeypatch.setattr("getpass.getpass", lambda prompt="": "abcd-efgh")
+        monkeypatch.setattr(cli, "_prompt_password", lambda prompt="": "abcd-efgh-ijkl-mnop")
         monkeypatch.setattr("builtins.input", lambda prompt="": "1")
         with patch.object(cli.commands, "cal_list_caldav_calendars",
                           new=AsyncMock(return_value=CALS)):
@@ -106,7 +106,7 @@ class TestSrcAddTimezone:
 
 class TestSrcAddUsername:
     def test_explicit_username_is_saved(self, ts4k_config, monkeypatch):
-        monkeypatch.setattr("getpass.getpass", lambda prompt="": "abcd-efgh")
+        monkeypatch.setattr(cli, "_prompt_password", lambda prompt="": "abcd-efgh-ijkl-mnop")
         monkeypatch.setattr("builtins.input", lambda prompt="": "1")
         with patch.object(cli.commands, "cal_list_caldav_calendars",
                           new=AsyncMock(return_value=CALS)):
@@ -115,3 +115,83 @@ class TestSrcAddUsername:
         from ts4k.auth.caldav import load_credentials
         creds = load_credentials("a@icloud.com")
         assert creds is not None and creds["username"] == "bob"
+
+
+class TestPromptPassword:
+    def test_off_tty_falls_back_to_getpass(self, monkeypatch):
+        monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "sentinel-value")
+        assert cli._prompt_password("Password: ") == "sentinel-value"
+
+
+class TestSrcAddPasswordFormat:
+    def test_reprompts_on_bad_format_then_accepts_valid(self, ts4k_config, monkeypatch, capsys):
+        responses = iter(["wrong-format", "abcd-efgh-ijkl-mnop"])
+        monkeypatch.setattr(cli, "_prompt_password", lambda prompt="": next(responses))
+        monkeypatch.setattr("builtins.input", lambda prompt="": "1")
+        with patch.object(cli.commands, "cal_list_caldav_calendars",
+                          new=AsyncMock(return_value=CALS)):
+            cli._cmd_sources(_args("apple", ["email=a@icloud.com"]))
+
+        from ts4k.auth.caldav import load_credentials
+        creds = load_credentials("a@icloud.com")
+        assert creds is not None and creds["app_password"] == "abcd-efgh-ijkl-mnop"
+        assert "app-specific password" in capsys.readouterr().out.lower()
+
+    def test_double_paste_regression_reprompts_then_accepts_valid(self, ts4k_config, monkeypatch):
+        double_pasted = "abcd-efgh-ijkl-mnopabcd-efgh-ijkl-mnop"[:39]
+        responses = iter([double_pasted, "abcd-efgh-ijkl-mnop"])
+        monkeypatch.setattr(cli, "_prompt_password", lambda prompt="": next(responses))
+        monkeypatch.setattr("builtins.input", lambda prompt="": "1")
+        with patch.object(cli.commands, "cal_list_caldav_calendars",
+                          new=AsyncMock(return_value=CALS)):
+            cli._cmd_sources(_args("apple", ["email=a@icloud.com"]))
+
+        from ts4k.auth.caldav import load_credentials
+        creds = load_credentials("a@icloud.com")
+        assert creds is not None and creds["app_password"] == "abcd-efgh-ijkl-mnop"
+
+    def test_whitespace_is_stripped(self, ts4k_config, monkeypatch):
+        monkeypatch.setattr(cli, "_prompt_password", lambda prompt="": " abcd-efgh-ijkl-mnop\n")
+        monkeypatch.setattr("builtins.input", lambda prompt="": "1")
+        with patch.object(cli.commands, "cal_list_caldav_calendars",
+                          new=AsyncMock(return_value=CALS)):
+            cli._cmd_sources(_args("apple", ["email=a@icloud.com"]))
+
+        from ts4k.auth.caldav import load_credentials
+        creds = load_credentials("a@icloud.com")
+        assert creds is not None and creds["app_password"] == "abcd-efgh-ijkl-mnop"
+
+    def test_three_bad_attempts_aborts(self, ts4k_config, monkeypatch, capsys):
+        monkeypatch.setattr(cli, "_prompt_password", lambda prompt="": "nope")
+        cli._cmd_sources(_args("apple", ["email=a@icloud.com"]))
+
+        from ts4k.auth.caldav import load_credentials
+        assert load_credentials("a@icloud.com") is None
+        assert "aborting" in capsys.readouterr().out.lower()
+
+
+class TestSrcAddCredentialDiscard:
+    def test_fresh_credentials_discarded_on_failed_validation(self, ts4k_config, monkeypatch, capsys):
+        monkeypatch.setattr(cli, "_prompt_password", lambda prompt="": "abcd-efgh-ijkl-mnop")
+        with patch.object(cli.commands, "cal_list_caldav_calendars",
+                          new=AsyncMock(side_effect=Exception("boom"))):
+            cli._cmd_sources(_args("apple", ["email=a@icloud.com"]))
+
+        from ts4k.auth.caldav import credentials_path
+        assert not credentials_path("a@icloud.com").exists()
+        assert "cc" not in sources.list_all()
+        assert "discarded" in capsys.readouterr().out.lower()
+
+    def test_preexisting_credentials_retained_on_failed_validation(self, ts4k_config, monkeypatch, capsys):
+        from ts4k.auth.caldav import ICLOUD_CALDAV_URL, credentials_path, save_credentials
+
+        save_credentials("a@icloud.com", username="a@icloud.com",
+                         app_password="abcd-efgh-ijkl-mnop", server_url=ICLOUD_CALDAV_URL)
+        with patch.object(cli.commands, "cal_list_caldav_calendars",
+                          new=AsyncMock(side_effect=Exception("boom"))):
+            cli._cmd_sources(_args("apple", ["email=a@icloud.com"]))
+
+        assert credentials_path("a@icloud.com").exists()
+        out = capsys.readouterr().out.lower()
+        assert "discarded" not in out

--- a/tests/test_caldav_cli.py
+++ b/tests/test_caldav_cli.py
@@ -1,0 +1,67 @@
+"""Tests for CalDAV source-add CLI flow."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import AsyncMock, patch
+
+from ts4k import cli
+from ts4k.state import sources
+
+
+def _args(provider: str, params: list[str]) -> argparse.Namespace:
+    return argparse.Namespace(
+        action="add", prefix="cc", provider=provider, params=params,
+    )
+
+
+CALS = [
+    {"id": "https://caldav.icloud.com/1/calendars/home/", "summary": "Home",
+     "access_role": "owner", "timezone": "UTC", "primary": False},
+    {"id": "https://caldav.icloud.com/1/calendars/work/", "summary": "Work",
+     "access_role": "owner", "timezone": "UTC", "primary": False},
+]
+
+
+class TestSrcAddApple:
+    def test_apple_alias_prompts_saves_and_adds_selected(self, ts4k_config, monkeypatch):
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "abcd-efgh")
+        monkeypatch.setattr("builtins.input", lambda prompt="": "1")
+        with patch.object(cli.commands, "cal_list_caldav_calendars",
+                          new=AsyncMock(return_value=CALS)):
+            cli._cmd_sources(_args("apple", ["email=a@icloud.com"]))
+
+        from ts4k.auth.caldav import load_credentials
+        creds = load_credentials("a@icloud.com")
+        assert creds is not None and creds["app_password"] == "abcd-efgh"
+        assert creds["server_url"] == "https://caldav.icloud.com"
+
+        cfg = sources.list_all()["cc"]
+        assert cfg["provider"] == "caldav"
+        assert cfg["calendar_id"] == "https://caldav.icloud.com/1/calendars/home/"
+        assert cfg["calendar_name"] == "Home"
+        assert cfg["level"] == "readonly"
+
+    def test_explicit_calendar_id_skips_picker(self, ts4k_config, monkeypatch):
+        from ts4k.auth.caldav import ICLOUD_CALDAV_URL, save_credentials
+
+        save_credentials("a@icloud.com", username="a@icloud.com",
+                         app_password="x", server_url=ICLOUD_CALDAV_URL)
+        cli._cmd_sources(_args("apple", [
+            "email=a@icloud.com",
+            "calendar_id=https://caldav.icloud.com/1/calendars/home/",
+            "calendar_name=Home",
+        ]))
+        cfg = sources.list_all()["cc"]
+        assert cfg["provider"] == "caldav"
+        assert cfg["calendar_id"] == "https://caldav.icloud.com/1/calendars/home/"
+
+    def test_missing_email_prints_usage_and_adds_nothing(self, ts4k_config, capsys):
+        cli._cmd_sources(_args("apple", []))
+        assert "email" in capsys.readouterr().out
+        assert "cc" not in sources.list_all()
+
+
+class TestSuggestPrefix:
+    def test_caldav_base_is_cc(self):
+        assert cli._suggest_cal_prefix("Home", {}, provider="caldav").startswith("cc")

--- a/tests/test_caldav_cli.py
+++ b/tests/test_caldav_cli.py
@@ -65,3 +65,53 @@ class TestSrcAddApple:
 class TestSuggestPrefix:
     def test_caldav_base_is_cc(self):
         assert cli._suggest_cal_prefix("Home", {}, provider="caldav").startswith("cc")
+
+
+class TestLocalTimezone:
+    def test_uses_tz_env_when_valid(self, monkeypatch):
+        monkeypatch.setenv("TZ", "Europe/Amsterdam")
+        assert cli._local_timezone() == "Europe/Amsterdam"
+
+    def test_falls_back_to_utc_when_tz_env_invalid(self, monkeypatch):
+        monkeypatch.setenv("TZ", "Not/AZone")
+        assert cli._local_timezone() != "Not/AZone"
+
+
+class TestSrcAddTimezone:
+    def test_picker_uses_local_timezone(self, ts4k_config, monkeypatch):
+        monkeypatch.setenv("TZ", "Europe/Amsterdam")
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "abcd-efgh")
+        monkeypatch.setattr("builtins.input", lambda prompt="": "1")
+        with patch.object(cli.commands, "cal_list_caldav_calendars",
+                          new=AsyncMock(return_value=CALS)):
+            cli._cmd_sources(_args("apple", ["email=a@icloud.com"]))
+
+        cfg = sources.list_all()["cc"]
+        assert cfg["timezone"] == "Europe/Amsterdam"
+
+    def test_explicit_calendar_id_uses_local_timezone(self, ts4k_config, monkeypatch):
+        from ts4k.auth.caldav import ICLOUD_CALDAV_URL, save_credentials
+
+        monkeypatch.setenv("TZ", "Europe/Amsterdam")
+        save_credentials("a@icloud.com", username="a@icloud.com",
+                         app_password="x", server_url=ICLOUD_CALDAV_URL)
+        cli._cmd_sources(_args("apple", [
+            "email=a@icloud.com",
+            "calendar_id=https://caldav.icloud.com/1/calendars/home/",
+            "calendar_name=Home",
+        ]))
+        cfg = sources.list_all()["cc"]
+        assert cfg["timezone"] == "Europe/Amsterdam"
+
+
+class TestSrcAddUsername:
+    def test_explicit_username_is_saved(self, ts4k_config, monkeypatch):
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "abcd-efgh")
+        monkeypatch.setattr("builtins.input", lambda prompt="": "1")
+        with patch.object(cli.commands, "cal_list_caldav_calendars",
+                          new=AsyncMock(return_value=CALS)):
+            cli._cmd_sources(_args("apple", ["email=a@icloud.com", "username=bob"]))
+
+        from ts4k.auth.caldav import load_credentials
+        creds = load_credentials("a@icloud.com")
+        assert creds is not None and creds["username"] == "bob"

--- a/tests/test_caldav_commands.py
+++ b/tests/test_caldav_commands.py
@@ -65,6 +65,39 @@ class TestCalGates:
         assert out == "Created: X (cc:1)"
 
 
+class TestCalFetchEventsIsolation:
+    async def test_one_source_failing_does_not_abort_others(self, monkeypatch):
+        # A revoked app-specific password (or any adapter connect failure)
+        # should not take down `cal today/week` for the other sources.
+        broken_cfg = dict(CALDAV_CFG)
+        ok_cfg = dict(CALDAV_CFG)
+
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all",
+            lambda: {"broken": broken_cfg, "ok": ok_cfg},
+        )
+
+        broken_adapter = MagicMock()
+        broken_adapter.__aenter__ = AsyncMock(side_effect=RuntimeError("bad app password"))
+        broken_adapter.__aexit__ = AsyncMock(return_value=None)
+
+        ok_event = {"id": "ok:1", "title": "Standup", "start": "2026-07-30T09:00:00"}
+        ok_adapter = MagicMock()
+        ok_adapter.__aenter__ = AsyncMock(return_value=ok_adapter)
+        ok_adapter.__aexit__ = AsyncMock(return_value=None)
+        ok_adapter.list_events = AsyncMock(return_value=[ok_event])
+
+        def fake_make_adapter(prefix, cfg):
+            return broken_adapter if prefix == "broken" else ok_adapter
+
+        monkeypatch.setattr(commands, "_make_adapter", fake_make_adapter)
+
+        events = await commands._cal_fetch_events(
+            None, "2026-07-30T00:00:00", "2026-07-31T00:00:00"
+        )
+        assert events == [ok_event]
+
+
 class TestTokenHealth:
     def test_caldav_with_credentials_is_ok(self, tmp_path: Path, monkeypatch):
         from ts4k.auth.caldav import ICLOUD_CALDAV_URL, save_credentials

--- a/tests/test_caldav_commands.py
+++ b/tests/test_caldav_commands.py
@@ -97,6 +97,28 @@ class TestCalFetchEventsIsolation:
         )
         assert events == [ok_event]
 
+    async def test_explicit_source_failure_raises(self, monkeypatch):
+        # When the caller explicitly asked for one source (-s cc) and it
+        # fails, silently returning no events is misleading — surface the
+        # failure instead of swallowing it.
+        broken_cfg = dict(CALDAV_CFG)
+
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all",
+            lambda: {"cc": broken_cfg},
+        )
+
+        broken_adapter = MagicMock()
+        broken_adapter.__aenter__ = AsyncMock(side_effect=RuntimeError("bad app password"))
+        broken_adapter.__aexit__ = AsyncMock(return_value=None)
+
+        monkeypatch.setattr(commands, "_make_adapter", lambda p, c: broken_adapter)
+
+        with pytest.raises(RuntimeError, match="cc"):
+            await commands._cal_fetch_events(
+                "cc", "2026-07-30T00:00:00", "2026-07-31T00:00:00"
+            )
+
 
 class TestTokenHealth:
     def test_caldav_with_credentials_is_ok(self, tmp_path: Path, monkeypatch):

--- a/tests/test_caldav_commands.py
+++ b/tests/test_caldav_commands.py
@@ -1,0 +1,81 @@
+"""Tests for CalDAV provider registration in commands.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ts4k import commands
+from ts4k.adapters.caldav_cal import CaldavAdapter
+
+CALDAV_CFG = {
+    "provider": "caldav",
+    "email": "a@icloud.com",
+    "server_url": "https://caldav.icloud.com",
+    "calendar_id": "https://caldav.icloud.com/123/calendars/home/",
+    "calendar_name": "Home",
+    "timezone": "UTC",
+    "level": "modify",
+}
+
+
+class TestMakeAdapter:
+    def test_builds_caldav_adapter(self):
+        a = commands._make_adapter("cc", dict(CALDAV_CFG))
+        assert isinstance(a, CaldavAdapter)
+        assert a.source_prefix == "cc"
+
+    def test_missing_email_returns_none(self):
+        cfg = dict(CALDAV_CFG)
+        del cfg["email"]
+        assert commands._make_adapter("cc", cfg) is None
+
+    def test_missing_calendar_id_returns_none(self):
+        cfg = dict(CALDAV_CFG)
+        del cfg["calendar_id"]
+        assert commands._make_adapter("cc", cfg) is None
+
+
+class TestResolvePrefixes:
+    def test_apple_alias_resolves_to_caldav_sources(self, monkeypatch):
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"cc": dict(CALDAV_CFG)}
+        )
+        assert commands._resolve_prefixes("apple") == ["cc"]
+        assert commands._resolve_prefixes("icloud") == ["cc"]
+        assert commands._resolve_prefixes("caldav") == ["cc"]
+
+
+class TestCalGates:
+    async def test_cal_create_accepts_caldav_source(self, monkeypatch):
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"cc": dict(CALDAV_CFG)}
+        )
+        fake = MagicMock()
+        fake.__aenter__ = AsyncMock(return_value=fake)
+        fake.__aexit__ = AsyncMock(return_value=None)
+        fake.create_event = AsyncMock(return_value={"title": "X", "id": "cc:1"})
+        monkeypatch.setattr(commands, "_make_adapter", lambda p, c: fake)
+        out = await commands.cal_create(
+            "cc", "X", "2026-07-30T10:00:00", "2026-07-30T11:00:00",
+            None, None, None,
+        )
+        assert out == "Created: X (cc:1)"
+
+
+class TestTokenHealth:
+    def test_caldav_with_credentials_is_ok(self, tmp_path: Path, monkeypatch):
+        from ts4k.auth.caldav import ICLOUD_CALDAV_URL, save_credentials
+
+        monkeypatch.setenv("TS4K_CONFIG_DIR", str(tmp_path))
+        save_credentials("a@icloud.com", username="a@icloud.com",
+                         app_password="x", server_url=ICLOUD_CALDAV_URL)
+        th = commands.check_token_health("cc", dict(CALDAV_CFG))
+        assert th.status == "ok"
+
+    def test_caldav_without_credentials_is_na(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("TS4K_CONFIG_DIR", str(tmp_path))
+        th = commands.check_token_health("cc", dict(CALDAV_CFG))
+        assert th.status == "na"

--- a/tests/test_caldav_write.py
+++ b/tests/test_caldav_write.py
@@ -1,0 +1,114 @@
+"""Tests for CalDAV create/update/level gating."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from icalendar import Calendar as IcsCalendar
+
+from ts4k.adapters.caldav_cal import CaldavAdapter, CaldavAdapterConfig
+from ts4k.auth.caldav import ICLOUD_CALDAV_URL, save_credentials
+
+
+def _adapter(tmp_path: Path, level: str) -> CaldavAdapter:
+    save_credentials("test@icloud.com", username="test@icloud.com",
+                     app_password="x", server_url=ICLOUD_CALDAV_URL,
+                     config_dir=tmp_path)
+    config = CaldavAdapterConfig(
+        email="test@icloud.com", server_url=ICLOUD_CALDAV_URL,
+        calendar_id="https://caldav.icloud.com/123/calendars/home/",
+        timezone="Europe/Amsterdam", config_dir=tmp_path, level=level,
+    )
+    a = CaldavAdapter(config, prefix="cc")
+    a._principal = MagicMock()
+    a._calendar = MagicMock()
+    return a
+
+
+def _echo_save_event(ics: str) -> MagicMock:
+    """Fake caldav save_event: parse the ICS we were given and echo it back."""
+    obj = MagicMock()
+    obj.icalendar_component = IcsCalendar.from_ical(ics).walk("VEVENT")[0]
+    return obj
+
+
+class TestLevelGating:
+    async def test_readonly_blocks_create(self, tmp_path: Path):
+        a = _adapter(tmp_path, "readonly")
+        with pytest.raises(PermissionError):
+            await a.create_event("X", "2026-07-30T10:00:00", "2026-07-30T11:00:00")
+
+    async def test_readonly_blocks_update(self, tmp_path: Path):
+        a = _adapter(tmp_path, "readonly")
+        with pytest.raises(PermissionError):
+            await a.update_event("cc:uid1", title="Y")
+
+    async def test_readonly_blocks_rsvp(self, tmp_path: Path):
+        a = _adapter(tmp_path, "readonly")
+        with pytest.raises(PermissionError):
+            await a.rsvp("cc:uid1", "accepted")
+
+
+class TestCreateEvent:
+    async def test_timed_event(self, tmp_path: Path):
+        a = _adapter(tmp_path, "draft")  # create_event with no attendees requires DRAFT
+        a._calendar.save_event.side_effect = _echo_save_event
+        e = await a.create_event(
+            "Dinner", "2026-07-30T19:00:00", "2026-07-30T21:00:00",
+            description="Birthday", location="Cafe",
+        )
+        assert e["title"] == "Dinner"
+        assert e["start"] == "2026-07-30T19:00:00+02:00"
+        assert e["duration_minutes"] == 120
+        sent_ics = a._calendar.save_event.call_args.args[0]
+        assert "SUMMARY:Dinner" in sent_ics
+        assert "DESCRIPTION:Birthday" in sent_ics
+        assert "UID:" in sent_ics
+
+    async def test_all_day_inclusive_end_becomes_exclusive(self, tmp_path: Path):
+        a = _adapter(tmp_path, "draft")  # create_event with no attendees requires DRAFT
+        a._calendar.save_event.side_effect = _echo_save_event
+        e = await a.create_event("Trip", "2026-08-01", "2026-08-03")
+        assert e["all_day"] is True
+        assert e["start"] == "2026-08-01"
+        assert e["end"] == "2026-08-04"  # exclusive, mirrors gcal convention
+
+    async def test_attendees_require_send_level(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")  # modify < send
+        with pytest.raises(PermissionError):
+            await a.create_event("X", "2026-07-30T10:00:00", "2026-07-30T11:00:00",
+                                 attendees=["a@example.com"])
+
+    async def test_attendees_allowed_at_send_level(self, tmp_path: Path):
+        # Requires "caldav" in the SEND calendar-provider allowlist (levels.py:46);
+        # without it check_level raises NotImplementedError regardless of level.
+        a = _adapter(tmp_path, "send")
+        a._calendar.save_event.side_effect = _echo_save_event
+        e = await a.create_event("X", "2026-07-30T10:00:00", "2026-07-30T11:00:00",
+                                 attendees=["a@example.com"])
+        assert e["attendees_summary"] == "1 people"
+
+
+class TestUpdateEvent:
+    async def test_update_title_and_start(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        ics = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:up1
+SUMMARY:Old
+DTSTART;TZID=Europe/Amsterdam:20260730T100000
+DTEND;TZID=Europe/Amsterdam:20260730T110000
+END:VEVENT
+END:VCALENDAR
+"""
+        obj = MagicMock()
+        obj.icalendar_component = IcsCalendar.from_ical(ics).walk("VEVENT")[0]
+        a._calendar.event_by_uid.return_value = obj
+        e = await a.update_event("cc:up1", title="New", start="2026-07-30T12:00:00")
+        obj.save.assert_called_once()
+        assert e["title"] == "New"
+        assert e["start"] == "2026-07-30T12:00:00+02:00"

--- a/tests/test_caldav_write.py
+++ b/tests/test_caldav_write.py
@@ -112,3 +112,76 @@ END:VCALENDAR
         obj.save.assert_called_once()
         assert e["title"] == "New"
         assert e["start"] == "2026-07-30T12:00:00+02:00"
+
+
+INVITE_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:inv1
+SUMMARY:Party
+DTSTART;TZID=Europe/Amsterdam:20260730T190000
+DTEND;TZID=Europe/Amsterdam:20260730T230000
+ORGANIZER:mailto:org@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:test@icloud.com
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:other@example.com
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+def _invite_obj():
+    obj = MagicMock(spec=["icalendar_component", "save"])  # no accept_invite → manual path
+    obj.icalendar_component = IcsCalendar.from_ical(INVITE_ICS).walk("VEVENT")[0]
+    return obj
+
+
+class TestRsvp:
+    async def test_manual_partstat_path(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        obj = _invite_obj()
+        a._calendar.event_by_uid.return_value = obj
+        e = await a.rsvp("cc:inv1", "accepted")
+        obj.save.assert_called_once()
+        assert e["your_status"] == "accepted"
+
+    async def test_invite_helper_preferred_when_available(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        obj = MagicMock()  # has accept_invite (MagicMock auto-attrs)
+        obj.icalendar_component = IcsCalendar.from_ical(INVITE_ICS).walk("VEVENT")[0]
+        a._calendar.event_by_uid.return_value = obj
+        await a.rsvp("cc:inv1", "accepted")
+        obj.accept_invite.assert_called_once()
+        obj.save.assert_not_called()
+
+    async def test_invite_helper_failure_falls_back_to_manual(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        obj = MagicMock()
+        obj.icalendar_component = IcsCalendar.from_ical(INVITE_ICS).walk("VEVENT")[0]
+        obj.accept_invite.side_effect = Exception("scheduling not supported")
+        a._calendar.event_by_uid.return_value = obj
+        e = await a.rsvp("cc:inv1", "accepted")
+        obj.save.assert_called_once()
+        assert e["your_status"] == "accepted"
+
+    async def test_server_rejection_raises_actionable_runtimeerror(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        obj = _invite_obj()
+        obj.save.side_effect = Exception("403 Forbidden")
+        a._calendar.event_by_uid.return_value = obj
+        with pytest.raises(RuntimeError, match="Calendar app"):
+            await a.rsvp("cc:inv1", "accepted")
+
+    async def test_not_an_attendee_raises_valueerror(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        ics = INVITE_ICS.replace("mailto:test@icloud.com", "mailto:someoneelse@x.com")
+        obj = MagicMock(spec=["icalendar_component", "save"])
+        obj.icalendar_component = IcsCalendar.from_ical(ics).walk("VEVENT")[0]
+        a._calendar.event_by_uid.return_value = obj
+        with pytest.raises(ValueError, match="not an attendee"):
+            await a.rsvp("cc:inv1", "accepted")
+
+    async def test_bad_status_raises_valueerror(self, tmp_path: Path):
+        a = _adapter(tmp_path, "modify")
+        with pytest.raises(ValueError, match="status"):
+            await a.rsvp("cc:inv1", "maybe")

--- a/tests/test_caldav_write.py
+++ b/tests/test_caldav_write.py
@@ -88,7 +88,40 @@ class TestCreateEvent:
         a._calendar.save_event.side_effect = _echo_save_event
         e = await a.create_event("X", "2026-07-30T10:00:00", "2026-07-30T11:00:00",
                                  attendees=["a@example.com"])
-        assert e["attendees_summary"] == "1 people"
+        # Organizer is now added as a self-attendee alongside the invitee.
+        assert e["attendees_summary"] == "2 people"
+
+    async def test_organizer_added_when_attendees_present(self, tmp_path: Path):
+        # RFC 6638 scheduling requires ORGANIZER on invite-bearing events, or
+        # iCloud stores attendees inertly and never sends invites.
+        a = _adapter(tmp_path, "send")
+        a._calendar.save_event.side_effect = _echo_save_event
+        await a.create_event("X", "2026-07-30T10:00:00", "2026-07-30T11:00:00",
+                             attendees=["a@example.com"])
+        sent_ics = a._calendar.save_event.call_args.args[0]
+        assert "ORGANIZER" in sent_ics
+        assert "mailto:test@icloud.com" in sent_ics
+        parsed = IcsCalendar.from_ical(sent_ics).walk("VEVENT")[0]
+        organizer = parsed.get("ORGANIZER")
+        assert organizer is not None
+        assert str(organizer).lower().endswith("test@icloud.com")
+        attendees = parsed.get("ATTENDEE")
+        if not isinstance(attendees, list):
+            attendees = [attendees]
+        organizer_attendee = next(
+            (att for att in attendees if str(att).lower().endswith("test@icloud.com")),
+            None,
+        )
+        assert organizer_attendee is not None
+        assert str(organizer_attendee.params.get("ROLE")) == "CHAIR"
+        assert str(organizer_attendee.params.get("PARTSTAT")) == "ACCEPTED"
+
+    async def test_no_organizer_when_no_attendees(self, tmp_path: Path):
+        a = _adapter(tmp_path, "draft")
+        a._calendar.save_event.side_effect = _echo_save_event
+        await a.create_event("X", "2026-07-30T10:00:00", "2026-07-30T11:00:00")
+        sent_ics = a._calendar.save_event.call_args.args[0]
+        assert "ORGANIZER" not in sent_ics
 
 
 class TestUpdateEvent:

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,1570 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.120.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/10/4ca013cb166f226bd89e0aeb0fcaff94f45ddf716d4925ce89475d3c587b/anthropic-0.120.2.tar.gz", hash = "sha256:9722efc10c27a30a69f5338ddacdb35bc6a64297a4e4ba729bf83af873d5fb3a", size = 1008421, upload-time = "2026-07-28T17:38:26.986Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/af/0f5db57b9397a0f3b7fc204cbef143401a7cadaf982330f97f1ce3d39f34/anthropic-0.120.2-py3-none-any.whl", hash = "sha256:0f0bc2b381dc0eb41c8d886b815d79c2041cd2374f83aed36f574b6dc9c579c1", size = 1022851, upload-time = "2026-07-28T17:38:25.466Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "caldav"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "icalendar" },
+    { name = "icalendar-searcher" },
+    { name = "lxml" },
+    { name = "niquests" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "recurring-ical-events" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/20/fd2054d0fe08b2641b5e501fdc1b7d7f989960ce7c2e4ec5a0fad4f8a82b/caldav-3.2.1.tar.gz", hash = "sha256:b474900130226f22dbe3e3abed34559faaeed8a29c455af920c2afb0e355e3d3", size = 10681945, upload-time = "2026-05-28T15:22:26.059Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/39/970a6699f06487088d8a936ae67e7197d98d11dd778b13b3a1261eac7331/caldav-3.2.1-py3-none-any.whl", hash = "sha256:6869e505ad14741a582003c93e49be2689013d19c9b91679c7c385775b673408", size = 215892, upload-time = "2026-05-28T15:22:20.539Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/85/990925db5df586ec90beb97529c853497e7f85ba0234830447faf41c3057/cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f", size = 184829, upload-time = "2026-07-06T21:32:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/92/e7bb136ad6b5352603732cf907ef862ca103f20f2031c1735a46300c20c9/cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde", size = 184728, upload-time = "2026-07-06T21:32:45.683Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815, upload-time = "2026-07-06T21:32:48.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429, upload-time = "2026-07-06T21:32:49.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b", size = 210315, upload-time = "2026-07-06T21:32:51.221Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7", size = 208859, upload-time = "2026-07-06T21:32:52.512Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844, upload-time = "2026-07-06T21:32:53.704Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287, upload-time = "2026-07-06T21:32:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681, upload-time = "2026-07-06T21:32:56.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/c138990aa2a70b1a269f6e06348729836d733d6f970867943f61d367f8cc/cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a", size = 175269, upload-time = "2026-07-06T21:32:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/eb/f636456ff21a83fc13c032b58cc5dde061691546ac79efa284b2989b7982/cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384", size = 185881, upload-time = "2026-07-06T21:32:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/400ea43e721727dca8a65c4521390e9196757caba4a45643acb2b63271b8/cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6", size = 180088, upload-time = "2026-07-06T21:33:02.278Z" },
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/62/8fb1fb647d2788c950d69d6a769cd9d55c918ac1fc57be2f90b7e4029787/google_api_core-2.33.0.tar.gz", hash = "sha256:3a36bcc3e319783f4c97da41f6f45ea6ffcaa55848e341de16e09cb70243c2bb", size = 181607, upload-time = "2026-07-22T16:28:28.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/31/5056a347bb934ea04583c8b27916ef1501729c72638629545bce26ff4223/google_api_core-2.33.0-py3-none-any.whl", hash = "sha256:a2e22a0c1d0f03eafff1858b38cf46f832d5902b0c052235bf0ab8402929fbdc", size = 176462, upload-time = "2026-07-22T16:28:22.447Z" },
+]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/53/0cd38e3a29d72ce45e27feba2ce1cd8049d69af9c48cb14fb164f1be9133/google_api_python_client-2.198.0.tar.gz", hash = "sha256:dfe3e16fb241af6e9c460a33f65085b3450e05cea09364f6b5d8997fb7e43e2a", size = 15060142, upload-time = "2026-06-25T14:32:42.953Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/92/0fc9e7a09eb240c31b879bd8d2e43f81ed1f86c4798b79ead4a083921ab3/google_api_python_client-2.198.0-py3-none-any.whl", hash = "sha256:fabac935474e817da5e662ff61bf7139439d6f92b32d332a7318a2d45931e03e", size = 15644203, upload-time = "2026-06-25T14:32:39.963Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.56.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/33/dbc946a407401b975f0719658f18e664ece2109f79ffd1ff3bf226c205f4/google_auth-2.56.2.tar.gz", hash = "sha256:e28f103ca8091fb7012b99c44243d7366c29863713b8e34a220c3322b7a07051", size = 365820, upload-time = "2026-07-21T21:53:28.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/63/50636aae68c9bf17c891c7eb18b49baa9bd6b31d2a97b8de4813a9fc8d1c/google_auth-2.56.2-py3-none-any.whl", hash = "sha256:c8270ea95b2697b74e3d8438ae9c5b898e38b623b915c7b5c5635921e7de68a6", size = 258588, upload-time = "2026-07-21T21:53:26.399Z" },
+]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b3/f192c8bc7e41e0ebdbd95afcae4783417a34b6a6af62d22daf22c3fd38fc/google_auth_httplib2-0.4.0.tar.gz", hash = "sha256:d5b030a204b7a4b4d553ba9ca701b62481ee2b74419325580be70f7d85ffed35", size = 11161, upload-time = "2026-05-07T08:03:46.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/be/954c35a62b9e31de66b0a43c225c9b6bb9e0f98d6b1dc110a2308e3644f5/google_auth_httplib2-0.4.0-py3-none-any.whl", hash = "sha256:8e55cfafa3358cba85f6cad4a886138e88e158d71e7e5c9ee5936a5c1507fb91", size = 9529, upload-time = "2026-05-07T08:02:12.375Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/18/90c7fac516e63cf2058166fce0c88c353647c677b51cc036c09c49bb5cbb/google_auth_oauthlib-1.4.0.tar.gz", hash = "sha256:18b5e28880eb8eba9065c436becdc0ee8e4b59117a73a510679c82f70cd363d2", size = 21675, upload-time = "2026-05-07T08:03:47.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/d3/d7dff0d58a9e9244b48044bfb6a898bfcc8ecc42e0031d1bebc695344725/google_auth_oauthlib-1.4.0-py3-none-any.whl", hash = "sha256:251314f213a9ee46a5ae73988e84fd7cca8bb68e7ecf4bfd45940f9e7f51d070", size = 19261, upload-time = "2026-05-07T08:02:13.798Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "html2text"
+version = "2025.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/27/e158d86ba1e82967cc2f790b0cb02030d4a8bef58e0c79a8590e9678107f/html2text-2025.4.15.tar.gz", hash = "sha256:948a645f8f0bc3abe7fd587019a2197a12436cd73d0d4908af95bfc8da337588", size = 64316, upload-time = "2025-04-15T04:02:30.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl", hash = "sha256:00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc", size = 34656, upload-time = "2025-04-15T04:02:28.44Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/f5/ccf58de92d61e3ad921119668f54ed36ca1d0cf5dcc5c1657dfb164fd78b/httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025", size = 254283, upload-time = "2026-06-26T10:13:56.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/a0/550eec327e5f5c7b732531c489f5307efec41f047b0d703bd4ca1e5ad2db/httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816", size = 93148, upload-time = "2026-06-26T10:13:54.985Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "icalendar"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/37/4c43e9534a4d43f8cde8f0fd7f869628b45f63f27c5b040230c8f1d90b3d/icalendar-7.2.2.tar.gz", hash = "sha256:6cf904a928881e20c89b682e75bca2eb97e8c5ca629782ed44a519abf4cac1cc", size = 491618, upload-time = "2026-07-20T12:04:05.173Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/fd/8cbebc368afc020c979e5f9433348531215c65df93b0d6d6f1a1b13a39eb/icalendar-7.2.2-py3-none-any.whl", hash = "sha256:90dd280cb4f67d1ef07b5178c2c33db4fc0a05627e50a3758b6b2aa9b117bc07", size = 502831, upload-time = "2026-07-20T12:04:03.796Z" },
+]
+
+[[package]]
+name = "icalendar-searcher"
+version = "1.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "icalendar" },
+    { name = "recurring-ical-events" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/65/255f6eb7589c3c98d1d739076c961d60ce70bbb55f7f406589f0245ddc6a/icalendar_searcher-1.0.6.tar.gz", hash = "sha256:2440d4d0d9fbe0021a6647916853744dbca179abd39d25c742ebb8442bbc1bc3", size = 71418, upload-time = "2026-05-29T07:53:29.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/34/2248bb70ca2b4affa2e80623d3bae38a51b435254c3ce17dcff883a44a00/icalendar_searcher-1.0.6-py3-none-any.whl", hash = "sha256:649aad558df211bc50ca3dea3646e1b2f3e93f0995bca2b6358e9c79031471b6", size = 38251, upload-time = "2026-05-29T07:53:28.659Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jh2"
+version = "5.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/b1/b2b7389b2e0ddac90a1aecbf4a761db8790de85dace7695c01173ed083cc/jh2-5.0.13.tar.gz", hash = "sha256:f8c78cffb3a35c4410513c3eb7989de36028c84277c04f07c97909dd94c23a75", size = 7322505, upload-time = "2026-05-29T05:21:43.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/96/c38d3555cc9bbb1c309c896e99dbb0b1f76308bed7f2d6226cdbeaeb3eee/jh2-5.0.13-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2195557f5953ceee743d0eaab0b09ec537bbc1b9a2c6c1463106bfca9b03805f", size = 601454, upload-time = "2026-05-29T05:19:23.763Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/84/a3043ddaf636cec0f4c3aa179a9ef3a59db3d06f770ab6007133ca31bc5f/jh2-5.0.13-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e734f8a5cf002316cc81b80d8a91a0f7c62d631270abd913746644fb9ae288d", size = 384187, upload-time = "2026-05-29T05:19:25.504Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/8b/72dba3fb64bf01355a0bbd78cbe0a2635759d4a6f273c1b118760ca8ecf0/jh2-5.0.13-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ba5e545b3209e8aa5b6af88e7032814473e57d60d32d3fc6b6185453733a4b26", size = 389346, upload-time = "2026-05-29T05:19:26.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/2e/6f07e42de6101d4555f14be1e4f42a056c9a44d7ee8f745b3c188c96cbe0/jh2-5.0.13-cp313-cp313t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:2a37164eb8f2462268e6252db93b009cb685fa060b62ad217bf1b333b450c68d", size = 510278, upload-time = "2026-05-29T05:19:28.175Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a5/85682dcc959682aede0f80206a16574c51af51ed26eb1e87252fd31c6ded/jh2-5.0.13-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b4eae2d5bc1a91033450fd4381c04f33db7d4c9cfd31046c4708c8c1323c06d0", size = 503090, upload-time = "2026-05-29T05:19:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4c/a8a301d494c0a1c2859951d44b4fa54f3b2db91826c719ce5be8b662c5c8/jh2-5.0.13-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40d0a10036cdf8bf1a36b07c10b69ad0d08ce31d99b8962e3d055ee417fe3423", size = 402843, upload-time = "2026-05-29T05:19:30.505Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5f/5f9e0933f458a89005af3b2aa7d1c61cc3cc57c8a633fd54a95acff85121/jh2-5.0.13-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ad4d68340e38a8474a48c424e2929d3e2e82e35e4e8ff1188decb1985d1b4d7", size = 386327, upload-time = "2026-05-29T05:19:31.988Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3d/353ec4a6763e8b6be8d162e6b23f7e1499e75b1bb934cee1e5b5fc062f1e/jh2-5.0.13-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3f8c5e81254b986f8abe9fd974e7ed595aeaead3f3066ce9ed95dfff236ceca9", size = 406978, upload-time = "2026-05-29T05:19:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/e5/cca58b58cb8bab1891f45da43ef91b498ff93d573a1a2836af11962ccfb8/jh2-5.0.13-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:da030729eb8ef386569e78c10e2429adb10026ce82989fdeb906b037314d66c7", size = 560030, upload-time = "2026-05-29T05:19:34.879Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/c9/c3391d8607781016daa1881d8d80f81e0cf0302ff06c86342c492279cf48/jh2-5.0.13-cp313-cp313t-musllinux_1_1_armv7l.whl", hash = "sha256:a5d2ceb2e9d42ac236f0da7b2f9e8237818d32a10d892b06f30f7160ee4365ae", size = 664407, upload-time = "2026-05-29T05:19:36.138Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/b4/3375744e2f33d097da241dfd5262c9997a87c2b948db2385fbf100c7dd12/jh2-5.0.13-cp313-cp313t-musllinux_1_1_i686.whl", hash = "sha256:1f4dffe1c6ed0d4b0d2d9a45d064622bb786cbf87db35eac469dd4c376ac6fb6", size = 625242, upload-time = "2026-05-29T05:19:37.93Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2f/e33763b1f66817bd8c848777f05cf3781ad9ee1c642741458bfb66da1921/jh2-5.0.13-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:bdeb48657db508e8bc299744aa431798efdf090feb3959cf0123167c9251ebb0", size = 591124, upload-time = "2026-05-29T05:19:39.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/92/5a8de2f6936c7af77555299732795f4607d2cefb974ad485acf25b3f998b/jh2-5.0.13-cp313-cp313t-win32.whl", hash = "sha256:b41867d5decd7cd62e12cdacfc45c5d8f6eae872578ae01d78900174d5e47b82", size = 238101, upload-time = "2026-05-29T05:19:40.917Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/71/0f7ba74bb6681e60e871284772a216a50cfd63f4f62ef52edd13d8a7c057/jh2-5.0.13-cp313-cp313t-win_amd64.whl", hash = "sha256:62aee4bd128e17871980e4847cc4b94b67651de612bc96dd3d7ebf647c68a6e4", size = 245923, upload-time = "2026-05-29T05:19:42.338Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/dc/11434a6deee70630f5f38cc40813692e1faadd4259f242f4f810f35709eb/jh2-5.0.13-cp313-cp313t-win_arm64.whl", hash = "sha256:267aaa7a96f54452e1e07c7701799bc7817e1f3bb2de09301b2c492841e4c98e", size = 242596, upload-time = "2026-05-29T05:19:43.853Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f8/e9e82b7b51947edbf762edb26eb9bcfadda10fc7526d092244528e9cea8c/jh2-5.0.13-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:1dd137086b13d55a53c4b7b8b75869c824060a4d35615e4f49180ae58c7783f5", size = 601736, upload-time = "2026-05-29T05:19:45.14Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/e82b4c5797c20facb2f1b54f893a422f8ba44f83bc66da3d60d90a1c3064/jh2-5.0.13-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75d0b2bffb2e260a0f3578a11a4999a713c94d1bd8de7cfe692c840e20ae83cf", size = 383983, upload-time = "2026-05-29T05:19:46.687Z" },
+    { url = "https://files.pythonhosted.org/packages/27/df/f439704e7a884b5bd0181188b30217d71d48ce6bb9a9d7e8378d00ed3497/jh2-5.0.13-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f681e197bf6552df3bb7a3abfd676e81316b69e36e7263e72383477174032ca2", size = 389233, upload-time = "2026-05-29T05:19:47.973Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9e/c2cbdb2261724edb83fa0bdb260f75ad9b091189ada1651608f8ade71906/jh2-5.0.13-cp314-cp314t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:bde7e7ff0f17e87aca9ef23f66b80540a2de0ff8e2c26af55eb2e288a2a5f74f", size = 510268, upload-time = "2026-05-29T05:19:49.183Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/cf/65925f2aaea92e5f4a90a578b86a975bf6327ad53d82035a4d94f8f63580/jh2-5.0.13-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6f8d364d53cc0854d910f2305726a8254acb527f13fa933dc213a591e21e7ffa", size = 503003, upload-time = "2026-05-29T05:19:50.699Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fc/684ae4efe7568ec9f8ce427b6ecdc7387f870b3bbdcee75c370326685865/jh2-5.0.13-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b572daaafbd867bb5c5f324c918704ddd6d76af1cc7c2be483c3649b76ce7940", size = 402856, upload-time = "2026-05-29T05:19:52.004Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/41/009c8b95f471ca83667e63e87a845f634f7b100f9fa2c1cbfc090c142ec9/jh2-5.0.13-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0772ad66f346038fe05cb2928866ff1b21bcaa9ec3f14709fa1d419ed1dc287", size = 386592, upload-time = "2026-05-29T05:19:53.201Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8b/5b49f66cadc6d89db5339b602c06a9567ef493c33b860324f24a96b390a4/jh2-5.0.13-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b1d8313b13acfdef19c5ff793fdf397bae3d8d75181f6eee62604f13e4ec20a8", size = 406930, upload-time = "2026-05-29T05:19:54.441Z" },
+    { url = "https://files.pythonhosted.org/packages/55/a4/7b997c7787ee6316c6b4f7bc0ff4d80c062ef3288038fbee870ed83f0946/jh2-5.0.13-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:99aedd20daacb32f377152c9103d8d0271f32d1932bd39a5ed2cd2eef97f7e07", size = 559781, upload-time = "2026-05-29T05:19:55.659Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/08/b75afc38215f961ba8d92af64a9e7cba57767829786484c5cb98fc1a1d2f/jh2-5.0.13-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:53b1df29ffe966cde1d2f0085b6acfcd237504627d406a51717ef3849ec88831", size = 664237, upload-time = "2026-05-29T05:19:57.031Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/92/0fad513d95376611b337c631abd0263e641b78b0adbe80f3cf561e614d6e/jh2-5.0.13-cp314-cp314t-musllinux_1_1_i686.whl", hash = "sha256:0ee6a5dd24a1dc0772a89b3498ed20f60167fbc633404b1e02895f04ae66c47c", size = 625249, upload-time = "2026-05-29T05:19:58.447Z" },
+    { url = "https://files.pythonhosted.org/packages/79/28/4f70df7bfaf1cdb560340400b46849cfa96e4b08d2430793501013d7ee8a/jh2-5.0.13-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:521f871864880cabe361060f070516a56a54abc3e96f07bee9ba8b061eada891", size = 591017, upload-time = "2026-05-29T05:19:59.839Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/58/ed891762aa68542fa7969c4cbb109817231740f342931165f60ea7a2a923/jh2-5.0.13-cp314-cp314t-win32.whl", hash = "sha256:5909e2273f8b6fcea93c95564aa0f366ff9261a544a7a5d640ea95341321cc37", size = 238041, upload-time = "2026-05-29T05:20:01.228Z" },
+    { url = "https://files.pythonhosted.org/packages/48/13/46ae2bf16baad7841526dba44668083f9de3e427027e4fa44a567cb778d6/jh2-5.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:2cc4923ac6f57753e0cb4aef054a04f5d5c744b274dabf863f695fa3c2fd75f9", size = 245861, upload-time = "2026-05-29T05:20:02.757Z" },
+    { url = "https://files.pythonhosted.org/packages/79/49/3652903fc82c0e5c82e9caa3445e3e514b168969c2dae3da15c46627661f/jh2-5.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:d3cf203de31371289d4c1e6b4d30c9f6de95b2bd2b300fe5468ff946299d0e48", size = 242699, upload-time = "2026-05-29T05:20:03.9Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f3/8c151f371f7962902e6f1f494b50abc1b8be27305a9d12cb88cf049c5a80/jh2-5.0.13-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3f54095cde010ff4e52f23dda92b31d3d3160c64f5f23fc6e181f8c7938afd33", size = 618581, upload-time = "2026-05-29T05:20:05.043Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3f/a2d5458586c024e0076ae8182dcbb71450bd9d4dd65ffdaa659313461bd4/jh2-5.0.13-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f810dd02b4a9647eacbe4eab617111c0e3ffc68e923e3ff172948db601d2ba1e", size = 392776, upload-time = "2026-05-29T05:20:06.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/1f/cf205104cfcef4bd26aa2b736f36ddf3739b69ddaf14d23a5f7697673d74/jh2-5.0.13-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29c23f3937f257beb5cd5b17f8727404f1267ff25d26e54c0a35d5defd0c895e", size = 397943, upload-time = "2026-05-29T05:20:07.479Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/82/bd218132e5a081293cf3d7de5cf41d871f3f88808c23f6c6aebbe073fb5e/jh2-5.0.13-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c697b250a935030a128b45b41f507a4d33a082d8b8e12311c7e73fbb3970f057", size = 520351, upload-time = "2026-05-29T05:20:08.936Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/78b564899237909ddf4103569be59ea31b6c00f8b4f1c178cc57c6e4e45d/jh2-5.0.13-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:47d3203ed6fec39df4922764817979fad3a13d22cf750adc9cf9dc2b3399eacf", size = 511162, upload-time = "2026-05-29T05:20:10.239Z" },
+    { url = "https://files.pythonhosted.org/packages/db/3a/b59157363139436cb60620353aa8b687197c9a4ec1eb87952004a8843e6e/jh2-5.0.13-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a5146468a76bbe8f4035f23a78813c5c433c70c0ca44eb0ba5558627a9e644b8", size = 411838, upload-time = "2026-05-29T05:20:11.515Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a4/18b35000b00d9fb72003e0eacf66b3af828a0bb897c21a287a33d2025138/jh2-5.0.13-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85d3d338284fbfbe173243c3cc62e510c6fa0d6d023e67da2292bd7578c734e3", size = 395975, upload-time = "2026-05-29T05:20:13.157Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/42/f017b6b7b666e6ef615f7c64fd748201d0b20edeed094182c4f37f23a6e8/jh2-5.0.13-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:641f65f5414b8990251bd7609513a696831558f69d2ca77d65dc3f7087f31267", size = 417493, upload-time = "2026-05-29T05:20:14.394Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/fc/054443bd40a9827ade99508482185692530cf56a50d4ad8ed2aba761f11d/jh2-5.0.13-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:cf3dc6f7c14340241260bf63e5d6006b2ee7db45dafcb39c16fdf164ea0240a0", size = 568373, upload-time = "2026-05-29T05:20:15.914Z" },
+    { url = "https://files.pythonhosted.org/packages/47/48/dde093626bb976722c940053ceaa82407bd358e07fa6a1690590456d21b5/jh2-5.0.13-cp37-abi3-musllinux_1_1_armv7l.whl", hash = "sha256:fb8e37ecf37382c02af83da521df5a77561441bc4cbb93b00627e015b7bbf349", size = 673766, upload-time = "2026-05-29T05:20:17.136Z" },
+    { url = "https://files.pythonhosted.org/packages/96/94/edae999301bb28738e17cf54ecd50b7d7d9fd96d9536376bbeb9b8498526/jh2-5.0.13-cp37-abi3-musllinux_1_1_i686.whl", hash = "sha256:296ee44dfad08ccc3857daf433dfa4a555d5b45f2df39503ccdd90ff10b32943", size = 635045, upload-time = "2026-05-29T05:20:18.633Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/5b/d9fd0fc71e43c37c30d581affbb7371fa8177ce211b663457939bbed9e61/jh2-5.0.13-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:1a75eed545420a31ea356e8046b8d86fcf694234dd1035191734a03720fb8a44", size = 599870, upload-time = "2026-05-29T05:20:20.117Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ec/66c17d8aec77d41c8f93145dd7faa7138b9f1bc370fa685008bf92d75f9f/jh2-5.0.13-cp37-abi3-win32.whl", hash = "sha256:4812710810010c428db04e9290a13117f7b7c5a3a663b46a0586fe101cf25c9d", size = 245231, upload-time = "2026-05-29T05:20:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/107f16a84c8becef5281040fdb50681f06e4615bb4a754f211abe7d61a6f/jh2-5.0.13-cp37-abi3-win_amd64.whl", hash = "sha256:5d61bc0a62b4eee11039bf29d4bdbb26efcff760dfb9d8e0739740028aa52b0f", size = 252085, upload-time = "2026-05-29T05:20:22.426Z" },
+    { url = "https://files.pythonhosted.org/packages/47/7b/e8baeef7655449a6c9abee0165fcb1c63d12ec5432b8d810ff5910184690/jh2-5.0.13-cp37-abi3-win_arm64.whl", hash = "sha256:3f74dad9036e599eed51576492b00955237b86cf886f96844708a81cd0f5c710", size = 249139, upload-time = "2026-05-29T05:20:23.558Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/1e/be44f6e9ff5689fcdf9a2c0ed30880fd5da303676d89d6457a603450b7b1/jh2-5.0.13-py3-none-any.whl", hash = "sha256:2b311414989da48a155721fe47d0dc3e3b75360efd62d779aaff72d786be91cf", size = 98909, upload-time = "2026-05-29T05:21:42.086Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+]
+
+[[package]]
+name = "msal"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b0/d807279f4b55d16d1f120d5ac4344c6e39b56732e2a224d40bded7fd67ad/msal-1.37.0-py3-none-any.whl", hash = "sha256:dd17e95a7c71bce75e8108113438ba7c4a086b3bcad4f57a8c09b7af3d753c2d", size = 123725, upload-time = "2026-05-29T19:49:04.335Z" },
+]
+
+[[package]]
+name = "niquests"
+version = "3.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "urllib3-future" },
+    { name = "wassima", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/1c/836ad34fb18fac781722019100e2bffd81eb9a0011d7a91c434a7094460d/niquests-3.21.0.tar.gz", hash = "sha256:5b7d10a05f4c7ed08cede0af74f492ae7a8a5a71291833d029e23365fc3ea80a", size = 1070211, upload-time = "2026-07-29T10:26:24.993Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/9b/c08403f905f9aaffc74b483fbb0ad4cc372d1da22cccb4ca771a3e65a185/niquests-3.21.0-py3-none-any.whl", hash = "sha256:dbea441b9e9d5d755e02caa2b57b94cdb97b23d754ead21b80a4ac18ef66805f", size = 230382, upload-time = "2026-07-29T10:26:23.194Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.28.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/3e/29e0d6a2c5adde6ab5772253fd16ab346324026b89a66e354689c86d0584/proto_plus-1.28.2.tar.gz", hash = "sha256:26d843eb99c1e32fdf1d20ff0faae56607f7748fe774acf9ecd5cfe6c6472501", size = 58063, upload-time = "2026-07-22T16:28:29.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/84/4e9a53a062d4073c74897a6bd20fff74d55307341b3e85c081002462b3ef/proto_plus-1.28.2-py3-none-any.whl", hash = "sha256:b874236fcac2358f601e4330bcb76cb8b89c851303ccf4078408b3d4774d1c52", size = 50693, upload-time = "2026-07-22T16:28:24.059Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qh3"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/ae/9d42d6df0ab9a014138332346fd690f7b0be0556861421d2459caec28d6f/qh3-1.9.4.tar.gz", hash = "sha256:bd2ea9baf19656c544a48a56a195f2ac257cd973b566f5f2998fa3b7446281a1", size = 346724, upload-time = "2026-07-13T06:36:32.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/b2/7a8f6dcb93a7a23db07c556fe57b167be7b880dd1771d3df62ab1dce4e56/qh3-1.9.4-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:66567176a55bc92f12a7cdaae6d0245f808333a6a55221f37577f79c56848b71", size = 4359072, upload-time = "2026-07-13T06:33:03.308Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ef/343c02a1fe2ee1215120483fee965eab0ee72ea4a9ae122a9b31add14ea6/qh3-1.9.4-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a931eba5b6b11292ed65e164a416b78a50139fb9c9dc9dce90006cbd853d1fdd", size = 2159084, upload-time = "2026-07-13T06:33:05.531Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c5/c92e03e4711a1b3e09924d654f3c17dd62b91233302a77ce5695215a2b5b/qh3-1.9.4-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:325ee1f729e7b2f8600e71e354715db18ec4e669a001449f5924ba0521b9bafe", size = 1862100, upload-time = "2026-07-13T06:33:07.147Z" },
+    { url = "https://files.pythonhosted.org/packages/73/9d/88f5088430d25f3a0bc414b15b2b0b22a117468e49bba981c140337bb90b/qh3-1.9.4-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d9b38c9e5c6552828118676795b0a270e2337571e25d17bf57c18c2c5c346df5", size = 2032620, upload-time = "2026-07-13T06:33:08.738Z" },
+    { url = "https://files.pythonhosted.org/packages/49/0e/26470349a310715c05776c26e289e54c6a49f08289249445d5a660d364bd/qh3-1.9.4-cp313-cp313t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:9cf35ac8f4133a88ad3d8e35d63bfd566f369071a496a16ed69ae09b01b9a64a", size = 2034678, upload-time = "2026-07-13T06:33:10.398Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ae/ad55ebd12852e5c714e1c2956c4497d6d09417e9af5c66eb672b79cdd7f6/qh3-1.9.4-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6e5458cdc9e5214b111d13b86207c2ac799e1191d2e084c442d4fae1ec73fd9b", size = 2032574, upload-time = "2026-07-13T06:33:11.973Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/27/62b09bdee46d603fd581bec43c98a86c9380f2722d10cb7885d623c1d4e8/qh3-1.9.4-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9486a8dfc1d8eba625e7f92f3a1c45e4a131c7d96d33b73c20d584cf6bb99055", size = 2089542, upload-time = "2026-07-13T06:33:13.591Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b4/b89476bfd17c47c29425f3b9cdf5bfbe27872853c1d0a53c9315be05c89b/qh3-1.9.4-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3e2e90656a46c49ec04e920fbdff28a14eb4439fb660e5de3074c3fbab4ee13", size = 2367301, upload-time = "2026-07-13T06:33:15.142Z" },
+    { url = "https://files.pythonhosted.org/packages/46/a9/f21458c4ee1b527030f3d23d67ecf97caa75a8a9c0e021ddaac02083413a/qh3-1.9.4-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:4555d49cb3167904a48dec772fb3a71279282c05e70cc2be9d59b597d1fe71a0", size = 2015315, upload-time = "2026-07-13T06:33:17.003Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9f/30d83600b6f6bf8a3a995e05b46578e333c8ea5e0a799ea28d5f6f28c262/qh3-1.9.4-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d5b6a7af8eb57dd168c023ffb041274b35b120a8eddf0a37f9bebcf4d69bf3c9", size = 2349006, upload-time = "2026-07-13T06:33:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/7dc1ac91848f2774c68935da37ecf5e5d069a02b4f98934a74f8868a531a/qh3-1.9.4-cp313-cp313t-musllinux_1_1_armv7l.whl", hash = "sha256:593165d62fb259ee9a756e1bf07aa66cb445680e5bbb7fa15d8d3ba59dcf923e", size = 2133242, upload-time = "2026-07-13T06:33:21.12Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/07/d7d59c1474be53394555b575614eb086d10ed23b7ef3d83f93571ee40fd2/qh3-1.9.4-cp313-cp313t-musllinux_1_1_i686.whl", hash = "sha256:2369dd42c97de4cf628503fd5c02b359b23cabd0ff1773d33b135395748c6e42", size = 2230318, upload-time = "2026-07-13T06:33:22.584Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/42/eeca764d3e78b6a3910f95bd33af638f15fc88c6af98807abdc9fb0d75ec/qh3-1.9.4-cp313-cp313t-musllinux_1_1_riscv64.whl", hash = "sha256:eb99f81ad441f64f29da560a0619c9e5b8d9f4532e611c1d6319b536a9d36f53", size = 2125385, upload-time = "2026-07-13T06:33:24.284Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4d/41d6e4f8d06052873a590557769dfce8a14627e1cc03f74600313ed0c552/qh3-1.9.4-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:2a875175ab7c03d06fdb6784bf207d6aa1d30d2bef8170cde49b6960a0ca96a1", size = 2587129, upload-time = "2026-07-13T06:33:25.841Z" },
+    { url = "https://files.pythonhosted.org/packages/65/79/05804bdedc1be747e319091ec770cc8ce5499008b16a70ce2cde035d2558/qh3-1.9.4-cp313-cp313t-win32.whl", hash = "sha256:72c37f9fcf7b1136f245a333bceb7582fb4dcc955bfad0937ca6c857748b5638", size = 1855980, upload-time = "2026-07-13T06:33:27.522Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2c/4eb17c6e4743b8b003ed9c4fffe3acfaa29c000de09a9d8ce6ade1f0b428/qh3-1.9.4-cp313-cp313t-win_amd64.whl", hash = "sha256:257a1454732d261b3cf8af90d52cfa13ebb213a899d7983d7707b0c30f4a2533", size = 2122099, upload-time = "2026-07-13T06:33:29.075Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/bb/b8101f7a96237516a57b6fbcfebacc2c3349ab0b6ff528784f1c90d69edf/qh3-1.9.4-cp313-cp313t-win_arm64.whl", hash = "sha256:a21c68c0724521fedc4df1abc4402020a1eb37500d138a1bee1c3e50c1b0edb4", size = 1970072, upload-time = "2026-07-13T06:33:30.535Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/89/1b52aa142d772479393c4868f41255ddaf29627db72a36c1f635f51987ad/qh3-1.9.4-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:100368855b0e103774438aaf8b38c711fb51b79f18e3b9dc873ea573648bcc3d", size = 4360094, upload-time = "2026-07-13T06:33:32.269Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/71/c9dd5b4093999b651869e5277ed33d88fa2ae4eca064896c66319563dd16/qh3-1.9.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b9d45e544e0a556380bd2a92af180ee98d32bca6cf622f28350ebc000611bdf", size = 2159530, upload-time = "2026-07-13T06:33:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/b4b34a93b1acf1476a757b1c5bac9d38d5c7cb2272d68b3ce1457476101f/qh3-1.9.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43f80d662078c26563a1aac32a4df22649473d996bf2422e073c8aa55b1c837c", size = 1862303, upload-time = "2026-07-13T06:33:35.801Z" },
+    { url = "https://files.pythonhosted.org/packages/31/cb/dc3004df9af3922cab529c53bd6b58a7d44cce02f6b6dd7f795d8a3350ce/qh3-1.9.4-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:551f60d487d849d6f2313dda94e54ebb16b1a29acb93676540ae790a56308c24", size = 2033172, upload-time = "2026-07-13T06:33:37.677Z" },
+    { url = "https://files.pythonhosted.org/packages/82/be/6952fde329c37b8c2f64548df726bd86b8dfda12df740b244114adc7e60d/qh3-1.9.4-cp314-cp314t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:3755d777ff35561bc719f571ebc4b91aaa8a945c210e50b2576bf2cc69cb511f", size = 2035596, upload-time = "2026-07-13T06:33:39.391Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5b/67676a616baba1265e5f06ef202779099a9b4926c81342c007528c68a3f8/qh3-1.9.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:04b64bb18e10d8f482bea1ef43e5da3448e2d5ba78bb0c735da5b9e02d7dfb0e", size = 2033387, upload-time = "2026-07-13T06:33:41.034Z" },
+    { url = "https://files.pythonhosted.org/packages/94/03/6823de539154091b46234c667e49bff9b06bae44a82d14895d813f909fae/qh3-1.9.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b47597daa4ae9195f81a35822217a395d3277f01a393d9c2bb3796a6b458b22c", size = 2090092, upload-time = "2026-07-13T06:33:42.875Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/5c/8a3e3b005f66091baf0310a429003733986d9e001d13f3f7781ff3849873/qh3-1.9.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9bb9012bc02c44da6af1b931b6082588519685fad8a1f866c341f749394f53f", size = 2368083, upload-time = "2026-07-13T06:33:45.085Z" },
+    { url = "https://files.pythonhosted.org/packages/02/3b/6feff7b78e7cf9eaf3b25af6d7239754c32d62881f9f392bf4d18d60a907/qh3-1.9.4-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:9c7f3781ec022dd958b5eb0e5cb2e2a54e207a3d8837fb7290bc239912648fd7", size = 2015665, upload-time = "2026-07-13T06:33:46.794Z" },
+    { url = "https://files.pythonhosted.org/packages/54/24/07692a20232b6f8788a54c7f06b25ce702b4a94a5ad79bf680a9e32fae08/qh3-1.9.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:633a24ab2db76d64881876c9d0f1b226a47d892bd7d78e61ea2c788ab59570af", size = 2349383, upload-time = "2026-07-13T06:33:48.495Z" },
+    { url = "https://files.pythonhosted.org/packages/38/15/f447e2ea4216757fbb5627ce96bb79e386133b0cd3e8f3c1b0142d4d1bdd/qh3-1.9.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:f2ff36b84a4ab9b68806af1f6985fa3b47e29695effe766a3e70c21efac8157c", size = 2133616, upload-time = "2026-07-13T06:33:50.079Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4a/dc4a346000aeb4d21aabb4b6daf47231556e47d534be3fa4a9ce95ee6d83/qh3-1.9.4-cp314-cp314t-musllinux_1_1_i686.whl", hash = "sha256:2100697d736dbdfd1d3f0266c9fcadea6230b66ed59e3e7f8c9a9d1a6eec0c65", size = 2231106, upload-time = "2026-07-13T06:33:51.678Z" },
+    { url = "https://files.pythonhosted.org/packages/38/b8/6090e97b28c7486d045309ebf010f8bd79a94b5838edeb7b39080ef8b1ad/qh3-1.9.4-cp314-cp314t-musllinux_1_1_riscv64.whl", hash = "sha256:9ce179efaf97f927f01fe158619f5624d8d874c7161b7c497f06897cdde210d5", size = 2125844, upload-time = "2026-07-13T06:33:54.318Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b7/a8d8d0568758ac85e87003aa550b7557b502eb1b600309abbdbe6246294b/qh3-1.9.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:476ee4fcdbd3454eb0eb4dee5678294f06c08ca8e8b83160e2d0ae3c4ae34603", size = 2588008, upload-time = "2026-07-13T06:33:55.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/318fb071ed092edc1b6572066157b6a029c15c42369520d7d7353a126334/qh3-1.9.4-cp314-cp314t-win32.whl", hash = "sha256:fe9df8136bf358d45a2757287523abaeb208fcbe2c1e34664562eb2d8f64dbdb", size = 1855852, upload-time = "2026-07-13T06:33:57.59Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/5f/2b617597c665739ee6d0b190aef22df378e759a810a86fe1de7acab31857/qh3-1.9.4-cp314-cp314t-win_amd64.whl", hash = "sha256:1fbdf53feb1732faf6c1cb34f2e1cbe4b543054db7b4d19d8752f1162e9370be", size = 2122462, upload-time = "2026-07-13T06:33:59.182Z" },
+    { url = "https://files.pythonhosted.org/packages/85/3e/56694a36751508ec18f66ba115c83a4dad6d576ebbb50523c940eb89b3ca/qh3-1.9.4-cp314-cp314t-win_arm64.whl", hash = "sha256:e03ee1e2157a31c69415c3dbfbfe64e02469499ca46e968d13d8a7b289bf520a", size = 1971117, upload-time = "2026-07-13T06:34:00.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/48/646ee80a03ef7fac2b70cccea8a8f17c284fbb86fb854227f6ce70898053/qh3-1.9.4-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:26f7c8ed1a7ac0e25b654f030a4f472830c80890cc284dc40a31c17ecc21fbf0", size = 4376855, upload-time = "2026-07-13T06:34:02.745Z" },
+    { url = "https://files.pythonhosted.org/packages/af/86/d6777ff057a45debcfeb2a55b21692ce0c6f32a3c3a45531e83cf8ed4ef6/qh3-1.9.4-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a57b3dfe5dd2da2084adea63dba0bf587a4096ebf9207339187c90139d1f460d", size = 2164636, upload-time = "2026-07-13T06:34:04.437Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7b/7ebfd6babc3aaac74fb40beb5f85c289e2dcc40116282a3e48db99558eb7/qh3-1.9.4-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7fa1a3debb5199da3c7f45b0ca6efa55174dfd6229370e774099073143ebe9e9", size = 1865942, upload-time = "2026-07-13T06:34:06.03Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8f/bbc0b834b1252356d49d8813156606d426eb7f90ed5bc6aa479bc8aef7c6/qh3-1.9.4-cp37-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6dc9ff40d3a06f27b47d93417666f03ba6fd6b9585d9711ebbddf84fa4b7c50f", size = 2038977, upload-time = "2026-07-13T06:34:09.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/32/fe10f124f2062cb9004c18c1b506d29961e2e4d72d2c20ea1b3503ebe6fe/qh3-1.9.4-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:010b132c33719af3df4c1d6f569e52a2a20046c55a31c5532e741019c8c53868", size = 2042505, upload-time = "2026-07-13T06:34:10.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/eb/b7b93687c033d4291c8207f47b2b0c7fdb738db89ab5beceae08d866734f/qh3-1.9.4-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:124045b0c04c05afc038a239d7717019b4c4b9d0cb967040b4331f4d588eff7d", size = 2039083, upload-time = "2026-07-13T06:34:12.952Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/22/b064ec3fd14f121a8710f41bb42680ed96635b55bc78f2e85d475e8dbd65/qh3-1.9.4-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7a94a1726bf46a451a0295d68fafde28794e83ab6fda7457cbd9309c38151de9", size = 2092767, upload-time = "2026-07-13T06:34:14.925Z" },
+    { url = "https://files.pythonhosted.org/packages/29/92/54bac0ab3aad24b84f1e3c4868399e42cb8678054650f5f2e436acc2554c/qh3-1.9.4-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b361e627b6a529ecb231c1d5f3f2abd6d1952b0d7cc02c7718d9657d55dae37", size = 2372367, upload-time = "2026-07-13T06:34:16.589Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/78/99f27d776e54724050d41a14762e25e6b8d251b20943b59928f4fca366ad/qh3-1.9.4-cp37-abi3-manylinux_2_39_riscv64.whl", hash = "sha256:43b6cfb2240836e3e54bbe61ad1b8fa5716516ff5359131a2421c55676a24f26", size = 2017823, upload-time = "2026-07-13T06:34:18.114Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f7/ac383f019b69e9c7021e300cde900de36953d44e408fbd323993575ce765/qh3-1.9.4-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e6db3def610e9c2d2f3602d3e9c8b2156273225f6eedf74a4749d3bc21af8167", size = 2353468, upload-time = "2026-07-13T06:34:19.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/db/d60b95e872368e51756877e98841b77691acb833e89997839a7adfe053d0/qh3-1.9.4-cp37-abi3-musllinux_1_1_armv7l.whl", hash = "sha256:22d5879dc93d2c7ee14cc5933b12c7780d9c7705dff4553becea152fcb767d99", size = 2136024, upload-time = "2026-07-13T06:34:21.837Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ed/a84cbc776edb96b8502d9e9093432431927dd827ca2d064b196a43418bb7/qh3-1.9.4-cp37-abi3-musllinux_1_1_i686.whl", hash = "sha256:2c2b2005fe6c605d61cac05ec2b3c019cc546184fa43444f3d1e3d22ed020ab2", size = 2235665, upload-time = "2026-07-13T06:34:23.425Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/0b/ef538579ba7144fadc6865df30bc9ccb3b78ae1dd61899a5da115b0ea461/qh3-1.9.4-cp37-abi3-musllinux_1_1_riscv64.whl", hash = "sha256:e991b0f20b172fea466d0ffd499a85bf2f26decdeeda537275c72b5f7b26ccfe", size = 2128989, upload-time = "2026-07-13T06:34:25.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ad/fb9f922d0ea410c7f7f19a746f02be0fab2b5b5c061872ca0965fe767c52/qh3-1.9.4-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:c13775ed27a88b297f6a1aa05ffb286879453f99e1e53e0af2b22e7ed8f92ebf", size = 2593826, upload-time = "2026-07-13T06:34:27.288Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a5/aeef82a0edae7003d42c0587dfbceae4ff0ce375f8c2c13398a4aa4a29f3/qh3-1.9.4-cp37-abi3-win32.whl", hash = "sha256:952abe1be90c0114993886792a8a5ec2211f8391df41227f5b7a5a02ff71bc26", size = 1868838, upload-time = "2026-07-13T06:34:28.944Z" },
+    { url = "https://files.pythonhosted.org/packages/05/48/77f3055a3790a515fc59b37cdf1f23c374f8a235c6fa1b110153b78668e4/qh3-1.9.4-cp37-abi3-win_amd64.whl", hash = "sha256:5543cb40a48d401f3fa4ec89398e3a213634f195716a9d06d70417c05edbbb32", size = 2130155, upload-time = "2026-07-13T06:34:30.526Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bc/aec1f86da0d093a319f43d88b005b4b71efa94e8f675c2c9764098c2abb2/qh3-1.9.4-cp37-abi3-win_arm64.whl", hash = "sha256:d0bd73b3e73f4f80d2430d410b532222ecf57e9d4fe8600b7683c775cbff9479", size = 1980028, upload-time = "2026-07-13T06:34:32.376Z" },
+]
+
+[[package]]
+name = "recurring-ical-events"
+version = "3.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "icalendar" },
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+    { name = "x-wr-timezone" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f5/898abd8fbb25766ec6cb17b244730ebf192f47963c71eeacd61aadd903a1/recurring_ical_events-3.8.2.tar.gz", hash = "sha256:e731af31d0b7dec5cd47a1defacd8549e2f36fab1c1995e8b9f042822a0acf8e", size = 604992, upload-time = "2026-04-30T19:21:46.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/f7/d3eb4f545baf5d6daaa5881694517626fb7ad04036d94168197a4f021384/recurring_ical_events-3.8.2-py3-none-any.whl", hash = "sha256:9ad605e27b4fbeb70ee1c66205ade32550be15a57cedc579606522f1c67aef6d", size = 241358, upload-time = "2026-04-30T19:21:44.079Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/38/e12680bbe6b4f8f3d17adcaf38d26850aa756c85cf4a80e79fc12a018fe8/soupsieve-2.9.1.tar.gz", hash = "sha256:c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba", size = 122261, upload-time = "2026-07-21T16:57:17.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl", hash = "sha256:4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c", size = 37404, upload-time = "2026-07-21T16:57:16.421Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/10/a34c656829ffc1c4b22ef36d70d9ebb6b99c020e2aeb17cee5485099f028/sse_starlette-3.4.6.tar.gz", hash = "sha256:725f8a1bd6d26ae1b2c9610c0ef5065dfdd496f3988d28adcf8c4b49dc25c627", size = 32542, upload-time = "2026-07-20T14:16:32.201Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/36/e10c1d1b7ca881d2625db2ec28508578499187bb1c389952c398474e1834/sse_starlette-3.4.6-py3-none-any.whl", hash = "sha256:56217ab4c9a9f9c5db7b21e08732d3e7c2b807f45231ad23de0551a24c4a41f6", size = 16516, upload-time = "2026-07-20T14:16:30.978Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "ts4k"
+version = "0.1.21"
+source = { editable = "." }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "caldav" },
+    { name = "google-api-python-client" },
+    { name = "google-auth-httplib2" },
+    { name = "google-auth-oauthlib" },
+    { name = "html2text" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "msal" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "anthropic" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.40" },
+    { name = "beautifulsoup4", specifier = ">=4.12" },
+    { name = "caldav", specifier = ">=3.2.1" },
+    { name = "google-api-python-client", specifier = ">=2.100" },
+    { name = "google-auth-httplib2", specifier = ">=0.2" },
+    { name = "google-auth-oauthlib", specifier = ">=1.2" },
+    { name = "html2text", specifier = ">=2024.2" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "mcp", specifier = ">=1.0,<2" },
+    { name = "msal", specifier = ">=1.28" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "urllib3-future"
+version = "2.24.900"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "jh2" },
+    { name = "qh3", marker = "(platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'i686' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'ppc64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'ppc64le' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'riscv64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'riscv64gc' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 's390x' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'x86' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'i686' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'ppc64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'ppc64le' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'riscv64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'riscv64gc' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 's390x' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'armv7l' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'i686' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ppc64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ppc64le' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'riscv64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'riscv64gc' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 's390x' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'x86' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/9f/590bfa6575e8872829dc65d02c887d0599b3897912479e5ca198660a8c1e/urllib3_future-2.24.900.tar.gz", hash = "sha256:05c2e9d09293ab29a154fed8f5b60644c7cdaffe4ae2587a07b1c7f00f23a7fb", size = 1370419, upload-time = "2026-07-27T06:16:52.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/b6/1a7cf7971c979e56ecff5eb76cf8d748d567ef5f7a4fa39fb87adac922e4/urllib3_future-2.24.900-py3-none-any.whl", hash = "sha256:a4fe06b59b0c3ce2fffa821c3de72eaf59b1e61619becc255dee18919ee25260", size = 809879, upload-time = "2026-07-27T06:16:50.77Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.52.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/c8/2d307868453a4bca6e64fa3581d122ae0748a0869c53f159339def179c7c/uvicorn-0.52.0.tar.gz", hash = "sha256:ca8876ad6c1983f394157c168b39d52f6dd56dabf5602fa0982751cffc2293ae", size = 97504, upload-time = "2026-07-29T08:45:34.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/e6/b5c0630ace9757232aec07112be8146b812787db52141ff9d50674aa7634/uvicorn-0.52.0-py3-none-any.whl", hash = "sha256:3d887809810b89ed33501bcf0a9aba469b06ecd608158efce04bd6b48d8c9b08", size = 79058, upload-time = "2026-07-29T08:45:32.492Z" },
+]
+
+[[package]]
+name = "wassima"
+version = "2.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a1/714674b53d3a57013730187e027e291c652a25db053e02236798bec49d61/wassima-2.1.3.tar.gz", hash = "sha256:fcd6c38be0f909c393da35cb2a993101fcdcff673b8fa8d5da228f73b630d0d0", size = 140075, upload-time = "2026-07-24T18:36:21.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/a2/4c8cd0dddfe40a779739afab2f09e84286bea37cdb73c7b1c12b4990ff12/wassima-2.1.3-py3-none-any.whl", hash = "sha256:f8251c23720dd092117a554b3012756caee3feed6d0122c2458a2aca5d7d92c5", size = 131416, upload-time = "2026-07-24T18:36:19.36Z" },
+]
+
+[[package]]
+name = "x-wr-timezone"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "icalendar" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/2b/8ae5f59ab852c8fe32dd37c1aa058eb98aca118fec2d3af5c3cd56fffb7b/x_wr_timezone-2.0.1.tar.gz", hash = "sha256:9166c40e6ffd4c0edebabc354e1a1e2cffc1bb473f88007694793757685cc8c3", size = 18212, upload-time = "2025-02-06T17:10:40.913Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/b7/4bac35b4079b76c07d8faddf89467e9891b1610cfe8d03b0ebb5610e4423/x_wr_timezone-2.0.1-py3-none-any.whl", hash = "sha256:e74a53b9f4f7def8138455c240e65e47c224778bce3c024fcd6da2cbe91ca038", size = 11102, upload-time = "2025-02-06T17:10:39.192Z" },
+]


### PR DESCRIPTION
## Summary

Adds a generic CalDAV calendar adapter so `cal` commands work against Apple/iCloud calendars alongside Google Calendar and O365 — and against any RFC 4791 server (Fastmail, Nextcloud) via `server_url=`.

- **New provider `caldav`** with aliases `apple`/`icloud`/`apple-calendar` presetting `https://caldav.icloud.com`
- **Auth**: Apple app-specific password (no OAuth) stored 0600 at `~/.config/ts4k/caldav/<email>/credentials.json`; `ts4k src add cc apple email=you@icloud.com` prompts via getpass and offers an interactive calendar picker
- **Adapter** (`src/ts4k/adapters/caldav_cal.py`): list/read/create/update events, list calendars, RSVP — built on the `caldav` library wrapped in `asyncio.to_thread`; normalized event dicts are key-identical to gcal's so `format.py` needed no changes
- **Recurring events** expand to instances in-window (gcal `singleEvents=True` parity); timed events normalize to the source timezone so string ordering is chronological
- **RSVP degrades gracefully**: prefers the library's invite helpers, falls back to PARTSTAT edit, and returns an actionable "respond in the Calendar app" error when iCloud rejects — never a stack trace
- **Invites**: attendee-bearing events carry ORGANIZER + self-CHAIR attendee (RFC 6638) and are gated at `level=send`, matching gcal semantics
- **Registration**: `_CAL_PROVIDERS` constant replaces all seven `("gcal", "o365cal")` gate tuples in `commands.py`; token health, provider labels, and `_resolve_prefixes` aliases wired in; per-source failure isolation added to the calendar fetch path so one dead source can't take down `cal today`
- Spec + implementation plan committed under `docs/superpowers/`

## Test plan

- 55 new tests across `test_caldav_auth/adapter/write/commands/cli.py` (real ICS parsed through `icalendar`, not shallow mocks); full suite **832 passed, 4 skipped, 3 deselected**
- Every task went through spec+quality review, and the branch passed a final whole-branch review; two review-found issues (missing ORGANIZER on invites, missing per-source isolation) were fixed and re-verified
- ⚠️ Outstanding: manual smoke test against a real iCloud account (needs an app-specific password) — recommended before relying on the adapter, especially attendee invites

🤖 Generated with [Claude Code](https://claude.com/claude-code)