### PR TITLE
Filter WhatsApp group system notifications from listings

### DIFF
--- a/src/ts4k/adapters/whatsapp.py
+++ b/src/ts4k/adapters/whatsapp.py
@@ -91,10 +91,25 @@ def _wa_msg_to_dict(msg: dict, prefix: str) -> dict:
     return result
 
 
+def _is_system_notification(msg: dict) -> bool:
+    """True for system/protocol events (e.g. "group members have changed").
+
+    These carry no text content and no media attachment, unlike every real
+    message. The upstream bridge also mixes up the sender/chat-name fields
+    for these events, so FROM/SUBJECT can't be trusted for them — filtering
+    them out avoids surfacing the swapped mapping entirely.
+    """
+    return not msg.get("content") and not msg.get("media_type")
+
+
 def parse_list_messages_response(text: str, prefix: str) -> list[dict]:
     """Parse structured JSON dicts from whatsapp-mcp list_messages."""
     items = _parse_ndjson(text)
-    return [_wa_msg_to_dict(msg, prefix) for msg in items]
+    return [
+        _wa_msg_to_dict(msg, prefix)
+        for msg in items
+        if not _is_system_notification(msg)
+    ]
 
 
 def _parse_ndjson(text: str) -> list[dict]:

--- a/tests/test_whatsapp_adapter.py
+++ b/tests/test_whatsapp_adapter.py
@@ -1,0 +1,124 @@
+"""Tests for the WhatsApp adapter's message parsing (issue #11).
+
+Covers the FROM/SUBJECT mapping for regular group messages and DMs, and
+the filtering of system/membership-change notifications (which arrive
+with swapped sender/chat-name fields from the upstream bridge).
+"""
+
+import json
+
+from ts4k.adapters.whatsapp import parse_list_messages_response
+
+
+def _ndjson(*msgs: dict) -> str:
+    return "\n".join(json.dumps(m) for m in msgs)
+
+
+def test_regular_group_message_maps_sender_to_from_and_group_to_subject():
+    text = _ndjson({
+        "id": "ABC123",
+        "timestamp": "2026-08-01 10:00:00",
+        "sender_jid": "15551234567@s.whatsapp.net",
+        "sender_name": "Guy",
+        "chat_jid": "120363000000000000@g.us",
+        "chat_name": "SC26 core group",
+        "content": "hey everyone",
+        "is_from_me": False,
+    })
+
+    result = parse_list_messages_response(text, "w")
+
+    assert len(result) == 1
+    assert result[0]["from"] == "Guy"
+    assert result[0]["subject"] == "SC26 core group"
+    assert result[0]["body"] == "hey everyone"
+
+
+def test_dm_maps_sender_to_from_and_contact_to_subject():
+    text = _ndjson({
+        "id": "DEF456",
+        "timestamp": "2026-08-01 11:00:00",
+        "sender_jid": "15559876543@s.whatsapp.net",
+        "sender_name": "Mom",
+        "chat_jid": "15559876543@s.whatsapp.net",
+        "chat_name": "Mom",
+        "content": "call me later",
+        "is_from_me": False,
+    })
+
+    result = parse_list_messages_response(text, "w")
+
+    assert len(result) == 1
+    assert result[0]["from"] == "Mom"
+    assert result[0]["subject"] == "Mom"
+
+
+def test_membership_change_notification_is_filtered_out():
+    # Upstream reports these with the group name in sender_name and the
+    # member's name in chat_name (swapped), and no content/media — this
+    # is what distinguishes them from real messages.
+    text = _ndjson({
+        "id": "GHI789",
+        "timestamp": "2026-08-01 12:00:00",
+        "sender_jid": "120363111111111111@g.us",
+        "sender_name": "Book Club \U0001f4d6\U0001f377",
+        "chat_jid": "120363111111111111@g.us",
+        "chat_name": "Christoph Hartmann",
+        "content": "",
+        "is_from_me": False,
+    })
+
+    result = parse_list_messages_response(text, "w")
+
+    assert result == []
+
+
+def test_membership_notification_filtered_but_real_message_in_same_batch_kept():
+    text = _ndjson(
+        {
+            "id": "GHI789",
+            "timestamp": "2026-08-01 12:00:00",
+            "sender_jid": "120363111111111111@g.us",
+            "sender_name": "Book Club \U0001f4d6\U0001f377",
+            "chat_jid": "120363111111111111@g.us",
+            "chat_name": "Christoph Hartmann",
+            "content": "",
+            "is_from_me": False,
+        },
+        {
+            "id": "ABC123",
+            "timestamp": "2026-08-01 10:00:00",
+            "sender_jid": "15551234567@s.whatsapp.net",
+            "sender_name": "Guy",
+            "chat_jid": "120363000000000000@g.us",
+            "chat_name": "SC26 core group",
+            "content": "hey everyone",
+            "is_from_me": False,
+        },
+    )
+
+    result = parse_list_messages_response(text, "w")
+
+    assert len(result) == 1
+    assert result[0]["from"] == "Guy"
+    assert result[0]["subject"] == "SC26 core group"
+
+
+def test_media_message_with_empty_content_is_not_filtered():
+    text = _ndjson({
+        "id": "JKL012",
+        "timestamp": "2026-08-01 13:00:00",
+        "sender_jid": "15551234567@s.whatsapp.net",
+        "sender_name": "Guy",
+        "chat_jid": "120363000000000000@g.us",
+        "chat_name": "SC26 core group",
+        "content": "",
+        "media_type": "image",
+        "is_from_me": False,
+    })
+
+    result = parse_list_messages_response(text, "w")
+
+    assert len(result) == 1
+    assert result[0]["from"] == "Guy"
+    assert result[0]["subject"] == "SC26 core group"


### PR DESCRIPTION
Closes #11

## Problem
WhatsApp "group members have changed" system notifications had FROM and SUBJECT swapped in listings — the group name appeared in FROM and the member name appeared in SUBJECT, making it look like the person sent a message in (or even DM'd from) that group.

## Fix
Filter these system/protocol notifications out of `whatsnew`/`list_messages` entirely (the issue's preferred option 1 — they're non-actionable noise). Detection: a message with no text content AND no media attachment is classified as a system event (every real message has one or the other) and is dropped before FROM/SUBJECT mapping, so the swapped fields never reach listings. Thread/context reads are untouched — full history stays intact.

## Testing
New `tests/test_whatsapp_adapter.py`:
- Regular group message maps FROM=sender, SUBJECT=group correctly
- DM maps FROM=sender, SUBJECT=contact correctly
- Membership-change notification (empty content, no media) is filtered
- Filtering doesn't drop real messages in the same batch
- Media message with empty caption is NOT filtered (media_type set)

Full suite: 896 passed, 4 skipped.

**Caveat:** detection is content-shape-based (no explicit `is_system` field exists in the bridge payload). Worth a sanity pass against live bridge output after tomorrow's whatsapp-mcp deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)