### PR TITLE
feat: thread-level operations for manage and listings

### DIFF
--- a/src/ts4k/adapters/base.py
+++ b/src/ts4k/adapters/base.py
@@ -161,6 +161,19 @@ class BaseAdapter(ABC):
         """Move a message to trash (recoverable)."""
         raise NotImplementedError(f"{type(self).__name__} does not support trash")
 
+    async def modify_thread(
+        self, thread_id: str, action: str, label: str | None = None
+    ) -> dict:
+        """Apply a management *action* to every message in a thread.
+
+        *action* is one of the manage actions: archive, unarchive, label,
+        unlabel, read, unread, trash.  Implementations must do this in a
+        single platform call, not a per-message loop.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support thread operations"
+        )
+
     async def list_labels(self) -> list[dict]:
         """List available labels/categories/folders."""
         raise NotImplementedError(f"{type(self).__name__} does not support list_labels")

--- a/src/ts4k/adapters/gmail.py
+++ b/src/ts4k/adapters/gmail.py
@@ -245,6 +245,15 @@ def _thread_to_dict(thread: dict, prefix: str) -> dict:
     }
 
 
+# Thread action -> (modify body key, label ID, result status).
+_THREAD_LABEL_OPS: dict[str, tuple[str, str, str]] = {
+    "archive": ("removeLabelIds", "INBOX", "archived"),
+    "unarchive": ("addLabelIds", "INBOX", "unarchived"),
+    "read": ("removeLabelIds", "UNREAD", "marked_read"),
+    "unread": ("addLabelIds", "UNREAD", "marked_unread"),
+}
+
+
 # ---------------------------------------------------------------------------
 # Adapter
 # ---------------------------------------------------------------------------
@@ -694,6 +703,47 @@ class GmailAdapter(BaseAdapter):
             ).execute()
         )
         return {"id": f"{self._prefix}:{raw_id}", "status": "trashed"}
+
+    async def modify_thread(
+        self, thread_id: str, action: str, label: str | None = None
+    ) -> dict:
+        """Apply *action* to every message in a thread with one API call.
+
+        Gmail shows a thread in the inbox while *any* of its messages carries
+        INBOX, so per-message archiving leaves threads behind — threads.modify
+        covers the whole conversation.
+        """
+        self._check_modify(action)
+        service = self._require_service()
+        raw_id = self._strip_prefix(thread_id)
+        result = {"id": f"{self._prefix}:{raw_id}"}
+
+        if action == "trash":
+            await asyncio.to_thread(
+                lambda: service.users().threads().trash(
+                    userId="me", id=raw_id,
+                ).execute()
+            )
+            return {**result, "status": "trashed"}
+
+        if action in ("label", "unlabel"):
+            if not label:
+                raise ValueError(f"{action} requires a label")
+            label_id = await self._resolve_label_id(label, create=action == "label")
+            key = "addLabelIds" if action == "label" else "removeLabelIds"
+            status = "labeled" if action == "label" else "unlabeled"
+            result["label"] = label
+        elif action in _THREAD_LABEL_OPS:
+            key, label_id, status = _THREAD_LABEL_OPS[action]
+        else:
+            raise ValueError(f"Action {action!r} is not supported at thread level")
+
+        await asyncio.to_thread(
+            lambda: service.users().threads().modify(
+                userId="me", id=raw_id, body={key: [label_id]},
+            ).execute()
+        )
+        return {**result, "status": status}
 
     async def list_labels(self) -> list[dict]:
         self._check_modify("list_labels")

--- a/src/ts4k/cli.py
+++ b/src/ts4k/cli.py
@@ -89,6 +89,7 @@ def _suggest_ref_table(ref: str, current_key: str | None, cmd: str = "get") -> s
 async def _cmd_whatsnew(args: argparse.Namespace) -> None:
     refs = RefTable()
     refs.load(_refs_path(args.key))  # load existing, accumulate
+    threads = getattr(args, "threads", False)
     result = await commands.whatsnew(
         key=args.key,
         source=getattr(args, "source", None),
@@ -96,13 +97,17 @@ async def _cmd_whatsnew(args: argparse.Namespace) -> None:
         fmt=getattr(args, "format", "pipe") or "pipe",
         filter=getattr(args, "filter", False),
         ref_table=refs,
+        threads=threads,
     )
     if result.error:
         print(result.error)
         return
     refs.save(_refs_path(args.key))  # save accumulated
     print(result.output)
-    print(f"→ ts4k get -k {args.key} N to read message N")
+    if threads:
+        print(f"→ ts4k thread -k {args.key} N to read thread N")
+    else:
+        print(f"→ ts4k get -k {args.key} N to read message N")
 
 
 async def _cmd_get(args: argparse.Namespace) -> None:
@@ -155,6 +160,7 @@ async def _cmd_list(args: argparse.Namespace) -> None:
     key = getattr(args, "key", None)
     refs = RefTable()
     refs.load(_refs_path(key))
+    threads = getattr(args, "threads", False)
     result = await commands.list_messages(
         source=getattr(args, "source", None),
         query=getattr(args, "query", None),
@@ -165,16 +171,18 @@ async def _cmd_list(args: argparse.Namespace) -> None:
         sender=getattr(args, "sender", None),
         domain=getattr(args, "domain", None),
         since=getattr(args, "since", None),
+        threads=threads,
     )
     if result.error:
         print(result.error)
         return
     refs.save(_refs_path(key))
     print(result.output)
+    cmd, noun = ("thread", "thread") if threads else ("get", "message")
     if key:
-        print(f"→ ts4k get -k {key} N to read message N")
+        print(f"→ ts4k {cmd} -k {key} N to read {noun} N")
     else:
-        print("→ ts4k get N to read message N")
+        print(f"→ ts4k {cmd} N to read {noun} N")
     if result._continuation_hint:
         print(f"→ {result._continuation_hint}  (older messages)")
 
@@ -191,7 +199,7 @@ def _cmd_help(args: argparse.Namespace) -> None:
     print()
     print("Commands:")
     print("  whatsnew KEY [--source S] [-n N]            Check new (keyed watermarks)  [wn]")
-    print("  list [--since T] [-q Q] [--source S] [-n N] [--from/--domain]  Search [l]")
+    print("  list [--since T] [-q Q] [--source S] [-n N] [--from/--domain] [--threads]  Search [l]")
     print("  get [-k KEY] ID                             Read a message               [g]")
     print("  thread [-k KEY] TID                         Read a thread/chat           [t]")
     print("  overview [--source S] [--contact C]         Cache summary (drill-down)   [o]")
@@ -218,6 +226,9 @@ def _cmd_help(args: argparse.Namespace) -> None:
     print("Refs:  listings assign numbers (1, 2, 3...) — use with get/thread/event/manage")
     print("       whatsnew refs accumulate per key; use get -k KEY N to resolve")
     print("       ts4k sources  shows configured source prefixes")
+    print()
+    print("Threads: list/whatsnew --threads  one row per thread; refs resolve to threads")
+    print("         manage ACTION REF --thread  act on every message in the thread (Gmail)")
 
     if not all_cfg:
         print()
@@ -647,6 +658,7 @@ async def _cmd_manage_async(args: argparse.Namespace) -> None:
         folder=getattr(args, "folder", None),
         dry_run=getattr(args, "dry_run", False),
         ref_table=rt,
+        thread=getattr(args, "thread", False),
     )
     print(result)
 
@@ -1288,6 +1300,7 @@ def _build_parser() -> argparse.ArgumentParser:
     wn.add_argument("key", help="Watermark key (e.g. life, peter)")
     wn.add_argument("--count", "-n", type=int, default=20, help="Max messages (default: 20)")
     wn.add_argument("--source", "-s", default="all", help="Source: prefix, provider name, or all")
+    wn.add_argument("--threads", action="store_true", help="One row per thread (refs resolve to threads)")
     _add_common_args(wn)
     wn.set_defaults(func=_cmd_whatsnew)
 
@@ -1340,6 +1353,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "  ts4k l --domain co.com -n 50             # by domain, up to 50\n"
             "  ts4k l -q invoice -s g -n 10             # Gmail search, 10 results\n"
             "  ts4k l --since 6h -s g -k work           # last 6h Gmail, refs under 'work'\n"
+            "  ts4k l --since 2d --threads              # one row per thread\n"
             "  ts4k l -q 'subject:urgent' -f json       # query, JSON output"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -1351,6 +1365,7 @@ def _build_parser() -> argparse.ArgumentParser:
     ls.add_argument("--from", dest="sender", help="Filter by sender email address")
     ls.add_argument("--domain", help="Filter by sender domain (e.g. example.com)")
     ls.add_argument("--key", "-k", help="Accumulate refs under a key (use with get -k KEY N)")
+    ls.add_argument("--threads", action="store_true", help="One row per thread (refs resolve to threads)")
     _add_common_args(ls)
     ls.set_defaults(func=_cmd_list)
 
@@ -1571,6 +1586,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "  ts4k m archive 1,2,3                 # batch archive by ref\n"
             "  ts4k m label 5 --label llm-garbage    # add label by ref\n"
             "  ts4k m read 1,2,3 -k work             # use refs from key 'work'\n"
+            "  ts4k m archive 1 --thread             # archive the whole thread\n"
             "  ts4k m archive g:abc123               # by native ID\n"
             "  ts4k m list-labels g:any               # list labels for source g\n"
             "  ts4k m archive 1 --dry-run             # preview without acting"
@@ -1585,6 +1601,7 @@ def _build_parser() -> argparse.ArgumentParser:
     mg.add_argument("--label", "-l", help="Label/category name (for label/unlabel)")
     mg.add_argument("--folder", help="Folder name (for move, O365)")
     mg.add_argument("--key", "-k", help="Ref key for resolving short refs (e.g. life)")
+    mg.add_argument("--thread", action="store_true", help="Apply to every message in the thread (Gmail only)")
     mg.add_argument("--dry-run", action="store_true", help="Preview actions without executing")
     mg.set_defaults(func=_cmd_manage_async)
 

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -543,6 +543,8 @@ async def _fetch_messages(
                 parts.append(f"--from {sender}")
             if domain:
                 parts.append(f"--domain {domain}")
+            if threads:
+                parts.append("--threads")
             continuation_hint = " ".join(parts)
 
     _record_stats(stat_cmd, truncated, output)
@@ -1835,6 +1837,7 @@ async def manage_message(
             return f"Error listing labels: {e}"
 
     results = []
+    thread_calls: dict[tuple[str, str], tuple[str, dict]] = {}
     for mid in ids:
         prefix = mid.split(":")[0] if ":" in mid else None
         if not prefix:
@@ -1868,7 +1871,16 @@ async def manage_message(
                         results.append(f"{mid}: error — --label required")
                         continue
                     tid = await _thread_id_for(adapter, mid)
+                    key = (prefix, tid)
+                    if key in thread_calls:
+                        first_mid, prev_r = thread_calls[key]
+                        results.append(
+                            f"{mid}: {prev_r.get('status', 'ok')} "
+                            f"(same thread as {first_mid}, already {action}ed)"
+                        )
+                        continue
                     r = await adapter.modify_thread(tid, action, label)
+                    thread_calls[key] = (mid, r)
                 elif action == "archive":
                     r = await adapter.archive_message(mid)
                 elif action == "unarchive":

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -26,6 +26,7 @@ from ts4k.adapters.o365 import O365Adapter, O365AdapterConfig
 from ts4k.adapters.whatsapp import WhatsAppAdapter, WhatsAppAdapterConfig
 from ts4k.core.filter import apply_filters
 from ts4k.core.format import (
+    collapse_threads,
     estimate_size,
     format_event_detail,
     format_events,
@@ -34,6 +35,7 @@ from ts4k.core.format import (
     format_message,
     format_overview,
     format_thread,
+    format_thread_listing,
 )
 from ts4k.core.normalize import normalize, normalize_headers
 from ts4k.state import batch, cache, contacts, filters, sources, stats, watermarks
@@ -427,6 +429,24 @@ async def _fetch_for_source(
         return []
 
 
+def _format_rows(
+    messages: list[dict],
+    fmt: str,
+    ref_table: RefTable | None,
+    threads: bool,
+) -> tuple[str, dict[str, int] | None]:
+    """Format a listing, collapsing to one row per thread when *threads*.
+
+    Returns ``(output, ref_map)``.  In thread mode the refs are assigned to
+    the collapsed rows, so they resolve to threads rather than messages.
+    """
+    rows = collapse_threads(messages) if threads else messages
+    ref_map = ref_table.assign(rows) if ref_table else None
+    if threads:
+        return format_thread_listing(rows, fmt=fmt, ref_map=ref_map), ref_map
+    return format_listing(rows, fmt=fmt, ref_map=ref_map), ref_map
+
+
 async def _fetch_messages(
     since: dict[str, str | None],
     count: int = 20,
@@ -437,6 +457,7 @@ async def _fetch_messages(
     stat_cmd: str = "wn",
     sender: str | None = None,
     domain: str | None = None,
+    threads: bool = False,
 ) -> CommandResult:
     """Shared fetch layer — parallel fetch, collate, format.
 
