### PR TITLE
fix: CalDAV follow-up bundle (PR #51 review items)

### DIFF
--- a/src/ts4k/adapters/caldav_cal.py
+++ b/src/ts4k/adapters/caldav_cal.py
@@ -36,6 +36,14 @@ def _strip_mailto(value: Any) -> str:
     return s[7:] if s.lower().startswith("mailto:") else s
 
 
+def _attendees_of(comp: Any) -> list:
+    """ATTENDEE is absent, a single vCalAddress, or a list — always yield a list."""
+    raw = comp.get("ATTENDEE")
+    if raw is None:
+        return []
+    return list(raw) if isinstance(raw, list) else [raw]
+
+
 @dataclass
 class CaldavAdapterConfig:
     """Configuration for a CalDAV calendar source."""
@@ -186,13 +194,7 @@ class CaldavAdapter(BaseAdapter):
         else:
             duration_minutes = None
 
-        raw_attendees = comp.get("ATTENDEE")
-        if raw_attendees is None:
-            attendees = []
-        elif isinstance(raw_attendees, list):
-            attendees = raw_attendees
-        else:
-            attendees = [raw_attendees]
+        attendees = _attendees_of(comp)
 
         your_status = None
         my_email = self._config.email.lower()
@@ -277,12 +279,7 @@ class CaldavAdapter(BaseAdapter):
         base = self._normalize_component(comp)
 
         attendees_full = []
-        raw_attendees = comp.get("ATTENDEE")
-        if raw_attendees is None:
-            raw_attendees = []
-        elif not isinstance(raw_attendees, list):
-            raw_attendees = [raw_attendees]
-        for a in raw_attendees:
+        for a in _attendees_of(comp):
             email = _strip_mailto(a)
             partstat = str(a.params.get("PARTSTAT", "NEEDS-ACTION")).upper()
             attendees_full.append({
@@ -311,11 +308,24 @@ class CaldavAdapter(BaseAdapter):
         return base
 
     async def list_calendars(self) -> list[dict]:
-        """List calendars on the principal (used by setup; adapter may have empty calendar_id)."""
+        """List event-capable calendars on the principal.
+
+        Apple exposes legacy VTODO-only collections (Reminders) alongside real
+        calendars; they can't hold events, so they're filtered out of the
+        picker.  Servers that won't answer the propfind fail open.
+        """
+
+        def _holds_events(c: Any) -> bool:
+            try:
+                return "VEVENT" in c.get_supported_components()
+            except Exception:
+                return True
 
         def _list() -> list[dict]:
             out = []
             for c in self._principal.calendars():
+                if not _holds_events(c):
+                    continue
                 out.append({
                     "id": str(c.url),
                     "summary": c.name or str(c.url),
@@ -464,7 +474,8 @@ class CaldavAdapter(BaseAdapter):
         if "end" in fields:
             e = fields["end"]
             if "T" not in e:
-                _set("DTEND", date.fromisoformat(e))
+                # All-day: user provides inclusive end, iCal DTEND is exclusive
+                _set("DTEND", date.fromisoformat(e) + timedelta(days=1))
             else:
                 dt = datetime.fromisoformat(e)
                 _set("DTEND", dt.replace(tzinfo=tzinfo) if dt.tzinfo is None else dt)
@@ -503,13 +514,8 @@ class CaldavAdapter(BaseAdapter):
         comp = obj.icalendar_component
 
         my_email = self._config.email.lower()
-        raw_attendees = comp.get("ATTENDEE")
-        if raw_attendees is None:
-            raw_attendees = []
-        elif not isinstance(raw_attendees, list):
-            raw_attendees = [raw_attendees]
         me = next(
-            (a for a in raw_attendees if _strip_mailto(a).lower() == my_email), None
+            (a for a in _attendees_of(comp) if _strip_mailto(a).lower() == my_email), None
         )
         if me is None:
             raise ValueError(

--- a/src/ts4k/adapters/gcal.py
+++ b/src/ts4k/adapters/gcal.py
@@ -373,7 +373,12 @@ class GcalAdapter(BaseAdapter):
             body["start"] = {"date": s} if "T" not in s else {"dateTime": s}
         if "end" in fields:
             e = fields["end"]
-            body["end"] = {"date": e} if "T" not in e else {"dateTime": e}
+            if "T" not in e:
+                # All-day: user provides inclusive end, API end is exclusive
+                end_date = datetime.strptime(e, "%Y-%m-%d") + timedelta(days=1)
+                body["end"] = {"date": end_date.strftime("%Y-%m-%d")}
+            else:
+                body["end"] = {"dateTime": e}
 
         event = await asyncio.to_thread(
             lambda: self._service.events().patch(

--- a/src/ts4k/adapters/o365cal.py
+++ b/src/ts4k/adapters/o365cal.py
@@ -398,9 +398,19 @@ class O365CalAdapter(BaseAdapter):
         if "start" in fields:
             s = fields["start"]
             body["start"] = {"dateTime": s, "timeZone": self._config.timezone}
+            if "T" not in s:
+                body["isAllDay"] = True
         if "end" in fields:
             e = fields["end"]
-            body["end"] = {"dateTime": e, "timeZone": self._config.timezone}
+            if "T" not in e:
+                # All-day: user provides inclusive end, Graph end is exclusive
+                from datetime import timedelta
+                end_date = datetime.strptime(e, "%Y-%m-%d") + timedelta(days=1)
+                body["end"] = {"dateTime": end_date.strftime("%Y-%m-%d"),
+                               "timeZone": self._config.timezone}
+                body["isAllDay"] = True
+            else:
+                body["end"] = {"dateTime": e, "timeZone": self._config.timezone}
 
         event = await self._patch(f"/me/events/{raw_id}", json=body)
         return self._normalize_event(event)

--- a/src/ts4k/auth/caldav.py
+++ b/src/ts4k/auth/caldav.py
@@ -37,11 +37,16 @@ def save_credentials(
 ) -> Path:
     path = credentials_path(email, config_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(
+    payload = json.dumps(
         {"username": username, "app_password": app_password, "server_url": server_url},
         indent=2,
-    ))
-    path.chmod(0o600)
+    )
+    # Create 0600 up front (and tighten an existing file) so the password is
+    # never on disk under looser permissions, not even briefly.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    os.fchmod(fd, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(payload)
     return path
 
 

--- a/src/ts4k/cli.py
+++ b/src/ts4k/cli.py
@@ -1114,11 +1114,16 @@ def _auth_interactive(targets: list[tuple[str, dict]], no_calendar: bool) -> Non
             elif provider == "whatsapp":
                 print(f"  {prefix}: whatsapp — session-based, no auth needed")
             elif provider == "caldav":
+                from ts4k.auth.caldav import credentials_path
                 email = cfg.get("email", "<your-apple-id>")
                 print(f"  {prefix}: caldav — no OAuth; uses an app-specific password")
                 print(f"        Generate one at https://account.apple.com "
                       f"(Sign-In and Security → App-Specific Passwords),")
                 print(f"        then store it with: ts4k src add {prefix} apple email={email}")
+                # src add only prompts when no credential is stored, so a revoked
+                # password has to be removed first or the re-run is a no-op.
+                print(f"        Replacing a revoked password? delete "
+                      f"{credentials_path(email)} first.")
             else:
                 print(f"  {prefix}: unknown provider '{provider}' — skipping")
         except SystemExit:

--- a/src/ts4k/cli.py
+++ b/src/ts4k/cli.py
@@ -1113,6 +1113,12 @@ def _auth_interactive(targets: list[tuple[str, dict]], no_calendar: bool) -> Non
                 _auth_o365(prefix, cfg, no_calendar)
             elif provider == "whatsapp":
                 print(f"  {prefix}: whatsapp — session-based, no auth needed")
+            elif provider == "caldav":
+                email = cfg.get("email", "<your-apple-id>")
+                print(f"  {prefix}: caldav — no OAuth; uses an app-specific password")
+                print(f"        Generate one at https://account.apple.com "
+                      f"(Sign-In and Security → App-Specific Passwords),")
+                print(f"        then store it with: ts4k src add {prefix} apple email={email}")
             else:
                 print(f"  {prefix}: unknown provider '{provider}' — skipping")
         except SystemExit:

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -181,12 +181,17 @@ def _resolve_prefixes(source: str | None) -> list[str]:
 
     Accepts a specific prefix, a provider name, or ``"all"`` (default).
     """
-    source = (source or "all").lower().strip()
+    raw = (source or "all").strip()
     all_cfg = _ensure_sources()
 
-    if source == "all":
+    if raw.lower() == "all":
         return list(all_cfg.keys())
 
+    # Prefixes keep the case they were added with — exact key wins
+    if raw in all_cfg:
+        return [raw]
+
+    source = raw.lower()
     if source in all_cfg:
         return [source]
 

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -2184,11 +2184,14 @@ async def _cal_fetch_events(
     from ts4k.state import sources as src_mod
 
     all_sources = src_mod.list_all()
+    # Route through _resolve_prefixes so provider aliases (apple, icloud, ...)
+    # work on cal commands the same way they do on message commands.
+    wanted = set(_resolve_prefixes(source)) if source else None
     prefixes = []
     for pfx, cfg in all_sources.items():
         if cfg.get("provider") not in _CAL_PROVIDERS:
             continue
-        if source and pfx != source and cfg.get("provider") != source:
+        if wanted is not None and pfx not in wanted:
             continue
         prefixes.append((pfx, cfg))
 
@@ -2240,10 +2243,11 @@ def _get_cal_timezone(source: str | None) -> str:
     from ts4k.state import sources as src_mod
 
     all_sources = src_mod.list_all()
+    wanted = set(_resolve_prefixes(source)) if source else None
     for pfx, cfg in all_sources.items():
         if cfg.get("provider") not in _CAL_PROVIDERS:
             continue
-        if source and pfx != source:
+        if wanted is not None and pfx not in wanted:
             continue
         return cfg.get("timezone", "UTC")
     return "UTC"

--- a/tests/test_caldav_adapter.py
+++ b/tests/test_caldav_adapter.py
@@ -164,6 +164,20 @@ END:VCALENDAR
 """
 
 
+SINGLE_ATTENDEE_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:solo1
+SUMMARY:One on one
+DTSTART;TZID=Europe/Amsterdam:20260730T100000
+DTEND;TZID=Europe/Amsterdam:20260730T103000
+ATTENDEE;CN=Me;PARTSTAT=TENTATIVE:mailto:test@icloud.com
+END:VEVENT
+END:VCALENDAR
+"""
+
+
 class TestNormalization:
     def test_timed_event(self, adapter: CaldavAdapter):
         e = adapter._normalize_component(_mk_caldav_event(TIMED_ICS).icalendar_component)
@@ -197,6 +211,14 @@ class TestNormalization:
         e = adapter._normalize_component(_mk_caldav_event(INSTANCE_ICS).icalendar_component)
         assert e["recurring_event_id"] == "cc:rec1@icloud.com"
         assert e["id"].startswith("cc:rec1@icloud.com::2026-08-06T14:00:00")
+
+    def test_single_attendee_is_not_treated_as_a_sequence(self, adapter: CaldavAdapter):
+        # icalendar returns a bare vCalAddress (not a list) for one ATTENDEE
+        e = adapter._normalize_component(
+            _mk_caldav_event(SINGLE_ATTENDEE_ICS).icalendar_component
+        )
+        assert e["attendees_summary"] == "1 people"
+        assert e["your_status"] == "tentative"
 
     def test_foreign_timezone_normalized_to_config_tz(self, adapter: CaldavAdapter):
         # 09:00 EDT (America/New_York) on 2026-07-30 == 15:00 CEST (Europe/Amsterdam)
@@ -266,20 +288,37 @@ class TestReadEvent:
         assert e["updated"] == "2026-06-15T12:00:00+00:00"
         adapter._calendar.event_by_uid.assert_called_once_with("det1@icloud.com")
 
+    async def test_single_attendee_expands_to_one_entry(self, adapter: CaldavAdapter):
+        adapter._calendar.event_by_uid.return_value = _mk_caldav_event(SINGLE_ATTENDEE_ICS)
+        adapter._calendar.event_by_url.side_effect = Exception("404")
+        e = await adapter.read_event("cc:solo1")
+        assert e["attendees"] == [
+            {"name": "Me", "email": "test@icloud.com", "status": "tentative"},
+        ]
+
     async def test_instance_id_fetches_master(self, adapter: CaldavAdapter):
         adapter._calendar.event_by_uid.return_value = _mk_caldav_event(DETAIL_ICS)
         await adapter.read_event("cc:det1@icloud.com::2026-08-06T10:00:00+02:00")
         adapter._calendar.event_by_uid.assert_called_once_with("det1@icloud.com")
 
 
+def _mk_collection(url: str, name: str, components: list[str] | Exception) -> MagicMock:
+    c = MagicMock()
+    c.url = url
+    c.name = name
+    if isinstance(components, Exception):
+        c.get_supported_components.side_effect = components
+    else:
+        c.get_supported_components.return_value = components
+    return c
+
+
 class TestListCalendars:
     async def test_lists_principal_calendars(self, adapter: CaldavAdapter):
-        c1 = MagicMock()
-        c1.url = "https://caldav.icloud.com/123/calendars/home/"
-        c1.name = "Home"
-        c2 = MagicMock()
-        c2.url = "https://caldav.icloud.com/123/calendars/work/"
-        c2.name = "Work"
+        c1 = _mk_collection("https://caldav.icloud.com/123/calendars/home/", "Home", ["VEVENT"])
+        c2 = _mk_collection(
+            "https://caldav.icloud.com/123/calendars/work/", "Work", ["VEVENT", "VTODO"]
+        )
         adapter._principal.calendars.return_value = [c1, c2]
         cals = await adapter.list_calendars()
         assert cals == [
@@ -288,6 +327,27 @@ class TestListCalendars:
             {"id": "https://caldav.icloud.com/123/calendars/work/", "summary": "Work",
              "access_role": "owner", "timezone": "Europe/Amsterdam", "primary": False},
         ]
+
+    async def test_vtodo_only_collections_excluded(self, adapter: CaldavAdapter):
+        """Apple exposes legacy Reminders collections that hold no events."""
+        home = _mk_collection(
+            "https://caldav.icloud.com/123/calendars/home/", "Home", ["VEVENT"]
+        )
+        reminders = _mk_collection(
+            "https://caldav.icloud.com/123/calendars/reminders/", "Reminders", ["VTODO"]
+        )
+        adapter._principal.calendars.return_value = [home, reminders]
+        cals = await adapter.list_calendars()
+        assert [c["summary"] for c in cals] == ["Home"]
+
+    async def test_unqueryable_collection_is_kept(self, adapter: CaldavAdapter):
+        """Fail open: a server that won't answer the propfind shouldn't lose calendars."""
+        c = _mk_collection(
+            "https://caldav.icloud.com/123/calendars/home/", "Home", Exception("boom")
+        )
+        adapter._principal.calendars.return_value = [c]
+        cals = await adapter.list_calendars()
+        assert [c["summary"] for c in cals] == ["Home"]
 
 
 class TestFetchByUidUrlFirst:

--- a/tests/test_caldav_auth.py
+++ b/tests/test_caldav_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from ts4k.auth.caldav import (
@@ -35,6 +36,43 @@ def test_save_and_load_roundtrip(tmp_path: Path):
 
 def test_file_permissions_0600(tmp_path: Path):
     path = save_credentials(
+        "a@icloud.com",
+        username="a@icloud.com",
+        app_password="x",
+        server_url=ICLOUD_CALDAV_URL,
+        config_dir=tmp_path,
+    )
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_permissions_come_from_creation_not_followup_chmod(tmp_path: Path, monkeypatch):
+    """No window where the password is on disk world-readable.
+
+    Simulates the absence of a fix-up chmod: the mode must already be 0600
+    when the bytes are written, even under a permissive umask.
+    """
+    monkeypatch.setattr(Path, "chmod", lambda self, mode: None)
+    old_umask = os.umask(0)
+    try:
+        path = save_credentials(
+            "a@icloud.com",
+            username="a@icloud.com",
+            app_password="x",
+            server_url=ICLOUD_CALDAV_URL,
+            config_dir=tmp_path,
+        )
+    finally:
+        os.umask(old_umask)
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_rewrite_tightens_preexisting_loose_permissions(tmp_path: Path):
+    path = credentials_path("a@icloud.com", config_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}")
+    path.chmod(0o644)
+
+    save_credentials(
         "a@icloud.com",
         username="a@icloud.com",
         app_password="x",

--- a/tests/test_caldav_cli.py
+++ b/tests/test_caldav_cli.py
@@ -77,6 +77,18 @@ class TestAuthCaldav:
         assert "app-specific password" in out
         assert "src add" in out
 
+    def test_points_at_the_credential_file_to_replace(self, ts4k_config, capsys):
+        """`src add` only prompts when no credential exists — a revoked password
+        must be deleted first or the instruction is a dead end."""
+        from ts4k.auth.caldav import credentials_path
+
+        sources.add("cc", provider="caldav", email="a@icloud.com",
+                    calendar_id="https://caldav.icloud.com/1/calendars/home/")
+        cli._cmd_auth(self._auth_args())
+        out = capsys.readouterr().out
+        assert str(credentials_path("a@icloud.com")) in out
+        assert "delete" in out.lower()
+
     def test_provider_name_resolves(self, ts4k_config, capsys):
         sources.add("cc", provider="caldav", email="a@icloud.com",
                     calendar_id="https://caldav.icloud.com/1/calendars/home/")

--- a/tests/test_caldav_cli.py
+++ b/tests/test_caldav_cli.py
@@ -62,6 +62,28 @@ class TestSrcAddApple:
         assert "cc" not in sources.list_all()
 
 
+class TestAuthCaldav:
+    """`ts4k auth cc` should explain the app-specific password, not call caldav unknown."""
+
+    def _auth_args(self) -> argparse.Namespace:
+        return argparse.Namespace(target="cc", check=False, no_calendar=False)
+
+    def test_explains_app_specific_password(self, ts4k_config, capsys):
+        sources.add("cc", provider="caldav", email="a@icloud.com",
+                    calendar_id="https://caldav.icloud.com/1/calendars/home/")
+        cli._cmd_auth(self._auth_args())
+        out = capsys.readouterr().out.lower()
+        assert "unknown provider" not in out
+        assert "app-specific password" in out
+        assert "src add" in out
+
+    def test_provider_name_resolves(self, ts4k_config, capsys):
+        sources.add("cc", provider="caldav", email="a@icloud.com",
+                    calendar_id="https://caldav.icloud.com/1/calendars/home/")
+        cli._cmd_auth(argparse.Namespace(target="caldav", check=False, no_calendar=False))
+        assert "app-specific password" in capsys.readouterr().out.lower()
+
+
 class TestSuggestPrefix:
     def test_caldav_base_is_cc(self):
         assert cli._suggest_cal_prefix("Home", {}, provider="caldav").startswith("cc")

--- a/tests/test_caldav_commands.py
+++ b/tests/test_caldav_commands.py
@@ -81,6 +81,25 @@ class TestCalSourceAliases:
         assert commands._get_cal_timezone("apple") == "Europe/Amsterdam"
         assert commands._get_cal_timezone("icloud") == "Europe/Amsterdam"
 
+    async def test_exact_case_prefix_still_matches(self, monkeypatch):
+        """`src add` preserves prefix case — an exact key must win over lowercasing."""
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"Work": self._amsterdam_cfg()}
+        )
+        event = {"id": "Work:1", "title": "Standup", "start": "2026-07-30T09:00:00"}
+        adapter = MagicMock()
+        adapter.__aenter__ = AsyncMock(return_value=adapter)
+        adapter.__aexit__ = AsyncMock(return_value=None)
+        adapter.list_events = AsyncMock(return_value=[event])
+        monkeypatch.setattr(commands, "_make_adapter", lambda p, c: adapter)
+
+        assert commands._resolve_prefixes("Work") == ["Work"]
+        assert commands._get_cal_timezone("Work") == "Europe/Amsterdam"
+        events = await commands._cal_fetch_events(
+            "Work", "2026-07-30T00:00:00", "2026-07-31T00:00:00"
+        )
+        assert events == [event]
+
     def test_unknown_source_still_matches_nothing(self, monkeypatch):
         monkeypatch.setattr(
             "ts4k.state.sources.list_all", lambda: {"cc": dict(CALDAV_CFG)}

--- a/tests/test_caldav_commands.py
+++ b/tests/test_caldav_commands.py
@@ -48,6 +48,55 @@ class TestResolvePrefixes:
         assert commands._resolve_prefixes("caldav") == ["cc"]
 
 
+class TestCalSourceAliases:
+    """`cal today --source apple` must reach caldav sources, not silently return []."""
+
+    @staticmethod
+    def _amsterdam_cfg() -> dict:
+        cfg = dict(CALDAV_CFG)
+        cfg["timezone"] = "Europe/Amsterdam"
+        return cfg
+
+    async def test_alias_fetches_from_caldav_source(self, monkeypatch):
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"cc": dict(CALDAV_CFG)}
+        )
+        event = {"id": "cc:1", "title": "Standup", "start": "2026-07-30T09:00:00"}
+        adapter = MagicMock()
+        adapter.__aenter__ = AsyncMock(return_value=adapter)
+        adapter.__aexit__ = AsyncMock(return_value=None)
+        adapter.list_events = AsyncMock(return_value=[event])
+        monkeypatch.setattr(commands, "_make_adapter", lambda p, c: adapter)
+
+        for alias in ("apple", "icloud", "caldav", "cc"):
+            events = await commands._cal_fetch_events(
+                alias, "2026-07-30T00:00:00", "2026-07-31T00:00:00"
+            )
+            assert events == [event], f"alias {alias!r} returned {events}"
+
+    def test_alias_resolves_timezone(self, monkeypatch):
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"cc": self._amsterdam_cfg()}
+        )
+        assert commands._get_cal_timezone("apple") == "Europe/Amsterdam"
+        assert commands._get_cal_timezone("icloud") == "Europe/Amsterdam"
+
+    def test_unknown_source_still_matches_nothing(self, monkeypatch):
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"cc": dict(CALDAV_CFG)}
+        )
+        monkeypatch.setattr(commands, "_make_adapter", lambda p, c: MagicMock())
+
+        async def _run():
+            return await commands._cal_fetch_events(
+                "nosuch", "2026-07-30T00:00:00", "2026-07-31T00:00:00"
+            )
+
+        import asyncio
+
+        assert asyncio.run(_run()) == []
+
+
 class TestCalGates:
     async def test_cal_create_accepts_caldav_source(self, monkeypatch):
         monkeypatch.setattr(

--- a/tests/test_caldav_write.py
+++ b/tests/test_caldav_write.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -145,6 +146,28 @@ END:VCALENDAR
         obj.save.assert_called_once()
         assert e["title"] == "New"
         assert e["start"] == "2026-07-30T12:00:00+02:00"
+
+    async def test_all_day_inclusive_end_date_converted(self, tmp_path: Path):
+        """All-day end is inclusive from the user, exclusive in iCal — same as create."""
+        a = _adapter(tmp_path, "modify")
+        ics = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//test//EN
+BEGIN:VEVENT
+UID:up2
+SUMMARY:Vacation
+DTSTART;VALUE=DATE:20260317
+DTEND;VALUE=DATE:20260320
+END:VEVENT
+END:VCALENDAR
+"""
+        obj = MagicMock()
+        obj.icalendar_component = IcsCalendar.from_ical(ics).walk("VEVENT")[0]
+        a._calendar.event_by_uid.return_value = obj
+        e = await a.update_event("cc:up2", start="2026-03-17", end="2026-03-21")
+        assert obj.icalendar_component["DTEND"].dt == date(2026, 3, 22)  # +1 day
+        assert e["all_day"] is True
+        assert e["end"] == "2026-03-22"
 
 
 INVITE_ICS = """BEGIN:VCALENDAR

--- a/tests/test_gcal_write.py
+++ b/tests/test_gcal_write.py
@@ -99,6 +99,21 @@ class TestUpdateEvent:
         result = await adapter.update_event("gc:evt1", title="New Title")
         assert result["title"] == "New Title"
 
+    async def test_all_day_inclusive_end_date_converted(self):
+        """All-day end is inclusive from the user, exclusive in the API — same as create."""
+        adapter = _make_adapter(level="modify")
+        adapter._service.events.return_value.patch.return_value.execute.return_value = {
+            "id": "evt1", "summary": "Vacation",
+            "start": {"date": "2026-03-17"},
+            "end": {"date": "2026-03-22"},
+            "status": "confirmed",
+        }
+        await adapter.update_event("gc:evt1", start="2026-03-17", end="2026-03-21")
+
+        body = adapter._service.events.return_value.patch.call_args[1]["body"]
+        assert body["start"] == {"date": "2026-03-17"}
+        assert body["end"] == {"date": "2026-03-22"}  # +1 day
+
 
 class TestRsvp:
     async def test_modify_level_required(self):

--- a/tests/test_o365cal_write.py
+++ b/tests/test_o365cal_write.py
@@ -124,6 +124,26 @@ class TestUpdateEvent:
         result = await adapter.update_event("oc:evt1", title="New Title")
         assert result["title"] == "New Title"
 
+    async def test_all_day_inclusive_end_date_converted(self):
+        """All-day end is inclusive from the user, exclusive in Graph — same as create."""
+        adapter = _make_adapter(level="modify")
+        updated = {
+            "id": "evt1", "subject": "Vacation",
+            "start": {"dateTime": "2026-03-17", "timeZone": "UTC"},
+            "end": {"dateTime": "2026-03-22", "timeZone": "UTC"},
+            "isAllDay": True, "isCancelled": False,
+            "location": {"displayName": ""},
+            "responseStatus": {"response": "organizer"},
+        }
+        adapter._client.patch = AsyncMock(return_value=_mock_response(updated))
+        await adapter.update_event("oc:evt1", start="2026-03-17", end="2026-03-21")
+
+        call_args = adapter._client.patch.call_args
+        body = call_args.kwargs.get("json") or call_args[1].get("json", {})
+        assert body["start"]["dateTime"] == "2026-03-17"
+        assert body["end"]["dateTime"] == "2026-03-22"  # +1 day
+        assert body["isAllDay"] is True
+
 
 class TestRsvp:
     async def test_modify_level_required(self):


### PR DESCRIPTION
The six follow-ups from the PR #51 reviews, TDD'd one at a time, plus the o365cal all-day fix and the two Codex findings from the first review round.

| # | Fix | Files |
|---|-----|-------|
| 1 | `save_credentials` creates the file `0600` via `os.open`/`fchmod` instead of write-then-chmod — no window where the app-specific password is world-readable; also tightens a pre-existing loose file | `auth/caldav.py` |
| 2 | Extracted `_attendees_of()` for the None/single/list `ATTENDEE` coercion duplicated 3× | `adapters/caldav_cal.py` |
| 3 | All-day `update_event` converts the user's inclusive end date to the exclusive end the API/iCal expect — matching `create_event`. Fixed in gcal, caldav **and** o365cal (which also never set `isAllDay`) | `adapters/gcal.py`, `adapters/caldav_cal.py`, `adapters/o365cal.py` |
| 4 | `list_calendars` drops collections that can't hold VEVENTs (Apple's legacy Reminders collections that showed as "Reminders ⚠️" / "null ⚠️"), failing open if the server refuses the propfind | `adapters/caldav_cal.py` |
| 5 | `cal` commands route `--source` through `_resolve_prefixes`, so `--source apple`/`icloud` reach caldav sources instead of silently returning `[]` | `commands.py` |
| 6 | `ts4k auth <caldav-prefix>` explains the app-specific-password flow instead of "unknown provider 'caldav' — skipping" | `cli.py` |

## Review round 1 (Codex, both confirmed and fixed in 9020997)

- **Exact-case prefixes**: `_resolve_prefixes` lowercased the requested source, so a prefix added as `Work` stopped resolving once cal commands routed through it. Exact configured key now wins before alias normalization.
- **Dead-end re-auth instruction**: `src add` only prompts when no credential is stored, so a revoked password made the printed re-run a no-op. The message now names the credentials file to delete first, matching the adapter's existing `AuthorizationError` wording.

## Verification

- `uv run --extra dev pytest` — 872 passed, 4 skipped; CI green on 3.12 / 3.13 / 3.14
- Live read-only against the real iCloud account:
  - `ts4k cal week --source apple` now returns events (was `[]`)
  - `list_calendars` returns only the three VEVENT collections; both `⚠️` entries are gone

## Out of scope / noted

- UTC-storage retrofit is issue #54 (needs a spec first).
- Making `ts4k auth <caldav-prefix>` re-prompt interactively (rather than pointing at the file to delete) would mean extracting the prompt/validate/discard loop out of `_cmd_sources` — deliberately left for a follow-up.
- Still pending as a live check, not code: RSVP against a real externally-organized invite.
- `todos.md` is untouched here — the pending edit lives uncommitted in the main checkout for the publish flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)