@@ -449,6 +470,7 @@ async def _fetch_messages(
         filter: Whether to apply skip filters.
         ref_table: Optional ref table for short refs.
         stat_cmd: Stats command label (``"wn"`` or ``"l"``).
+        threads: Collapse the fetched messages into one row per thread.
 
     Returns a CommandResult with ``_messages`` populated (the truncated list).
     Does NOT touch watermarks.
@@ -501,8 +523,7 @@ async def _fetch_messages(
     if not truncated:
         return CommandResult(error="No new messages.")
 
-    ref_map = ref_table.assign(truncated) if ref_table else None
-    output = format_listing(truncated, fmt=fmt, ref_map=ref_map)
+    output, ref_map = _format_rows(truncated, fmt, ref_table, threads)
 
     if has_more:
         output += f"\n--- {remaining} more messages available ---"
@@ -552,6 +573,7 @@ async def updates(
     ref_table: RefTable | None = None,
     sender: str | None = None,
     domain: str | None = None,
+    threads: bool = False,
 ) -> CommandResult:
     """Deprecated — use list_messages(since=...) instead."""
     return await list_messages(
@@ -563,6 +585,7 @@ async def updates(
         ref_table=ref_table,
         sender=sender,
         domain=domain,
+        threads=threads,
     )
 
 
@@ -575,6 +598,7 @@ async def whatsnew(
     ref_table: RefTable | None = None,
     sender: str | None = None,
     domain: str | None = None,
+    threads: bool = False,
 ) -> CommandResult:
     """Fetch new messages using keyed watermarks."""
     from ts4k.state import keyed_watermarks
@@ -598,6 +622,7 @@ async def whatsnew(
         stat_cmd="wn",
         sender=sender,
         domain=domain,
+        threads=threads,
     )
 
     # Advance watermarks per source.
@@ -716,11 +741,15 @@ async def list_messages(
     sender: str | None = None,
     domain: str | None = None,
     since: str | None = None,
+    threads: bool = False,
 ) -> CommandResult:
     """List messages matching filters. All filters stack.
 
     When *since* is provided, uses the time-aware fetch path (adapter.whatsnew
     for O365, after: query for Gmail).  Otherwise uses adapter.list_messages.
+
+    When *threads* is set the result collapses to one row per thread, and the
+    assigned refs resolve to threads.
     """
     if since is not None:
         # Time-aware path — delegate to _fetch_messages which handles
@@ -738,6 +767,7 @@ async def list_messages(
             stat_cmd="l",
             sender=sender,
             domain=domain,
+            threads=threads,
         )
 
     # Query-only path — no time filter.
@@ -778,8 +808,7 @@ async def list_messages(
     if not all_messages:
         return CommandResult(error="No messages found.")
 
-    ref_map = ref_table.assign(all_messages) if ref_table else None
-    output = format_listing(all_messages, fmt=fmt, ref_map=ref_map)
+    output, ref_map = _format_rows(all_messages, fmt, ref_table, threads)
     _record_stats("l", all_messages, output)
 
     return CommandResult(
@@ -1746,6 +1775,23 @@ def manage_cache(
 # ---------------------------------------------------------------------------
 
 
+async def _thread_id_for(adapter: Any, mid: str) -> str:
+    """Map a message ID to its thread ID.
+
+    Cache first; one read as fallback.  A ref from a ``--threads`` listing is
+    already a thread ID — the read fails there, so *mid* passes through.
+    """
+    cached = cache.get_message(mid)
+    tid = (cached or {}).get("thread_id")
+    if tid:
+        return tid
+    try:
+        msg = await adapter.read_message(mid)
+    except Exception:
+        return mid
+    return msg.get("thread_id") or mid
+
+
 async def manage_message(
     action: str,
     msg_id: str,
@@ -1753,11 +1799,15 @@ async def manage_message(
     folder: str | None = None,
     dry_run: bool = False,
     ref_table: RefTable | None = None,
+    thread: bool = False,
 ) -> str:
     """Execute a management action on one or more messages.
 
     msg_id can be comma-separated for batch operations.
     Actions: archive, unarchive, label, unlabel, read, unread, trash, list-labels.
+
+    When *thread* is set the action covers every message in each thread
+    (Gmail only) — one API call per thread.
     """
     # Resolve refs to full IDs
     ids = [_resolve_ref(mid.strip(), ref_table) for mid in msg_id.split(",")]
@@ -1797,7 +1847,8 @@ async def manage_message(
                 detail += f" label={label}"
             if folder:
                 detail += f" folder={folder}"
-            results.append(f"{mid}: would {action}{detail}")
+            scope = " (whole thread)" if thread else ""
+            results.append(f"{mid}: would {action}{scope}{detail}")
             continue
 
         cfg = sources.get(prefix)
@@ -1812,7 +1863,13 @@ async def manage_message(
 
         try:
             async with adapter:
-                if action == "archive":
+                if thread:
+                    if action in ("label", "unlabel") and not label:
+                        results.append(f"{mid}: error — --label required")
+                        continue
+                    tid = await _thread_id_for(adapter, mid)
+                    r = await adapter.modify_thread(tid, action, label)
+                elif action == "archive":
                     r = await adapter.archive_message(mid)
                 elif action == "unarchive":
                     r = await adapter.unarchive_message(mid)
@@ -1843,6 +1900,14 @@ async def manage_message(
                 results.append(f"{mid}: {r.get('status', 'ok')}")
         except PermissionError as e:
             results.append(f"{mid}: {e}")
+        except NotImplementedError as e:
+            if thread:
+                results.append(
+                    f"{mid}: error — thread operations not supported for "
+                    f"source {prefix!r} (Gmail only)"
+                )
+            else:
+                results.append(f"{mid}: error — {e}")
         except Exception as e:
             results.append(f"{mid}: error — {e}")
 
@@ -2014,16 +2079,17 @@ def _sources_needing_auth(all_cfg: dict[str, dict[str, Any]]) -> list[str]:
 def _append_commands(lines: list[str]) -> None:
     """Append command reference to lines."""
     lines.append("COMMANDS:")
-    lines.append("  ts4k list [--since T] [-q Q] [--source S] [-n N] [-k K] [--from ADDR] [--domain D]  Search messages (all filters stack)")
+    lines.append("  ts4k list [--since T] [-q Q] [--source S] [-n N] [-k K] [--from ADDR] [--domain D] [--threads]  Search messages (all filters stack)")
     lines.append("  ts4k whatsnew KEY [--source S] [-n N]            Check new (keyed watermarks)")
     lines.append("  ts4k get [-k KEY] ID                            Read single message body")
     lines.append("  ts4k thread [-k KEY] TID                        Read thread/conversation")
     lines.append("  ts4k overview [--source S] [--contact C]        Cache summary drill-down")
-    lines.append("  ts4k manage ACTION ID [-k KEY] [--label L] [--folder F] [--dry-run]  Manage mailbox (archive, label, read/unread, trash)")
+    lines.append("  ts4k manage ACTION ID [-k KEY] [--label L] [--folder F] [--thread] [--dry-run]  Manage mailbox (archive, label, read/unread, trash)")
     lines.append("  ts4k draft create -s S --to ADDR --subject SUBJ --body TEXT  Create draft (never sends)")
     lines.append("  ts4k status                                     Health, stats, efficiency")
     lines.append("  Access levels: readonly (default), modify (manage), draft (create drafts). Set via: ts4k src add PREFIX PROVIDER level=modify")
     lines.append("  Refs: listings assign numbers (1, 2, ...) — use with get/thread/manage. Refs accumulate across calls.")
+    lines.append("  --threads: one row per thread (refs resolve to threads). --thread on manage acts on the whole thread (Gmail).")
     lines.append("  list refs are global: get N. list/whatsnew -k refs are keyed: get -k KEY N")
     lines.append("  IDs use prefix:id format: g:abc123, o:AAM..., w:3EB...")
     lines.append("  --since: 2d, 6h, 1w, ISO date, or 'all'. --from: sender address. --domain: sender domain.")
@@ -2112,6 +2178,7 @@ def skill_reference(level: str = "basic") -> str:
             "manage actions: archive, unarchive, label, unlabel, read, unread, trash, move, list-labels\n"
             "  manage archive 1,2,3|Batch archive by ref\n"
             "  manage label 5 --label llm-garbage|Add label by ref\n"
+            "  manage archive 1 --thread|Archive every message in the thread\n"
             "  manage read 1,2 -k work --dry-run|Preview with keyed refs\n"
             "draft create -s g --to alice@x.com --subject Hi --body Hello|New draft\n"
             "  draft create -s g --reply-to g:abc --body 'Sounds good!'|Reply draft with threading\n"
@@ -2123,12 +2190,12 @@ def skill_reference(level: str = "basic") -> str:
         )
     return (
         "ts4k \u2014 token-efficient messaging gateway\n"
-        "list [--since T] [-q Q] [--source S] [-n N] [-k KEY] [--from ADDR] [--domain D]|Search messages (all filters stack)\n"
+        "list [--since T] [-q Q] [--source S] [-n N] [-k KEY] [--from ADDR] [--domain D] [--threads]|Search messages (all filters stack; --threads collapses to one row per thread)\n"
         "whatsnew KEY [-n N] [--source S]|New msgs since last check (all sources unless --source)\n"
         "get [-k KEY] REF|Read message (e.g. get 3 or get -k life 7)\n"
         "thread [-k KEY] REF|Read thread (e.g. thread 5)\n"
         "overview [--source S] [--contact C] [--period P]|Cache summary\n"
-        "manage ACTION ID [-k KEY] [--label L] [--folder F] [--dry-run]|Manage mailbox (requires level=modify)\n"
+        "manage ACTION ID [-k KEY] [--label L] [--folder F] [--thread] [--dry-run]|Manage mailbox (requires level=modify; --thread acts on the whole Gmail thread)\n"
         "draft create -s S --to ADDR --subject SUBJ --body TEXT [--reply-to ID]|Create draft (requires level=draft)\n"
         "cal [today|tomorrow|week] [-s SOURCE]|Calendar events (default: today)\n"
         "cal next [N] [-s SOURCE]|Next N events (default 10)\n"

--- a/src/ts4k/core/format.py
+++ b/src/ts4k/core/format.py
@@ -106,7 +106,8 @@ def collapse_threads(messages: list[dict]) -> list[dict]:
                     row["subject"] = msg["subject"]
             if date > row["date"]:
                 row["date"] = date
-                row["snippet"] = msg.get("snippet", "")
+                # WhatsApp rows carry content in "body", not "snippet"
+                row["snippet"] = msg.get("snippet") or msg.get("body", "")
 
     return [rows[tid] for tid in order]
 

--- a/src/ts4k/core/format.py
+++ b/src/ts4k/core/format.py
@@ -56,13 +56,19 @@ def collapse_threads(messages: list[dict]) -> list[dict]:
     not the whole upstream thread — collapsing never costs an API call.
 
     Row ``id`` is the thread ID, so refs assigned to these rows resolve to
-    threads.  Messages with no ``thread_id`` stand alone.
+    threads.  WhatsApp messages carry no ``thread_id``, so a chat-derived key
+    (``source:chat_jid``, matching the adapter's own thread ID format) is used
+    instead when ``chat_jid`` is present.  Messages with neither stand alone.
     """
     rows: dict[str, dict] = {}
     order: list[str] = []
 
     for msg in messages:
-        tid = msg.get("thread_id") or msg.get("id", "")
+        tid = msg.get("thread_id")
+        if not tid and msg.get("chat_jid"):
+            tid = f"{_source(msg)}:{msg['chat_jid']}"
+        if not tid:
+            tid = msg.get("id", "")
         if not tid:
             continue
 

--- a/src/ts4k/core/format.py
+++ b/src/ts4k/core/format.py
@@ -954,7 +954,8 @@ def _thread_listing_xml(threads: list[dict]) -> str:
     ::
 
         <threads>
-        <t id="g:abc" subject="Meeting" who="a@x.com,b@y.com" n="3" from="..." to="..."/>
+        <t id="g:abc" subject="Meeting" who="a@x.com,b@y.com" n="3" from="..." to="..."
+           snip="Latest message text"/>
         </threads>
     """
     lines = ["<threads>"]
@@ -967,6 +968,10 @@ def _thread_listing_xml(threads: list[dict]) -> str:
             f' from={xml_quoteattr(thread.get("first_date", ""))}'
             f' to={xml_quoteattr(thread.get("date", ""))}'
         )
+        # Emitted only when there is one, matching the JSON listing — an empty
+        # attribute on every row is pure token cost.
+        if thread.get("snippet"):
+            attrs += f' snip={xml_quoteattr(thread["snippet"])}'
         lines.append(f"<t{attrs}/>")
     lines.append("</threads>")
     return "\n".join(lines)

--- a/src/ts4k/core/format.py
+++ b/src/ts4k/core/format.py
@@ -47,6 +47,87 @@ def format_listing(
         raise ValueError(f"Unknown format: {fmt!r}")
 
 
+def collapse_threads(messages: list[dict]) -> list[dict]:
+    """Collapse message headers into one row per thread.
+
+    Each row carries ``participants`` (unique senders, newest first),
+    ``message_count``, ``first_date``/``date`` (the span) and the latest
+    ``snippet``.  Counts and dates describe the messages in *messages*,
+    not the whole upstream thread — collapsing never costs an API call.
+
+    Row ``id`` is the thread ID, so refs assigned to these rows resolve to
+    threads.  Messages with no ``thread_id`` stand alone.
+    """
+    rows: dict[str, dict] = {}
+    order: list[str] = []
+
+    for msg in messages:
+        tid = msg.get("thread_id") or msg.get("id", "")
+        if not tid:
+            continue
+
+        row = rows.get(tid)
+        if row is None:
+            row = {
+                "id": tid,
+                "thread_id": tid,
+                "source": _source(msg),
+                "subject": msg.get("subject", ""),
+                "participants": [],
+                "message_count": 0,
+                "first_date": "",
+                "date": "",
+                "snippet": "",
+                "unread": False,
+            }
+            rows[tid] = row
+            order.append(tid)
+
+        row["message_count"] += 1
+        sender = msg.get("from", "")
+        if sender and sender not in row["participants"]:
+            row["participants"].append(sender)
+        if msg.get("unread"):
+            row["unread"] = True
+
+        date = msg.get("date", "")
+        if date:
+            # Oldest message owns the subject (no "Re:" pile-up), newest
+            # owns the snippet.
+            if not row["first_date"] or date < row["first_date"]:
+                row["first_date"] = date
+                if msg.get("subject"):
+                    row["subject"] = msg["subject"]
+            if date > row["date"]:
+                row["date"] = date
+                row["snippet"] = msg.get("snippet", "")
+
+    return [rows[tid] for tid in order]
+
+
+def format_thread_listing(
+    threads: list[dict],
+    fmt: str = "pipe",
+    ref_map: dict[str, int] | None = None,
+) -> str:
+    """Format collapsed thread rows as produced by :func:`collapse_threads`.
+
+    *fmt*: ``'pipe'``, ``'json'``, ``'xml'``.
+    *ref_map*: ``{thread_id: ref_num}`` — when provided, pipe format uses
+    ``N`` short refs instead of full thread IDs.
+    """
+    fmt = _resolve_fmt(fmt)
+
+    if fmt == "pipe":
+        return _thread_listing_pipe(threads, ref_map=ref_map)
+    elif fmt == "json":
+        return _thread_listing_json(threads)
+    elif fmt == "xml":
+        return _thread_listing_xml(threads)
+    else:
+        raise ValueError(f"Unknown format: {fmt!r}")
+
+
 def format_message(message: dict, fmt: str = "pipe") -> str:
     """Format a single message with body.
 
@@ -542,6 +623,70 @@ def _listing_pipe_refs(messages: list[dict], ref_map: dict[str, int]) -> str:
     return "\n".join(lines)
 
 
+# Senders listed in full on a thread row before falling back to "+N".
+_MAX_PARTICIPANTS = 3
+
+
+def _participants(thread: dict) -> str:
+    """Senders, truncated to ``_MAX_PARTICIPANTS`` with a ``+N`` tail."""
+    names = thread.get("participants", [])
+    shown = names[:_MAX_PARTICIPANTS]
+    extra = len(names) - len(shown)
+    joined = ",".join(shown)
+    return f"{joined}+{extra}" if extra else joined
+
+
+def _date_range(thread: dict, precision: str) -> str:
+    """``18Feb-20Feb`` for a multi-day thread, one timestamp for a single day."""
+    last = thread.get("date", "")
+    first = thread.get("first_date", "") or last
+    if first[:10] == last[:10]:
+        return _compact_ts(last, precision)
+    first_dt, last_dt = _parse_iso(first), _parse_iso(last)
+    if first_dt is None or last_dt is None:
+        return _compact_ts(last, precision)
+    return f"{_date_label(first_dt, precision)}-{_date_label(last_dt, precision)}"
+
+
+def _thread_listing_pipe(
+    threads: list[dict],
+    ref_map: dict[str, int] | None = None,
+) -> str:
+    """Pipe-delimited thread listing — one row per thread."""
+    # Precision has to see both ends of every span, not just the latest.
+    precision = _detect_precision(
+        [
+            {"date": d}
+            for t in threads
+            for d in (t.get("first_date", ""), t.get("date", ""))
+            if d
+        ]
+    )
+    has_snippets = any(t.get("snippet") for t in threads)
+
+    header = f" |{'N' if ref_map is not None else 'ID'}|SOURCE|WHO|SUBJECT|DATES|MSGS"
+    if has_snippets:
+        header += "|SNIPPET"
+    lines = [header]
+
+    for thread in threads:
+        tid = thread.get("id", "")
+        ident = str(ref_map.get(tid, 0)) if ref_map is not None else tid
+        row = (
+            f"{_unread_marker(thread)}|{ident}|{_source(thread)}|{_participants(thread)}"
+            f"|{thread.get('subject', '')}|{_date_range(thread, precision)}"
+            f"|{thread.get('message_count', 0)}"
+        )
+        if has_snippets:
+            snippet = thread.get("snippet", "").strip()
+            if len(snippet) > 80:
+                snippet = snippet[:77].rstrip() + "..."
+            row += f"|{snippet}"
+        lines.append(row)
+
+    return "\n".join(lines)
+
+
 def _message_pipe(message: dict) -> str:
     """Pipe-delimited single message with body.
 
@@ -707,6 +852,27 @@ def _listing_json(messages: list[dict]) -> str:
     return json.dumps(items, separators=(",", ":"))
 
 
+def _thread_listing_json(threads: list[dict]) -> str:
+    """Compact JSON array of collapsed thread rows."""
+    items = []
+    for thread in threads:
+        item: dict = {
+            "source": _source(thread),
+            "subject": thread.get("subject", ""),
+            "participants": thread.get("participants", []),
+            "message_count": thread.get("message_count", 0),
+            "first_date": thread.get("first_date", ""),
+            "date": thread.get("date", ""),
+            "id": thread.get("id", ""),
+        }
+        if thread.get("snippet"):
+            item["snippet"] = thread["snippet"]
+        if "unread" in thread:
+            item["unread"] = thread["unread"]
+        items.append(item)
+    return json.dumps(items, separators=(",", ":"))
+
+
 def _message_json(message: dict) -> str:
     """Compact JSON for a single message with body."""
     obj: dict = {
@@ -772,6 +938,30 @@ def _listing_xml(messages: list[dict]) -> str:
         )
         lines.append(f"<m{attrs}/>")
     lines.append("</msgs>")
+    return "\n".join(lines)
+
+
+def _thread_listing_xml(threads: list[dict]) -> str:
+    """XML thread listing — one self-closing tag per thread.
+
+    ::
+
+        <threads>
+        <t id="g:abc" subject="Meeting" who="a@x.com,b@y.com" n="3" from="..." to="..."/>
+        </threads>
+    """
+    lines = ["<threads>"]
+    for thread in threads:
+        attrs = (
+            f' id={xml_quoteattr(thread.get("id", ""))}'
+            f' subject={xml_quoteattr(thread.get("subject", ""))}'
+            f' who={xml_quoteattr(",".join(thread.get("participants", [])))}'
+            f' n={xml_quoteattr(str(thread.get("message_count", 0)))}'
+            f' from={xml_quoteattr(thread.get("first_date", ""))}'
+            f' to={xml_quoteattr(thread.get("date", ""))}'
+        )
+        lines.append(f"<t{attrs}/>")
+    lines.append("</threads>")
     return "\n".join(lines)
 
 

--- a/src/ts4k/server.py
+++ b/src/ts4k/server.py
@@ -115,6 +115,7 @@ async def list_tool(
     count: int = 20,
     fmt: str = "pipe",
     filter: bool = False,
+    threads: bool = False,
 ) -> str:
     """Search and list messages. All filters stack.
 
@@ -129,6 +130,7 @@ async def list_tool(
         count: Maximum messages to return (default 20).
         fmt: Output format — "pipe" (default, most compact), "json", or "xml".
         filter: Apply configured skip filters (default off).
+        threads: Collapse to one row per thread; refs then resolve to threads.
     """
     result = await commands.list_messages(
         source=source,
@@ -140,6 +142,7 @@ async def list_tool(
         fmt=fmt,
         filter=filter,
         ref_table=_refs,
+        threads=threads,
     )
     if result.error:
         return result.error
@@ -219,6 +222,7 @@ async def manage(
     label: str | None = None,
     folder: str | None = None,
     dry_run: bool = False,
+    thread: bool = False,
 ) -> str:
     """Manage mailbox: archive, label, mark read/unread, trash.
 
@@ -231,6 +235,7 @@ async def manage(
         label: Label/category name (required for label/unlabel).
         folder: Folder name (required for move, O365 only).
         dry_run: Preview actions without executing (default false).
+        thread: Apply to every message in the thread, one call (Gmail only).
     """
     return await commands.manage_message(
         action=action,
@@ -239,6 +244,7 @@ async def manage(
         folder=folder,
         dry_run=dry_run,
         ref_table=_refs,
+        thread=thread,
     )
 
 

--- a/src/ts4k/server.py
+++ b/src/ts4k/server.py
@@ -54,6 +54,7 @@ async def whatsnew(
     count: int = 20,
     fmt: str = "pipe",
     filter: bool = False,
+    threads: bool = False,
 ) -> str:
     """Check for new messages using keyed watermarks.
 
@@ -67,10 +68,11 @@ async def whatsnew(
         count: Maximum messages to return (default 20).
         fmt: Output format — "pipe" (default, most compact), "json", or "xml".
         filter: Apply configured skip filters (default off).
+        threads: Collapse to one row per thread; refs then resolve to threads.
     """
     result = await commands.whatsnew(
         key=key, source=source, count=count, fmt=fmt,
-        filter=filter, ref_table=_refs,
+        filter=filter, ref_table=_refs, threads=threads,
     )
     if result.error:
         return result.error

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -175,6 +175,55 @@ class TestToolRegistration:
 
 
 # ---------------------------------------------------------------------------
+# whatsnew --threads forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestWhatsnewThreadsForwarding:
+    @pytest.mark.asyncio
+    async def test_whatsnew_forwards_threads_true(self, monkeypatch):
+        """The whatsnew tool wrapper must pass threads through to
+        commands.whatsnew — it can't reach thread mode otherwise."""
+        from ts4k import server
+        from ts4k.commands import CommandResult
+
+        captured = {}
+
+        async def fake_whatsnew(**kwargs):
+            captured.update(kwargs)
+            return CommandResult(output="ok")
+
+        monkeypatch.setattr(server.commands, "whatsnew", fake_whatsnew)
+
+        await server.whatsnew(key="life", threads=True)
+
+        assert captured.get("threads") is True
+
+    @pytest.mark.asyncio
+    async def test_whatsnew_threads_defaults_false(self, monkeypatch):
+        from ts4k import server
+        from ts4k.commands import CommandResult
+
+        captured = {}
+
+        async def fake_whatsnew(**kwargs):
+            captured.update(kwargs)
+            return CommandResult(output="ok")
+
+        monkeypatch.setattr(server.commands, "whatsnew", fake_whatsnew)
+
+        await server.whatsnew(key="life")
+
+        assert captured.get("threads") is False
+
+    def test_whatsnew_schema_has_threads_param(self):
+        """CLI/MCP parity: --threads on the CLI implies a threads param here."""
+        tool = mcp._tool_manager._tools["whatsnew"]
+        props = tool.parameters.get("properties", {})
+        assert "threads" in props
+
+
+# ---------------------------------------------------------------------------
 # Admin tool routing
 # ---------------------------------------------------------------------------
 

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,0 +1,562 @@
+# tests/test_threads.py
+"""Tests for thread-level operations (#20).
+
+Covers the Gmail threads.modify adapter path, thread-collapsed listings,
+ref resolution to threads, and the non-Gmail error surface.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ts4k.adapters.gmail import GmailAdapter, GmailAdapterConfig
+from ts4k.commands import manage_message
+from ts4k.core.format import collapse_threads, format_listing, format_thread_listing
+from ts4k.state.refs import RefTable
+
+
+# ---------------------------------------------------------------------------
+# Test data — one 4-message thread plus a standalone message
+# ---------------------------------------------------------------------------
+
+# From-fields are bare addresses: normalize_headers strips display names
+# before any of this runs.  Newest first, as listings are sorted.
+THREAD_MESSAGES = [
+    {
+        "id": "g:m4",
+        "thread_id": "g:t1",
+        "from": "alice@acme.com",
+        "subject": "Re: Q3 planning",
+        "date": "2026-02-20T16:00:00Z",
+        "snippet": "Agreed, let's lock the room for Thursday.",
+        "source": "g",
+        "unread": True,
+    },
+    {
+        "id": "g:m3",
+        "thread_id": "g:t1",
+        "from": "carol@acme.com",
+        "subject": "Re: Q3 planning",
+        "date": "2026-02-19T11:30:00Z",
+        "snippet": "I can join after 2pm.",
+        "source": "g",
+    },
+    {
+        "id": "g:m2",
+        "thread_id": "g:t1",
+        "from": "bob@corp.com",
+        "subject": "Re: Q3 planning",
+        "date": "2026-02-18T09:05:00Z",
+        "snippet": "Numbers attached.",
+        "source": "g",
+    },
+    {
+        "id": "g:m1",
+        "thread_id": "g:t1",
+        "from": "alice@acme.com",
+        "subject": "Q3 planning",
+        "date": "2026-02-18T08:00:00Z",
+        "snippet": "Kicking this off.",
+        "source": "g",
+    },
+    {
+        "id": "g:solo",
+        "thread_id": "g:t2",
+        "from": "newsletter@example.com",
+        "subject": "Weekly digest",
+        "date": "2026-02-17T06:00:00Z",
+        "snippet": "This week in widgets.",
+        "source": "g",
+    },
+]
+
+
+@pytest.fixture
+def gmail_modify():
+    """GmailAdapter at modify level with a mocked service."""
+    adapter = GmailAdapter(
+        GmailAdapterConfig(user_email="test@gmail.com", level="modify"),
+        prefix="g",
+    )
+    adapter._service = MagicMock()
+    return adapter
+
+
+@pytest.fixture
+def gmail_source(monkeypatch, tmp_path):
+    """Isolated config dir with a single Gmail source at modify level."""
+    monkeypatch.setenv("TS4K_CONFIG_DIR", str(tmp_path))
+    from ts4k.state import cache, sources, stats
+
+    monkeypatch.setattr(sources, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(sources, "_SOURCES_FILE", tmp_path / "sources.json")
+    monkeypatch.setattr(stats, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(stats, "_STATS_FILE", tmp_path / "stats.json")
+    monkeypatch.setattr(cache, "_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path / "cache")
+    monkeypatch.setattr(cache, "_INDEX_FILE", tmp_path / "cache" / "index.json")
+    monkeypatch.setattr(cache, "_BODIES_DIR", tmp_path / "cache" / "bodies")
+    sources.add("g", provider="gmail", email="a@b.com", level="modify")
+    return sources
+
+
+# ---------------------------------------------------------------------------
+# Adapter — threads.modify
+# ---------------------------------------------------------------------------
+
+
+class TestGmailModifyThread:
+    @pytest.mark.asyncio
+    async def test_archive_removes_inbox_from_whole_thread(self, gmail_modify):
+        svc = gmail_modify._service
+        svc.users().threads().modify().execute.return_value = {"id": "t1"}
+
+        result = await gmail_modify.modify_thread("g:t1", "archive")
+
+        svc.users().threads().modify.assert_called_with(
+            userId="me", id="t1", body={"removeLabelIds": ["INBOX"]},
+        )
+        assert result == {"id": "g:t1", "status": "archived"}
+
+    @pytest.mark.asyncio
+    async def test_archive_is_one_api_call(self, gmail_modify):
+        """One threads.modify — never a per-message loop."""
+        svc = gmail_modify._service
+        svc.users().threads().modify().execute.return_value = {"id": "t1"}
+        svc.reset_mock()
+
+        await gmail_modify.modify_thread("g:t1", "archive")
+
+        assert svc.users().threads().modify.call_count == 1
+        assert svc.users().messages().modify.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_unarchive_adds_inbox(self, gmail_modify):
+        svc = gmail_modify._service
+        svc.users().threads().modify().execute.return_value = {"id": "t1"}
+
+        result = await gmail_modify.modify_thread("g:t1", "unarchive")
+
+        svc.users().threads().modify.assert_called_with(
+            userId="me", id="t1", body={"addLabelIds": ["INBOX"]},
+        )
+        assert result["status"] == "unarchived"
+
+    @pytest.mark.asyncio
+    async def test_label_resolves_and_applies_to_thread(self, gmail_modify):
+        svc = gmail_modify._service
+        svc.users().labels().list().execute.return_value = {
+            "labels": [{"id": "Label_7", "name": "llm-garbage"}]
+        }
+        svc.users().threads().modify().execute.return_value = {"id": "t1"}
+
+        result = await gmail_modify.modify_thread("g:t1", "label", "llm-garbage")
+
+        svc.users().threads().modify.assert_called_with(
+            userId="me", id="t1", body={"addLabelIds": ["Label_7"]},
+        )
+        assert result["status"] == "labeled"
+        assert result["label"] == "llm-garbage"
+
+    @pytest.mark.asyncio
+    async def test_unlabel_removes_from_thread(self, gmail_modify):
+        svc = gmail_modify._service
+        svc.users().labels().list().execute.return_value = {
+            "labels": [{"id": "Label_7", "name": "llm-garbage"}]
+        }
+        svc.users().threads().modify().execute.return_value = {"id": "t1"}
+
+        result = await gmail_modify.modify_thread("g:t1", "unlabel", "llm-garbage")
+
+        svc.users().threads().modify.assert_called_with(
+            userId="me", id="t1", body={"removeLabelIds": ["Label_7"]},
+        )
+        assert result["status"] == "unlabeled"
+
+    @pytest.mark.asyncio
+    async def test_label_without_name_raises(self, gmail_modify):
+        with pytest.raises(ValueError, match="requires a label"):
+            await gmail_modify.modify_thread("g:t1", "label")
+
+    @pytest.mark.asyncio
+    async def test_read_and_unread(self, gmail_modify):
+        svc = gmail_modify._service
+        svc.users().threads().modify().execute.return_value = {"id": "t1"}
+
+        assert (await gmail_modify.modify_thread("g:t1", "read"))["status"] == "marked_read"
+        svc.users().threads().modify.assert_called_with(
+            userId="me", id="t1", body={"removeLabelIds": ["UNREAD"]},
+        )
+
+        assert (await gmail_modify.modify_thread("g:t1", "unread"))["status"] == "marked_unread"
+        svc.users().threads().modify.assert_called_with(
+            userId="me", id="t1", body={"addLabelIds": ["UNREAD"]},
+        )
+
+    @pytest.mark.asyncio
+    async def test_trash_uses_threads_trash(self, gmail_modify):
+        svc = gmail_modify._service
+        svc.users().threads().trash().execute.return_value = {"id": "t1"}
+
+        result = await gmail_modify.modify_thread("g:t1", "trash")
+
+        svc.users().threads().trash.assert_called_with(userId="me", id="t1")
+        assert result["status"] == "trashed"
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_raises(self, gmail_modify):
+        with pytest.raises(ValueError, match="not supported at thread level"):
+            await gmail_modify.modify_thread("g:t1", "move")
+
+    @pytest.mark.asyncio
+    async def test_blocked_at_readonly(self):
+        adapter = GmailAdapter(
+            GmailAdapterConfig(user_email="test@gmail.com"), prefix="g",
+        )
+        adapter._service = MagicMock()
+        with pytest.raises(PermissionError, match="level='modify'"):
+            await adapter.modify_thread("g:t1", "archive")
+
+
+# ---------------------------------------------------------------------------
+# manage --thread
+# ---------------------------------------------------------------------------
+
+
+class TestManageThread:
+    @pytest.mark.asyncio
+    async def test_archive_thread_resolves_message_to_thread(self, gmail_source):
+        """A ref pointing at a message archives that message's thread."""
+        mock_adapter = AsyncMock()
+        mock_adapter.modify_thread.return_value = {"id": "g:t1", "status": "archived"}
+        mock_adapter.read_message.return_value = {"id": "g:m4", "thread_id": "g:t1"}
+
+        with patch("ts4k.commands._make_adapter", return_value=mock_adapter), \
+                patch("ts4k.commands.cache.get_message", return_value=None):
+            result = await manage_message(action="archive", msg_id="g:m4", thread=True)
+
+        mock_adapter.modify_thread.assert_awaited_once_with("g:t1", "archive", None)
+        assert "archived" in result
+
+    @pytest.mark.asyncio
+    async def test_thread_id_comes_from_cache_without_a_read(self, gmail_source):
+        mock_adapter = AsyncMock()
+        mock_adapter.modify_thread.return_value = {"id": "g:t1", "status": "archived"}
+
+        with patch("ts4k.commands._make_adapter", return_value=mock_adapter), \
+                patch("ts4k.commands.cache.get_message",
+                      return_value={"id": "g:m4", "thread_id": "g:t1"}):
+            await manage_message(action="archive", msg_id="g:m4", thread=True)
+
+        mock_adapter.read_message.assert_not_awaited()
+        mock_adapter.modify_thread.assert_awaited_once_with("g:t1", "archive", None)
+
+    @pytest.mark.asyncio
+    async def test_thread_ref_passes_through(self, gmail_source):
+        """A ref from a --threads listing is already a thread ID."""
+        mock_adapter = AsyncMock()
+        mock_adapter.modify_thread.return_value = {"id": "g:t1", "status": "archived"}
+        mock_adapter.read_message.side_effect = Exception("not a message")
+
+        with patch("ts4k.commands._make_adapter", return_value=mock_adapter), \
+                patch("ts4k.commands.cache.get_message", return_value=None):
+            await manage_message(action="archive", msg_id="g:t1", thread=True)
+
+        mock_adapter.modify_thread.assert_awaited_once_with("g:t1", "archive", None)
+
+    @pytest.mark.asyncio
+    async def test_label_thread(self, gmail_source):
+        mock_adapter = AsyncMock()
+        mock_adapter.modify_thread.return_value = {
+            "id": "g:t1", "status": "labeled", "label": "triage",
+        }
+
+        with patch("ts4k.commands._make_adapter", return_value=mock_adapter), \
+                patch("ts4k.commands.cache.get_message",
+                      return_value={"id": "g:m4", "thread_id": "g:t1"}):
+            result = await manage_message(
+                action="label", msg_id="g:m4", label="triage", thread=True,
+            )
+
+        mock_adapter.modify_thread.assert_awaited_once_with("g:t1", "label", "triage")
+        assert "labeled" in result
+
+    @pytest.mark.asyncio
+    async def test_label_without_name_errors(self, gmail_source):
+        mock_adapter = AsyncMock()
+        with patch("ts4k.commands._make_adapter", return_value=mock_adapter):
+            result = await manage_message(action="label", msg_id="g:m4", thread=True)
+
+        assert "--label required" in result
+        mock_adapter.modify_thread.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_batch_is_one_call_per_thread(self, gmail_source):
+        mock_adapter = AsyncMock()
+        mock_adapter.modify_thread.return_value = {"id": "g:t", "status": "archived"}
+
+        with patch("ts4k.commands._make_adapter", return_value=mock_adapter), \
+                patch("ts4k.commands.cache.get_message",
+                      side_effect=lambda mid: {"id": mid, "thread_id": f"g:t{mid[-1]}"}):
+            result = await manage_message(
+                action="archive", msg_id="g:m1,g:m2", thread=True,
+            )
+
+        assert mock_adapter.modify_thread.await_count == 2
+        assert result.count("archived") == 2
+
+    @pytest.mark.asyncio
+    async def test_dry_run_marks_thread_scope_and_acts_on_nothing(self, gmail_source):
+        mock_adapter = AsyncMock()
+        with patch("ts4k.commands._make_adapter", return_value=mock_adapter):
+            result = await manage_message(
+                action="archive", msg_id="g:m4", thread=True, dry_run=True,
+            )
+
+        assert "would archive (whole thread)" in result
+        mock_adapter.modify_thread.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_gmail_source_gets_clear_error(self, monkeypatch, tmp_path):
+        """O365 has no thread equivalent — say so, don't half-do it."""
+        monkeypatch.setenv("TS4K_CONFIG_DIR", str(tmp_path))
+        from ts4k.state import sources
+
+        monkeypatch.setattr(sources, "_CONFIG_DIR", tmp_path)
+        monkeypatch.setattr(sources, "_SOURCES_FILE", tmp_path / "sources.json")
+        sources.add("o", provider="o365", client_id="cid", level="modify")
+
+        from ts4k.adapters.o365 import O365Adapter, O365AdapterConfig
+
+        adapter = O365Adapter(O365AdapterConfig(client_id="cid", level="modify"), prefix="o")
+        adapter.connect = AsyncMock()
+        adapter.disconnect = AsyncMock()
+        adapter.read_message = AsyncMock(return_value={"id": "o:abc", "thread_id": "o:conv"})
+
+        with patch("ts4k.commands._make_adapter", return_value=adapter), \
+                patch("ts4k.commands.cache.get_message", return_value=None):
+            result = await manage_message(action="archive", msg_id="o:abc", thread=True)
+
+        assert "thread operations not supported" in result
+        assert "'o'" in result
+
+    @pytest.mark.asyncio
+    async def test_message_level_path_is_unchanged(self, gmail_source):
+        """Default (no --thread) still calls the per-message method."""
+        mock_adapter = AsyncMock()
+        mock_adapter.archive_message.return_value = {"id": "g:m4", "status": "archived"}
+
+        with patch("ts4k.commands._make_adapter", return_value=mock_adapter):
+            result = await manage_message(action="archive", msg_id="g:m4")
+
+        mock_adapter.archive_message.assert_awaited_once_with("g:m4")
+        mock_adapter.modify_thread.assert_not_awaited()
+        assert "archived" in result
+
+
+# ---------------------------------------------------------------------------
+# collapse_threads
+# ---------------------------------------------------------------------------
+
+
+class TestCollapseThreads:
+    def test_one_row_per_thread(self):
+        rows = collapse_threads(THREAD_MESSAGES)
+        assert len(rows) == 2
+        assert [r["id"] for r in rows] == ["g:t1", "g:t2"]
+
+    def test_row_carries_count_participants_and_range(self):
+        row = collapse_threads(THREAD_MESSAGES)[0]
+        assert row["message_count"] == 4
+        # Deduplicated (Alice sent twice), newest sender first.
+        assert row["participants"] == [
+            "alice@acme.com",
+            "carol@acme.com",
+            "bob@corp.com",
+        ]
+        assert row["first_date"] == "2026-02-18T08:00:00Z"
+        assert row["date"] == "2026-02-20T16:00:00Z"
+
+    def test_subject_from_oldest_snippet_from_newest(self):
+        row = collapse_threads(THREAD_MESSAGES)[0]
+        assert row["subject"] == "Q3 planning"  # not "Re: Q3 planning"
+        assert row["snippet"] == "Agreed, let's lock the room for Thursday."
+
+    def test_unread_if_any_message_unread(self):
+        rows = collapse_threads(THREAD_MESSAGES)
+        assert rows[0]["unread"] is True
+        assert rows[1]["unread"] is False
+
+    def test_row_id_is_thread_id(self):
+        row = collapse_threads(THREAD_MESSAGES)[0]
+        assert row["id"] == row["thread_id"] == "g:t1"
+
+    def test_message_without_thread_id_stands_alone(self):
+        rows = collapse_threads([{"id": "w:x", "from": "a", "date": "2026-01-01T00:00:00Z"}])
+        assert len(rows) == 1
+        assert rows[0]["id"] == "w:x"
+        assert rows[0]["message_count"] == 1
+
+    def test_empty_input(self):
+        assert collapse_threads([]) == []
+
+
+# ---------------------------------------------------------------------------
+# format_thread_listing
+# ---------------------------------------------------------------------------
+
+
+class TestThreadListingFormat:
+    def test_pipe_row_content(self):
+        rows = collapse_threads(THREAD_MESSAGES)
+        out = format_thread_listing(rows, fmt="pipe", ref_map={"g:t1": 1, "g:t2": 2})
+        lines = out.split("\n")
+
+        assert lines[0] == " |N|SOURCE|WHO|SUBJECT|DATES|MSGS|SNIPPET"
+        assert len(lines) == 3
+
+        fields = lines[1].split("|")
+        assert fields[0] == "*"  # unread marker
+        assert fields[1] == "1"  # ref
+        assert fields[2] == "g"
+        assert fields[3] == "alice@acme.com,carol@acme.com,bob@corp.com"
+        assert fields[4] == "Q3 planning"
+        assert fields[5] == "18Feb-20Feb"  # date range
+        assert fields[6] == "4"  # message count
+
+    def test_single_day_thread_shows_one_timestamp(self):
+        rows = collapse_threads([
+            {"id": "g:a", "thread_id": "g:t", "from": "a@x", "subject": "S",
+             "date": "2026-02-18T08:00:00Z"},
+            {"id": "g:b", "thread_id": "g:t", "from": "b@x", "subject": "Re: S",
+             "date": "2026-02-18T09:30:00Z"},
+        ])
+        out = format_thread_listing(rows, fmt="pipe", ref_map={"g:t": 1})
+        assert "|09:30|2" in out
+        assert "-" not in out.split("\n")[1]
+
+    def test_participants_truncate_with_plus_n(self):
+        msgs = [
+            {"id": f"g:m{i}", "thread_id": "g:t", "from": f"p{i}@x.com",
+             "subject": "S", "date": f"2026-02-1{i}T08:00:00Z"}
+            for i in range(5)
+        ]
+        out = format_thread_listing(collapse_threads(msgs), fmt="pipe", ref_map={"g:t": 1})
+        assert "p0@x.com,p1@x.com,p2@x.com+2" in out
+
+    def test_full_ids_without_ref_map(self):
+        rows = collapse_threads(THREAD_MESSAGES)
+        out = format_thread_listing(rows, fmt="pipe")
+        assert out.split("\n")[0].startswith(" |ID|SOURCE|")
+        assert "|g:t1|" in out
+
+    def test_json_format(self):
+        import json
+
+        rows = collapse_threads(THREAD_MESSAGES)
+        data = json.loads(format_thread_listing(rows, fmt="json"))
+        assert len(data) == 2
+        assert data[0]["id"] == "g:t1"
+        assert data[0]["message_count"] == 4
+        assert len(data[0]["participants"]) == 3
+        assert data[0]["first_date"] == "2026-02-18T08:00:00Z"
+
+    def test_xml_format(self):
+        from xml.etree import ElementTree as ET
+
+        rows = collapse_threads(THREAD_MESSAGES)
+        root = ET.fromstring(format_thread_listing(rows, fmt="xml"))
+        assert root.tag == "threads"
+        assert len(root) == 2
+        assert root[0].get("id") == "g:t1"
+        assert root[0].get("n") == "4"
+
+    def test_unknown_format_raises(self):
+        with pytest.raises(ValueError):
+            format_thread_listing([], fmt="yaml")
+
+
+def _both_formats(messages: list[dict]) -> tuple[str, str]:
+    """Render *messages* per-message and thread-collapsed, both with refs."""
+    per_message = format_listing(
+        messages, fmt="pipe",
+        ref_map={m["id"]: i + 1 for i, m in enumerate(messages)},
+    )
+    rows = collapse_threads(messages)
+    collapsed = format_thread_listing(
+        rows, fmt="pipe", ref_map={r["id"]: i + 1 for i, r in enumerate(rows)},
+    )
+    return per_message, collapsed
+
+
+class TestThreadListingTokenSavings:
+    def test_long_thread_collapses_to_a_fraction(self):
+        """AC: collapsed output is significantly smaller for multi-message threads."""
+        messages = [
+            {
+                "id": f"g:m{i}",
+                "thread_id": "g:t1",
+                "from": f"person{i}@acme.com",
+                "subject": "Re: Q3 planning offsite agenda",
+                "date": f"2026-02-{10 + i:02d}T09:00:00Z",
+                "snippet": f"Reply number {i} with some discussion of the agenda.",
+                "source": "g",
+            }
+            for i in range(10)
+        ]
+        per_message, collapsed = _both_formats(messages)
+
+        # 10 rows -> 1 row; the participant list is capped, so the win scales.
+        assert len(collapsed) < len(per_message) * 0.25, (
+            f"collapsed {len(collapsed)}b vs per-message {len(per_message)}b"
+        )
+        assert len(collapsed.split("\n")) == 2  # header + one thread row
+
+    def test_mixed_listing_still_shrinks(self):
+        per_message, collapsed = _both_formats(THREAD_MESSAGES)
+
+        assert len(collapsed) < len(per_message)
+        assert len(collapsed.split("\n")) < len(per_message.split("\n"))
+
+
+# ---------------------------------------------------------------------------
+# Listing integration — refs resolve to threads
+# ---------------------------------------------------------------------------
+
+
+class TestThreadListingIntegration:
+    @pytest.mark.asyncio
+    async def test_list_threads_assigns_refs_to_threads(self, gmail_source):
+        from ts4k import commands
+
+        mock_adapter = AsyncMock()
+        mock_adapter.list_messages.return_value = THREAD_MESSAGES
+
+        refs = RefTable()
+        with patch("ts4k.commands._make_adapter", return_value=mock_adapter):
+            result = await commands.list_messages(
+                source="g", count=20, ref_table=refs, threads=True,
+            )
+
+        assert result.ref_map == {"g:t1": 1, "g:t2": 2}
+        assert refs.resolve("1") == "g:t1"
+        # 5 messages processed, collapsed to a header plus 2 thread rows.
+        assert result.messages_processed == 5
+        assert len(result.output.split("\n")) == 3
+        assert "|4|" in result.output  # the 4-message thread row
+
+    @pytest.mark.asyncio
+    async def test_message_mode_remains_the_default(self, gmail_source):
+        from ts4k import commands
+
+        mock_adapter = AsyncMock()
+        mock_adapter.list_messages.return_value = THREAD_MESSAGES
+
+        refs = RefTable()
+        with patch("ts4k.commands._make_adapter", return_value=mock_adapter):
+            result = await commands.list_messages(source="g", count=20, ref_table=refs)
+
+        assert result.messages_processed == 5
+        assert refs.resolve("1") == "g:m4"

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -453,6 +453,25 @@ class TestCollapseThreads:
         assert rows[0]["id"] == rows[0]["thread_id"] == "w:123456@g.us"
         assert rows[0]["message_count"] == 2
 
+    def test_whatsapp_snippet_falls_back_to_body(self):
+        """WhatsApp rows carry content in body, not snippet — the latest
+        message's text must still surface on the collapsed row."""
+        wa_messages = [
+            {
+                "id": "w:msg2", "source": "w", "chat_jid": "123456@g.us",
+                "from": "alice", "date": "2026-02-19T10:00:00Z",
+                "body": "See you then.",
+            },
+            {
+                "id": "w:msg1", "source": "w", "chat_jid": "123456@g.us",
+                "from": "bob", "date": "2026-02-18T09:00:00Z",
+                "body": "Kickoff.",
+            },
+        ]
+        rows = collapse_threads(wa_messages)
+        assert len(rows) == 1
+        assert rows[0]["snippet"] == "See you then."
+
     def test_whatsapp_thread_ref_resolves_via_read_thread(self):
         """The derived row id, once stripped of its source prefix, is a chat
         JID — exactly what WhatsAppAdapter.read_thread treats as a chat

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -560,6 +560,31 @@ class TestThreadListingFormat:
         assert root[0].get("id") == "g:t1"
         assert root[0].get("n") == "4"
 
+    def test_xml_carries_the_latest_snippet(self):
+        """XML clients get the same latest-message text pipe and JSON show."""
+        from xml.etree import ElementTree as ET
+
+        msgs = [
+            {"id": "g:m1", "thread_id": "g:t", "from": "a@x.com", "subject": "S",
+             "date": "2026-02-18T08:00:00Z", "snippet": "first"},
+            {"id": "g:m2", "thread_id": "g:t", "from": "b@x.com", "subject": "S",
+             "date": "2026-02-19T08:00:00Z", "snippet": "latest word"},
+        ]
+        root = ET.fromstring(format_thread_listing(collapse_threads(msgs), fmt="xml"))
+        assert root[0].get("snip") == "latest word"
+
+    def test_xml_omits_snip_when_there_is_no_snippet(self):
+        """An empty attribute on every row is pure token cost."""
+        from xml.etree import ElementTree as ET
+
+        msgs = [
+            {"id": "g:m1", "thread_id": "g:t", "from": "a@x.com", "subject": "S",
+             "date": "2026-02-18T08:00:00Z"},
+        ]
+        out = format_thread_listing(collapse_threads(msgs), fmt="xml")
+        assert ET.fromstring(out)[0].get("snip") is None
+        assert "snip=" not in out
+
     def test_unknown_format_raises(self):
         with pytest.raises(ValueError):
             format_thread_listing([], fmt="yaml")

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -308,6 +308,29 @@ class TestManageThread:
         assert result.count("archived") == 2
 
     @pytest.mark.asyncio
+    async def test_two_refs_in_same_thread_dedupe_to_one_call(self, gmail_source):
+        """Two message refs that resolve to the same thread must issue only
+        one modify_thread call — and the second item is reported as covered,
+        not as an error."""
+        mock_adapter = AsyncMock()
+        mock_adapter.modify_thread.return_value = {"id": "g:t1", "status": "trashed"}
+
+        with patch("ts4k.commands._make_adapter", return_value=mock_adapter), \
+                patch("ts4k.commands.cache.get_message",
+                      return_value={"thread_id": "g:t1"}):
+            result = await manage_message(
+                action="trash", msg_id="g:m4,g:m3", thread=True,
+            )
+
+        mock_adapter.modify_thread.assert_awaited_once_with("g:t1", "trash", None)
+
+        lines = result.split("\n")
+        assert len(lines) == 2
+        assert "g:m4: trashed" in lines[0]
+        assert "error" not in lines[1].lower()
+        assert "g:m3" in lines[1] and "g:m4" in lines[1]  # covered by the first item
+
+    @pytest.mark.asyncio
     async def test_dry_run_marks_thread_scope_and_acts_on_nothing(self, gmail_source):
         mock_adapter = AsyncMock()
         with patch("ts4k.commands._make_adapter", return_value=mock_adapter):
@@ -401,6 +424,51 @@ class TestCollapseThreads:
 
     def test_empty_input(self):
         assert collapse_threads([]) == []
+
+    def test_whatsapp_messages_collapse_by_chat_jid(self):
+        """No thread_id, but chat_jid present — group by a derived chat key."""
+        wa_messages = [
+            {
+                "id": "w:msg2",
+                "source": "w",
+                "chat_jid": "123456@g.us",
+                "from": "alice",
+                "subject": "Team chat",
+                "date": "2026-02-19T10:00:00Z",
+                "snippet": "See you then.",
+            },
+            {
+                "id": "w:msg1",
+                "source": "w",
+                "chat_jid": "123456@g.us",
+                "from": "bob",
+                "subject": "Team chat",
+                "date": "2026-02-18T09:00:00Z",
+                "snippet": "Kickoff.",
+            },
+        ]
+        rows = collapse_threads(wa_messages)
+
+        assert len(rows) == 1
+        assert rows[0]["id"] == rows[0]["thread_id"] == "w:123456@g.us"
+        assert rows[0]["message_count"] == 2
+
+    def test_whatsapp_thread_ref_resolves_via_read_thread(self):
+        """The derived row id, once stripped of its source prefix, is a chat
+        JID — exactly what WhatsAppAdapter.read_thread treats as a chat
+        lookup (see the ``"@" in raw_id`` branch)."""
+        from ts4k.adapters.whatsapp import WhatsAppAdapter, WhatsAppAdapterConfig
+
+        msg = {
+            "id": "w:msg1", "source": "w", "chat_jid": "555@s.whatsapp.net",
+            "from": "carol", "date": "2026-02-18T09:00:00Z",
+        }
+        row = collapse_threads([msg])[0]
+
+        adapter = WhatsAppAdapter(WhatsAppAdapterConfig(), prefix="w")
+        raw_id = adapter._strip_prefix(row["id"])
+        assert raw_id == "555@s.whatsapp.net"
+        assert "@" in raw_id  # read_thread's chat-JID branch
 
 
 # ---------------------------------------------------------------------------
@@ -560,3 +628,56 @@ class TestThreadListingIntegration:
 
         assert result.messages_processed == 5
         assert refs.resolve("1") == "g:m4"
+
+
+# ---------------------------------------------------------------------------
+# Continuation hint — must retain --threads across pagination
+# ---------------------------------------------------------------------------
+
+
+def _wa_style_messages(n: int, base_hour: int = 1) -> list[dict]:
+    return [
+        {
+            "id": f"g:m{i}",
+            "thread_id": f"g:t{i}",
+            "source": "g",
+            "from": f"s{i}@test.com",
+            "subject": f"Subj {i}",
+            "date": f"2026-03-08T{base_hour + i:02d}:00:00Z",
+        }
+        for i in range(n)
+    ]
+
+
+class TestContinuationHintThreads:
+    @pytest.mark.asyncio
+    async def test_continuation_hint_retains_threads_flag(self, gmail_source, monkeypatch):
+        """An overflowing --threads listing must not silently drop --threads
+        from the printed continuation command — copying it should keep
+        paginating in thread mode, not switch back to message rows."""
+        from ts4k import commands
+
+        async def fake_fetch(prefix, cfg, since, count, **kwargs):
+            return _wa_style_messages(10)
+
+        monkeypatch.setattr(commands, "_fetch_for_source", fake_fetch)
+
+        result = await commands.updates(since="1d", source="g", count=3, threads=True)
+
+        assert result.has_more is True
+        assert "--threads" in result._continuation_hint
+
+    @pytest.mark.asyncio
+    async def test_continuation_hint_omits_threads_in_message_mode(self, gmail_source, monkeypatch):
+        """Message-mode listings must not gain a spurious --threads flag."""
+        from ts4k import commands
+
+        async def fake_fetch(prefix, cfg, since, count, **kwargs):
+            return _wa_style_messages(10)
+
+        monkeypatch.setattr(commands, "_fetch_for_source", fake_fetch)
+
+        result = await commands.updates(since="1d", source="g", count=3)
+
+        assert result.has_more is True
+        assert "--threads" not in result._continuation_hint


### PR DESCRIPTION
Closes #20

## Summary
- **Thread-level manage (Gmail):** `manage archive|label|read|unread|trash REF --thread` operates on the entire Gmail thread in one `threads.modify`/`threads.trash` API call — no per-message ID collection, no partially-archived threads lingering in inbox. Dry-run and batch semantics respected. Non-Gmail sources get a clear "thread operations not supported" error instead of silent half-behavior.
- **Thread-collapsed listings:** `list --threads` / `whatsnew --threads` show one row per thread (subject, participants, message count, date range, latest snippet); refs in this mode resolve to threads and feed straight into `manage --thread`.
- **Backwards compatible:** message-level mode stays the default everywhere; no output changes without the new flags.
- Token savings: a multi-message thread collapses from N listing rows to one.

## Testing
Full suite: 928 passed, 4 skipped — 37 new tests in `tests/test_threads.py` (threads.modify called with all-message scope, label/trash variants, collapsed row format and counts/date ranges, ref resolution to threads, non-Gmail error, dry-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)