### PR TITLE
Migrate the WhatsApp adapter from stdio-subprocess to HTTP MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each messaging platform needs a one-time setup. One provider is enough to get st
 |----------|-------|-------------|
 | Gmail | [docs/setup-gmail.md](docs/setup-gmail.md) | Google OAuth (browser) |
 | O365 | [docs/setup-o365.md](docs/setup-o365.md) | Azure device code flow |
-| WhatsApp | [docs/setup-whatsapp.md](docs/setup-whatsapp.md) | Local SQLite (no auth) |
+| WhatsApp | [docs/setup-whatsapp.md](docs/setup-whatsapp.md) | Local bridge, HMAC key |
 
 ### 2. Check it works
 
@@ -182,7 +182,7 @@ Agent (Claude, etc.)
 ts4k (normalize → filter → format)
   |── Gmail Adapter     → Google Gmail API (direct)
   |── O365 Adapter      → Microsoft Graph API (direct, httpx)
-  |── WhatsApp Adapter  → whatsapp-mcp (local SQLite)
+  |── WhatsApp Adapter  → whatsapp-mcp bridge (local HTTP MCP)
   |── GCal Adapter      → Google Calendar API (direct)
   |── O365 Cal Adapter  → Microsoft Graph Calendar API (direct, httpx)
   '── Future adapters   → Slack, Teams, Telegram, ...

--- a/docs/setup-whatsapp.md
+++ b/docs/setup-whatsapp.md
@@ -88,7 +88,18 @@ ts4k src add w whatsapp \
   bridge_token_file=/path/to/bridge/store/api_token
 ```
 
-If ts4k runs on a different machine from the bridge, paste the key in directly instead of pointing at a file (`bridge_token=<key>`), or export `WHATSAPP_API_TOKEN`. Note that the bridge binds loopback only — reaching it from another host needs a tunnel, not a config change here.
+If ts4k runs on a different machine from the bridge, copy the key to a file on that machine and point `bridge_token_file` at it, or export `WHATSAPP_API_TOKEN` in that environment:
+
+```bash
+# on the ts4k host
+install -m 600 /dev/null ~/.config/ts4k/wa_api_token
+# paste the key into it, then:
+ts4k src add w whatsapp bridge_token_file=~/.config/ts4k/wa_api_token
+```
+
+Prefer either of those over `bridge_token=<key>` on the command line: an argument lands in shell history and is visible in process listings, and this key grants read access to the whole archive wherever the bridge is reachable. `bridge_token` still works for throwaway setups, and ts4k redacts it from `src add` / `src list` output, but neither of those helps once it is in `~/.bash_history`.
+
+Note that the bridge binds loopback only — reaching it from another host needs a tunnel, not a config change here.
 
 Verify it's registered:
 
@@ -127,20 +138,22 @@ This re-adds the source with `transport=stdio`, which makes ts4k spawn the Pytho
 Install its dependencies first if you have not run it before:
 
 ```bash
-cd whatsapp-mcp-server && uv sync
+cd ../whatsapp-mcp-server && uv sync   # from bridge/; use the repo root otherwise
 ```
 
 ## Keeping Messages Current
 
-The Go bridge needs to be running to receive new messages. Options:
+On the default HTTP transport the bridge **is** the MCP endpoint, so it has to be running for every query — not just to receive new messages. With it stopped, ts4k gets connection-refused rather than stale-but-usable results. Run it as a systemd service (Linux) or a startup task.
 
-- **Run manually** when you need fresh data: `cd bridge && ./whatsapp-bridge`
-- **Run as a systemd service** (Linux) or startup task for continuous sync
-- **Run on a schedule** — even without the bridge running, ts4k can still query whatever was last synced into the database
+```bash
+cd bridge && ./whatsapp-bridge
+```
+
+Only the [stdio rollback](#rollback-to-the-stdio-server) can read the database while the bridge is down: there the Python server opens the SQLite file itself, so queries return whatever was last synced.
 
 ## Caching Note
 
-WhatsApp messages come from a local database, so they're already fast to query. ts4k does **not** cache WhatsApp messages (caching is reserved for network-heavy sources like Gmail and O365). This means WhatsApp queries always read directly from the SQLite database through the MCP server.
+WhatsApp messages come from a local database, so they're already fast to query. ts4k does **not** cache WhatsApp messages (caching is reserved for network-heavy sources like Gmail and O365). This means WhatsApp queries always read live from the bridge, which reads the SQLite database — there is no ts4k-side copy to go stale, and equally nothing to answer from while the bridge is stopped.
 
 ## Troubleshooting
 

--- a/docs/setup-whatsapp.md
+++ b/docs/setup-whatsapp.md
@@ -52,16 +52,18 @@ The bridge starts syncing messages into `bridge/store/messages.db`. Keep it runn
 
 ## Step 3: Verify the Database Exists
 
+Step 2 left you in `whatsapp-mcp/bridge`; these paths are relative to it.
+
 Make sure the SQLite database was created by the bridge:
 
 ```bash
-ls bridge/store/messages.db
+ls store/messages.db
 ```
 
 If the file exists, the bridge is working. You can also check message count:
 
 ```bash
-sqlite3 bridge/store/messages.db "SELECT COUNT(*) FROM messages;"
+sqlite3 store/messages.db "SELECT COUNT(*) FROM messages;"
 ```
 
 ## Step 4: Find the Bridge Key
@@ -69,7 +71,7 @@ sqlite3 bridge/store/messages.db "SELECT COUNT(*) FROM messages;"
 On first run the bridge mints a shared secret at `bridge/store/api_token` and never prints it again. It is an HMAC key, not a password: ts4k signs each request with it, and the key itself never crosses the wire.
 
 ```bash
-ls -l bridge/store/api_token
+ls -l store/api_token
 ```
 
 ## Step 5: Register the Source

--- a/docs/setup-whatsapp.md
+++ b/docs/setup-whatsapp.md
@@ -14,10 +14,14 @@ Unlike Gmail and O365, WhatsApp doesn't have an official API for personal accoun
 ## Architecture
 
 ```
-ts4k --> whatsapp-mcp (Python, MCP stdio) --> SQLite DB <-- Go bridge <-- WhatsApp
+ts4k --HTTP MCP--> Go bridge --> SQLite DB
+                       ^
+                       └-- WhatsApp
 ```
 
-ts4k spawns the whatsapp-mcp server as a subprocess on demand. The Go bridge syncs messages from WhatsApp into a local SQLite database. ts4k reads from that database through the MCP server — no direct WhatsApp API access, no cloud services, everything local.
+The Go bridge syncs messages from WhatsApp into a local SQLite database and serves MCP over streamable HTTP at `http://127.0.0.1:18741/mcp`. ts4k talks to it directly — no subprocess, no direct WhatsApp API access, no cloud services, everything local.
+
+The bridge also still runs a separate Python MCP server (`whatsapp-mcp-server/`) that speaks stdio and reads the same database. ts4k no longer uses it by default, but it remains the [rollback path](#rollback-to-the-stdio-server).
 
 ## Step 1: Clone the WhatsApp MCP Server
 
@@ -46,49 +50,49 @@ On first run, it displays a QR code in the terminal. Scan it with your phone:
 
 The bridge starts syncing messages into `bridge/store/messages.db`. Keep it running (or set it up as a service) to keep the database current.
 
-## Step 3: Install the MCP Server Dependencies
-
-```bash
-cd ../server
-pip install -r requirements.txt
-# or, if using uv:
-uv sync
-```
-
-## Step 4: Verify the Database Exists
+## Step 3: Verify the Database Exists
 
 Make sure the SQLite database was created by the bridge:
 
 ```bash
-ls ../bridge/store/messages.db
+ls bridge/store/messages.db
 ```
 
 If the file exists, the bridge is working. You can also check message count:
 
 ```bash
-sqlite3 ../bridge/store/messages.db "SELECT COUNT(*) FROM messages;"
+sqlite3 bridge/store/messages.db "SELECT COUNT(*) FROM messages;"
+```
+
+## Step 4: Find the Bridge Key
+
+On first run the bridge mints a shared secret at `bridge/store/api_token` and never prints it again. It is an HMAC key, not a password: ts4k signs each request with it, and the key itself never crosses the wire.
+
+```bash
+ls -l bridge/store/api_token
 ```
 
 ## Step 5: Register the Source
 
-Point ts4k at the whatsapp-mcp server directory:
-
 ```bash
-ts4k src add w whatsapp mcp_cwd=/path/to/whatsapp-mcp/server
+ts4k src add w whatsapp bridge_token_file=/path/to/whatsapp-mcp/bridge/store/api_token
 ```
 
-Replace `/path/to/whatsapp-mcp/server` with the actual path to the `server/` directory in your clone.
-
-If you need a custom command to start the server (instead of the default `uv run main.py`):
+`bridge_url` defaults to `http://127.0.0.1:18741/mcp`. Set it only if the bridge listens elsewhere:
 
 ```bash
-ts4k src add w whatsapp mcp_cwd=/path/to/server server_command="python main.py"
+ts4k src add w whatsapp \
+  bridge_url=http://127.0.0.1:18741/mcp \
+  bridge_token_file=/path/to/bridge/store/api_token
 ```
+
+If ts4k runs on a different machine from the bridge, paste the key in directly instead of pointing at a file (`bridge_token=<key>`), or export `WHATSAPP_API_TOKEN`. Note that the bridge binds loopback only — reaching it from another host needs a tunnel, not a config change here.
 
 Verify it's registered:
 
 ```bash
 ts4k src list
+ts4k auth --check          # reports whether the bridge key resolves
 ```
 
 ## Step 6: Verify It Works
@@ -97,11 +101,32 @@ ts4k src list
 ts4k wn --source w
 ```
 
-You should see your recent WhatsApp messages. If you get a connection error, make sure the `mcp_cwd` path is correct and the server dependencies are installed.
+You should see your recent WhatsApp messages.
 
-## No Authentication Needed
+## Authentication
 
-WhatsApp messages come from a local SQLite database — there are no OAuth tokens, API keys, or cloud credentials to manage. The Go bridge handles the WhatsApp device linking, and everything stays on your machine.
+There is no OAuth, no cloud credential, and no login flow. Two separate things authenticate:
+
+- **WhatsApp → bridge**: the QR pairing from Step 2. Lives in the bridge, done once.
+- **ts4k → bridge**: challenge-response over the shared key. Each request goes out unsigned, the bridge answers `401` with a single-use nonce, and ts4k re-sends an HMAC over the method, path, nonce and body — over a fresh connection. Nothing replayable is ever sent, so capturing a request buys an attacker only that one request.
+
+## Rollback to the stdio server
+
+The Python MCP server (`whatsapp-mcp-server/`) still exists and still reads the same database. To point ts4k back at it:
+
+```bash
+ts4k src add w whatsapp transport=stdio \
+  mcp_cwd=/path/to/whatsapp-mcp/whatsapp-mcp-server \
+  server_command="uv run main.py"
+```
+
+This re-adds the source with `transport=stdio`, which makes ts4k spawn the Python server as a subprocess again. `bridge_url` and the key are ignored in that mode. Switch back with `ts4k src add w whatsapp bridge_token_file=...` (no `transport` key, or `transport=http`).
+
+Install its dependencies first if you have not run it before:
+
+```bash
+cd whatsapp-mcp-server && uv sync
+```
 
 ## Keeping Messages Current
 
@@ -117,8 +142,11 @@ WhatsApp messages come from a local database, so they're already fast to query. 
 
 ## Troubleshooting
 
-**"Connection refused" or "server not found"**
-Check that `mcp_cwd` in your source config points to the `server/` directory (not the repo root). Verify deps are installed: `cd server && pip install -r requirements.txt`.
+**"Connection refused"**
+The bridge is not running, or is not listening on `bridge_url`. Start it (`cd bridge && ./whatsapp-bridge`) and check the port with `curl -i http://127.0.0.1:18741/mcp -X POST` — a healthy bridge answers `401` with a `WWW-Authenticate: HMAC-SHA256` header.
+
+**HTTP 401 from the bridge**
+ts4k has no key, or the wrong one. `ts4k auth --check` says whether one resolves at all; if it does, confirm `bridge_token_file` points at the `store/api_token` of the bridge you are actually talking to. The key is regenerated if that file is deleted, which invalidates every client holding the old one.
 
 **"No messages found"**
 Make sure the Go bridge has run at least once and the SQLite database exists at `bridge/store/messages.db`. Check that it has rows: `sqlite3 bridge/store/messages.db "SELECT COUNT(*) FROM messages;"`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,11 @@ dependencies = [
     "google-auth-oauthlib>=1.2",
     "html2text>=2024.2",
     "httpx>=0.27",
-    "mcp>=1.0,<2",
+    # 1.9.2 is the first release whose streamablehttp_client takes
+    # httpx_client_factory — the hook the WhatsApp HTTP transport hardens the
+    # client through. whatsapp.py imports that module unconditionally, so an
+    # older mcp breaks every command, not just WhatsApp.
+    "mcp>=1.9.2,<2",
     "msal>=1.28",
 ]
 

--- a/src/ts4k/adapters/wa_bridge_auth.py
+++ b/src/ts4k/adapters/wa_bridge_auth.py
@@ -83,7 +83,13 @@ def resolve_bridge_token(token: str | None = None, token_file: str | None = None
     if token and token.strip():
         return token.strip()
     if token_file and token_file.strip():
-        return _read_token_file(token_file.strip())
+        # Only wins if it actually resolves. A configured path that is missing,
+        # unreadable or empty — the shape a config copied to another host takes
+        # — must not shadow a working environment value, or the fallback the
+        # docstring promises is unreachable exactly when it is needed.
+        from_file = _read_token_file(token_file.strip())
+        if from_file:
+            return from_file
     env_token = os.environ.get("WHATSAPP_API_TOKEN", "").strip()
     if env_token:
         return env_token

--- a/src/ts4k/adapters/wa_bridge_auth.py
+++ b/src/ts4k/adapters/wa_bridge_auth.py
@@ -1,0 +1,244 @@
+"""Challenge-response auth for the WhatsApp bridge's HTTP MCP endpoint.
+
+The Go bridge (whatsapp-mcp) serves MCP over streamable HTTP behind the
+challenge-response middleware from whatsapp-mcp#58.  The shared secret is an
+HMAC key, not a bearer token, and it never crosses the wire:
+
+1. The request goes out unauthenticated.
+2. The bridge answers ``401`` with a single-use nonce in ``WWW-Authenticate``.
+3. The client re-sends carrying an HMAC over the method, the request target,
+   that nonce, and a hash of the body — **over a fresh connection**.
+4. Exactly one retry.  A second 401 is reported, never re-signed.
+
+This is a port of ``_bridge_challenge`` / ``_bridge_auth_headers`` /
+``_bridge_json_request`` in whatsapp-mcp's ``whatsapp-mcp-server/whatsapp.py``.
+The canonical string has to agree with ``requestMAC`` in
+``whatsapp-bridge/auth.go`` byte for byte, which is why it is built from what
+was *actually sent* rather than from what a caller meant to send.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+import re
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# The bridge's default listen address.  Configurable — ts4k may run on a
+# different host — but the literal 127.0.0.1 rather than "localhost": see
+# pin_loopback.
+DEFAULT_BRIDGE_URL = "http://127.0.0.1:18741/mcp"
+
+# Deliberately not "Bearer".  The token is an HMAC key here, so a client that
+# still sends one as a credential must fail rather than appear to work.
+AUTH_SCHEME = "HMAC-SHA256"
+
+_NONCE_PATTERN = re.compile(r'nonce="([^"]*)"')
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+def pin_loopback(url: str) -> str:
+    """Rewrite a ``localhost`` bridge URL to the literal ``127.0.0.1``.
+
+    The bridge binds the IPv4 loopback only.  On a dual-stack host
+    "localhost" can resolve to ``::1`` first, and another local account can
+    bind ``[::1]:18741`` *alongside* the live bridge — the one position from
+    which a signed request can still be relayed.  Pinning the literal keeps
+    client and bridge in the same address family.  Non-loopback hosts are
+    left alone; ts4k is allowed to run elsewhere.
+    """
+    parsed = httpx.URL(url)
+    if parsed.host.lower() != "localhost":
+        return url
+    logger.warning(
+        "Bridge URL uses 'localhost'; pinning to 127.0.0.1 so the connection "
+        "cannot land on an IPv6 listener alongside the bridge"
+    )
+    return str(parsed.copy_with(host="127.0.0.1"))
+
+
+def resolve_bridge_token(token: str | None = None, token_file: str | None = None) -> str:
+    """Resolve the bridge's shared secret, or ``""`` if it is not configured.
+
+    Order: explicit config value, explicit config file, then the same two
+    environment variables ``resolveAPIToken`` in ``whatsapp-bridge/auth.go``
+    reads.  No path is guessed from the stdio server's location — ts4k may run
+    on a different host from the bridge, where such a guess would silently
+    resolve to the wrong file or to nothing.
+
+    An unresolved token is not an error here: the request then goes out
+    unauthenticated and the bridge answers 401, which is a debuggable failure
+    rather than a silent one.
+    """
+    if token and token.strip():
+        return token.strip()
+    if token_file and token_file.strip():
+        return _read_token_file(token_file.strip())
+    env_token = os.environ.get("WHATSAPP_API_TOKEN", "").strip()
+    if env_token:
+        return env_token
+    env_file = os.environ.get("WHATSAPP_API_TOKEN_FILE", "").strip()
+    if env_file:
+        return _read_token_file(env_file)
+    return ""
+
+
+def _read_token_file(path: str) -> str:
+    try:
+        return Path(path).expanduser().read_text(encoding="utf-8").strip()
+    except OSError:
+        logger.warning("Bridge token file %s is unreadable", path)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Signing
+# ---------------------------------------------------------------------------
+
+
+def canonical_string(method: str, request_target: str, nonce: str, body: bytes) -> str:
+    """Build the string the bridge signs: method, target, nonce, body hash.
+
+    ``request_target`` is path + query exactly as sent (the bridge uses
+    ``r.URL.RequestURI()``).  ``body`` is the bytes actually sent — an empty
+    body hashes the empty string, not ``"null"`` or ``"{}"``.
+    """
+    return f"{method}\n{request_target}\n{nonce}\n{hashlib.sha256(body).hexdigest()}"
+
+
+def sign(token: str, method: str, request_target: str, nonce: str, body: bytes) -> str:
+    """HMAC-SHA256 the canonical string with the shared secret as the key."""
+    return hmac.new(
+        token.encode(),
+        canonical_string(method, request_target, nonce, body).encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def challenge_nonce(headers) -> str:
+    """Read the nonce out of a 401's ``WWW-Authenticate`` header, or ``""``.
+
+    An empty answer covers both a listener that does not speak this scheme and
+    a genuine 401 with nothing to sign; either way there is no second attempt
+    to make, and the caller reports the 401 as it stands.
+    """
+    scheme, _, params = headers.get("WWW-Authenticate", "").partition(" ")
+    if scheme.lower() != AUTH_SCHEME.lower():
+        return ""
+    match = _NONCE_PATTERN.search(params)
+    return match.group(1) if match else ""
+
+
+# ---------------------------------------------------------------------------
+# Transport
+# ---------------------------------------------------------------------------
+
+
+class BridgeHmacTransport(httpx.AsyncBaseTransport):
+    """An httpx transport that answers the bridge's challenge, once.
+
+    This lives at the transport layer rather than in an ``httpx.Auth`` flow so
+    that the connection carrying the challenge is provably gone before the
+    signed answer goes out — see ``_inner`` below.
+    """
+
+    def __init__(self, token: str, inner: httpx.AsyncBaseTransport | None = None) -> None:
+        self._token = token or ""
+        # max_keepalive_connections=0 is load-bearing, not tuning.  It means a
+        # connection is closed when its response is released rather than
+        # returned to the idle pool, so the signed retry *cannot* reuse the
+        # socket the challenge came back on.  That matters: during a restart
+        # window a squatter can accept the client's first connection, close
+        # only its *listening* socket so the real bridge can bind, fetch a
+        # genuine nonce from that bridge and hand it back over the still-open
+        # socket.  Answering over the same connection would deliver a valid
+        # signed request straight to the squatter.  Reconnecting means the
+        # credential lands on whichever process owns the port now.
+        #
+        # A `Connection: close` request header would not do this — it is a
+        # request to the *peer*, and the peer here is the attacker.  The pool
+        # has to be emptied on this side.
+        # tests/test_wa_bridge_auth.py::test_retry_travels_over_a_fresh_connection
+        # asserts the property directly.
+        self._inner = inner or httpx.AsyncHTTPTransport(
+            trust_env=False,
+            limits=httpx.Limits(max_keepalive_connections=0),
+        )
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        response = await self._inner.handle_async_request(request)
+        if response.status_code != 401:
+            return response
+
+        nonce = challenge_nonce(response.headers)
+        if not nonce or not self._token:
+            return response
+
+        # Sign what was actually sent: raw_path is the target as it goes on the
+        # wire, and request.content is the body httpx serialized.  If those ever
+        # disagreed with what the caller meant, the bridge would answer 401
+        # rather than accept a payload nobody signed.
+        target = request.url.raw_path.decode("ascii")
+        body = request.content
+        mac = sign(self._token, request.method, target, nonce, body)
+
+        # Drain and release the challenge before the credential goes anywhere,
+        # never after: releasing is what closes that connection.
+        await response.aread()
+        await response.aclose()
+
+        signed = httpx.Request(
+            request.method,
+            request.url,
+            headers=request.headers,
+            content=body,
+            extensions=request.extensions,
+        )
+        signed.headers["Authorization"] = f'{AUTH_SCHEME} nonce="{nonce}", mac="{mac}"'
+        # Exactly one retry.  A second 401 is returned as it stands — otherwise
+        # a bridge holding a different key becomes an infinite loop.  Re-sending
+        # is side-effect free because the middleware rejects before any handler
+        # runs.
+        return await self._inner.handle_async_request(signed)
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+def bridge_client_factory(token: str | None):
+    """Return an ``McpHttpClientFactory`` bound to this bridge's secret.
+
+    Handed to ``streamablehttp_client``, which owns the client's lifecycle.
+    """
+
+    def factory(headers=None, timeout=None, auth=None) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            headers=headers,
+            timeout=timeout if timeout is not None else httpx.Timeout(30.0, read=300.0),
+            auth=auth,
+            transport=BridgeHmacTransport(token or ""),
+            # The bridge is loopback-only by default, so nothing in the
+            # environment should be able to redirect this traffic: trust_env
+            # disables proxy env vars (HTTP_PROXY/HTTPS_PROXY/ALL_PROXY) and
+            # the SSL_CERT_FILE class of override in one place.  httpx does not
+            # apply ~/.netrc automatically the way requests does — that hazard,
+            # documented in whatsapp.py, does not reach us — but leaving
+            # trust_env on would still hand the environment a say.
+            trust_env=False,
+            # MCP's default client follows redirects.  A redirect here could
+            # only move bridge traffic somewhere it should not go; there is
+            # nothing legitimate for it to follow.
+            follow_redirects=False,
+        )
+
+    return factory

--- a/src/ts4k/adapters/whatsapp.py
+++ b/src/ts4k/adapters/whatsapp.py
@@ -1,12 +1,22 @@
-"""WhatsApp adapter — MCP client bridge to whatsapp-mcp.
+"""WhatsApp adapter — MCP client for the whatsapp-mcp archive.
 
-Connects to the whatsapp-mcp-server (Python FastMCP over stdio) which
-reads from a local SQLite database populated by the Go WhatsApp bridge.
+Two transports, same tool surface:
+
+``http`` (default)
+    Streamable HTTP MCP served directly by the Go bridge, behind the
+    challenge-response auth in :mod:`ts4k.adapters.wa_bridge_auth`.  No
+    subprocess.
+
+``stdio``
+    Spawns the Python FastMCP server (``whatsapp-mcp-server``) as a
+    subprocess.  Retained as the documented rollback while that server still
+    exists (whatsapp-mcp#85 retires it).
 
 Usage::
 
     adapter = WhatsAppAdapter(WhatsAppAdapterConfig(
-        server_cwd="~/whatsapp-mcp/server",
+        bridge_url="http://127.0.0.1:18741/mcp",
+        bridge_token_file="~/whatsapp-mcp/whatsapp-bridge/store/api_token",
     ))
     async with adapter:
         msgs = await adapter.list_messages(count=20)
@@ -14,6 +24,7 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from contextlib import AsyncExitStack
@@ -23,7 +34,9 @@ from typing import Any
 
 from mcp import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.streamable_http import streamablehttp_client
 
+from ts4k.adapters import wa_bridge_auth
 from ts4k.adapters.base import BaseAdapter
 
 logger = logging.getLogger(__name__)
@@ -38,6 +51,18 @@ logger = logging.getLogger(__name__)
 class WhatsAppAdapterConfig:
     """All knobs for the WhatsApp adapter."""
 
+    # "http" talks to the Go bridge directly; "stdio" spawns the Python server.
+    transport: str = "http"
+
+    # -- http transport ------------------------------------------------------
+    bridge_url: str = wa_bridge_auth.DEFAULT_BRIDGE_URL
+    # The HMAC key the bridge mints at store/api_token on first run.  Either
+    # the value or a path to it; both are optional here because the key also
+    # resolves from WHATSAPP_API_TOKEN / WHATSAPP_API_TOKEN_FILE.
+    bridge_token: str | None = None
+    bridge_token_file: str | None = None
+
+    # -- stdio transport (rollback) -----------------------------------------
     server_command: list[str] = field(default_factory=lambda: ["uv", "run", "main.py"])
     server_cwd: str | None = None
     server_env: dict[str, str] | None = None
@@ -175,6 +200,15 @@ def parse_message_context_response(text: str, prefix: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def _flatten(exc: BaseException):
+    """Yield the leaf exceptions of a (possibly nested) ExceptionGroup."""
+    if isinstance(exc, BaseExceptionGroup):
+        for sub in exc.exceptions:
+            yield from _flatten(sub)
+    else:
+        yield exc
+
+
 class WhatsAppAdapter(BaseAdapter):
     """WhatsApp adapter that bridges to whatsapp-mcp via stdio MCP client."""
 
@@ -194,22 +228,82 @@ class WhatsAppAdapter(BaseAdapter):
 
         stack = AsyncExitStack()
         self._exit_stack = stack
+        try:
+            if self._config.transport == "stdio":
+                streams = await self._connect_stdio(stack)
+            else:
+                streams = await self._connect_http(stack)
+            session = await stack.enter_async_context(ClientSession(*streams))
+            await session.initialize()
+        except BaseException as exc:
+            # The HTTP transport runs inside an anyio task group: a failed
+            # request cancels initialize(), and the error that explains why
+            # only surfaces when the group unwinds — here.  Both halves have
+            # to be considered or the operator is told "Cancelled via cancel
+            # scope", which names nothing.
+            teardown: BaseException | None = None
+            try:
+                await stack.aclose()
+            except BaseException as close_exc:
+                teardown = close_exc
+            self._exit_stack = None
+            raise self._connect_error(exc, teardown) from exc
+        self._session = session
+        logger.info("WhatsAppAdapter connected via %s", self._config.transport)
 
+    def _connect_error(
+        self, exc: BaseException, teardown: BaseException | None
+    ) -> BaseException:
+        """Pick the failure an operator can act on out of a task group's rubble."""
+        leaves = [leaf for group in (exc, teardown) if group is not None
+                  for leaf in _flatten(group)]
+        cause = next(
+            (leaf for leaf in leaves if not isinstance(leaf, asyncio.CancelledError)),
+            leaves[0] if leaves else exc,
+        )
+        if getattr(getattr(cause, "response", None), "status_code", None) == 401:
+            # The one failure that is all but guaranteed during rollout, and
+            # the one httpx describes least usefully.
+            return RuntimeError(
+                f"WhatsApp bridge at {self._config.bridge_url} rejected our key "
+                "(HTTP 401). Set bridge_token or bridge_token_file on the source "
+                "to the contents of the bridge's store/api_token."
+            )
+        return cause
+
+    async def _connect_stdio(self, stack: AsyncExitStack) -> tuple[Any, Any]:
         params = StdioServerParameters(
             command=self._config.server_command[0],
             args=self._config.server_command[1:],
             cwd=self._config.server_cwd,
             env=self._config.server_env,
         )
-        read_stream, write_stream = await stack.enter_async_context(
-            stdio_client(params)
+        return await stack.enter_async_context(stdio_client(params))
+
+    async def _connect_http(self, stack: AsyncExitStack) -> tuple[Any, Any]:
+        url = wa_bridge_auth.pin_loopback(self._config.bridge_url)
+        token = wa_bridge_auth.resolve_bridge_token(
+            self._config.bridge_token, self._config.bridge_token_file
         )
-        session = await stack.enter_async_context(
-            ClientSession(read_stream, write_stream)
+        if not token:
+            # Not fatal — the bridge answers 401, which names the problem more
+            # precisely than a guess here could — but silence would leave the
+            # operator staring at an auth error with no hint where the key
+            # comes from.
+            logger.warning(
+                "No WhatsApp bridge token configured; requests to %s will be "
+                "rejected. Set bridge_token / bridge_token_file on the source, "
+                "or WHATSAPP_API_TOKEN. The bridge mints it at store/api_token "
+                "on first run.",
+                url,
+            )
+        read_stream, write_stream, _get_session_id = await stack.enter_async_context(
+            streamablehttp_client(
+                url,
+                httpx_client_factory=wa_bridge_auth.bridge_client_factory(token),
+            )
         )
-        await session.initialize()
-        self._session = session
-        logger.info("WhatsAppAdapter connected via stdio")
+        return read_stream, write_stream
 
     async def disconnect(self) -> None:
         if self._exit_stack is not None:

--- a/src/ts4k/cli.py
+++ b/src/ts4k/cli.py
@@ -39,6 +39,12 @@ from ts4k.state import sources, watermarks
 from ts4k.state.refs import RefTable
 
 
+# Source config keys holding a secret rather than a pointer to one. `src list`
+# runs constantly in agent context and in terminal scrollback, so the value
+# itself never gets printed — `bridge_token_file` (a path) still does.
+_SECRET_SOURCE_KEYS = frozenset({"bridge_token"})
+
+
 # ---------------------------------------------------------------------------
 # Ref table helpers
 # ---------------------------------------------------------------------------
@@ -483,7 +489,8 @@ def _cmd_sources(args: argparse.Namespace) -> None:
             print(f"  {prefix}: {provider} ({detail}) [{level}]")
             for k, v in sorted(cfg.items()):
                 if k not in ("provider", "email", "mailbox", "mcp_cwd"):
-                    print(f"    {k}: {v}")
+                    shown = "<redacted>" if k in _SECRET_SOURCE_KEYS else v
+                    print(f"    {k}: {shown}")
 
     elif action == "discover":
         asyncio.run(_cmd_discover_o365(args))

--- a/src/ts4k/cli.py
+++ b/src/ts4k/cli.py
@@ -1113,7 +1113,7 @@ def _auth_interactive(targets: list[tuple[str, dict]], no_calendar: bool) -> Non
             elif provider in ("o365", "o365cal"):
                 _auth_o365(prefix, cfg, no_calendar)
             elif provider == "whatsapp":
-                print(f"  {prefix}: whatsapp — session-based, no auth needed")
+                _auth_whatsapp(prefix, cfg)
             elif provider == "caldav":
                 from ts4k.auth.caldav import credentials_path
                 email = cfg.get("email", "<your-apple-id>")
@@ -1135,6 +1135,27 @@ def _auth_interactive(targets: list[tuple[str, dict]], no_calendar: bool) -> Non
 
     if any_failed:
         sys.exit(1)
+
+
+def _auth_whatsapp(prefix: str, cfg: dict) -> None:
+    """Report how a WhatsApp source authenticates — there is nothing to run.
+
+    The WhatsApp session lives in the bridge (paired by QR, once). What ts4k
+    needs is the bridge's HMAC key, which the operator pastes in rather than
+    obtains through a flow.
+    """
+    from ts4k.adapters import wa_bridge_auth
+
+    if (cfg.get("transport") or "http").lower() == "stdio":
+        print(f"  {prefix}: whatsapp (stdio) — session-based, no auth needed")
+        return
+    if wa_bridge_auth.resolve_bridge_token(cfg.get("bridge_token"), cfg.get("bridge_token_file")):
+        print(f"  {prefix}: whatsapp — bridge key configured, nothing to authorize")
+        return
+    print(f"  {prefix}: whatsapp — no bridge key configured")
+    print("        The bridge mints one at <whatsapp-bridge>/store/api_token on first run.")
+    print(f"        ts4k src add {prefix} whatsapp "
+          "bridge_token_file=/path/to/whatsapp-bridge/store/api_token")
 
 
 def _auth_google(prefix: str, cfg: dict, no_calendar: bool) -> None:
@@ -1377,13 +1398,14 @@ def _build_parser() -> argparse.ArgumentParser:
         epilog=(
             "provider keys:\n"
             "  gmail:    email (required), mcp_url, transport\n"
-            "  whatsapp: mcp_cwd (required), server_command\n"
+            "  whatsapp: bridge_url, bridge_token, bridge_token_file, transport (http|stdio)\n"
+            "            transport=stdio also needs mcp_cwd, server_command\n"
             "  o365:     client_id (required), tenant_id, mailbox\n"
             "  apple/icloud: email (required), calendar_id, calendar_name  → generic caldav provider\n"
             "\n"
             "examples:\n"
             '  ts4k src add g gmail email=you@gmail.com\n'
-            '  ts4k src add w whatsapp mcp_cwd=/path/to/server server_command="uv run python main.py"\n'
+            '  ts4k src add w whatsapp bridge_token_file=/path/to/whatsapp-bridge/store/api_token\n'
             '  ts4k src add cc apple email=you@icloud.com\n'
             "\n"
             "List fields (server_command) are auto-split on spaces.\n"

--- a/src/ts4k/cli.py
+++ b/src/ts4k/cli.py
@@ -45,6 +45,16 @@ from ts4k.state.refs import RefTable
 _SECRET_SOURCE_KEYS = frozenset({"bridge_token"})
 
 
+def _shown(key: str, value: object) -> object:
+    """Value to print for a source config field — secrets never print.
+
+    Every place that echoes a source config goes through here; `src add` and
+    `src list` both display the same entries, so redacting only one of them
+    just moves where the key leaks.
+    """
+    return "<redacted>" if key in _SECRET_SOURCE_KEYS else value
+
+
 # ---------------------------------------------------------------------------
 # Ref table helpers
 # ---------------------------------------------------------------------------
@@ -467,7 +477,7 @@ def _cmd_sources(args: argparse.Namespace) -> None:
         verb = "Updated" if existed else "Added"
         print(f"{verb} source {prefix!r}:")
         for k, v in sorted(entry.items()):
-            print(f"  {k}: {v}")
+            print(f"  {k}: {_shown(k, v)}")
 
     elif action == "rm":
         prefix = args.prefix
@@ -489,8 +499,7 @@ def _cmd_sources(args: argparse.Namespace) -> None:
             print(f"  {prefix}: {provider} ({detail}) [{level}]")
             for k, v in sorted(cfg.items()):
                 if k not in ("provider", "email", "mailbox", "mcp_cwd"):
-                    shown = "<redacted>" if k in _SECRET_SOURCE_KEYS else v
-                    print(f"    {k}: {shown}")
+                    print(f"    {k}: {_shown(k, v)}")
 
     elif action == "discover":
         asyncio.run(_cmd_discover_o365(args))

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -23,6 +23,7 @@ from ts4k.adapters.gcal import GcalAdapter, GcalAdapterConfig
 from ts4k.adapters.o365cal import O365CalAdapter, O365CalAdapterConfig
 from ts4k.adapters.gmail import GmailAdapter, GmailAdapterConfig
 from ts4k.adapters.o365 import O365Adapter, O365AdapterConfig
+from ts4k.adapters import wa_bridge_auth
 from ts4k.adapters.whatsapp import WhatsAppAdapter, WhatsAppAdapterConfig
 from ts4k.core.filter import apply_filters
 from ts4k.core.format import (
@@ -96,14 +97,29 @@ def _make_adapter(
         )
 
     if provider == "whatsapp":
-        cwd = cfg.get("mcp_cwd", "")
-        if not cwd or not os.path.isdir(cwd):
-            return None
-        cmd = cfg.get("server_command", ["uv", "run", "main.py"])
-        if isinstance(cmd, str):
-            cmd = cmd.split()
+        # "stdio" spawns the Python whatsapp-mcp-server as a subprocess. It is
+        # the documented rollback from the HTTP transport (ts4k#71) and stays
+        # available while that server exists (whatsapp-mcp#85).
+        if (cfg.get("transport") or "http").lower() == "stdio":
+            cwd = cfg.get("mcp_cwd", "")
+            if not cwd or not os.path.isdir(cwd):
+                return None
+            cmd = cfg.get("server_command", ["uv", "run", "main.py"])
+            if isinstance(cmd, str):
+                cmd = cmd.split()
+            return WhatsAppAdapter(
+                WhatsAppAdapterConfig(
+                    transport="stdio", server_command=cmd, server_cwd=cwd
+                ),
+                prefix=prefix,
+            )
         return WhatsAppAdapter(
-            WhatsAppAdapterConfig(server_command=cmd, server_cwd=cwd),
+            WhatsAppAdapterConfig(
+                transport="http",
+                bridge_url=cfg.get("bridge_url") or wa_bridge_auth.DEFAULT_BRIDGE_URL,
+                bridge_token=cfg.get("bridge_token"),
+                bridge_token_file=cfg.get("bridge_token_file"),
+            ),
             prefix=prefix,
         )
 
@@ -1966,7 +1982,19 @@ def check_token_health(prefix: str, cfg: dict[str, Any]) -> "TokenHealth":
     provider = cfg.get("provider", "").lower()
 
     if provider == "whatsapp":
-        return TokenHealth(status="ok", expiry=None, scopes=[], detail="session-based")
+        # The WhatsApp session itself lives in the bridge and has no token ts4k
+        # can validate. The HTTP transport does have one — the bridge's HMAC
+        # key — and a missing key is the failure an operator hits first.
+        if (cfg.get("transport") or "http").lower() == "stdio":
+            return TokenHealth(status="ok", expiry=None, scopes=[], detail="session-based")
+        if wa_bridge_auth.resolve_bridge_token(
+            cfg.get("bridge_token"), cfg.get("bridge_token_file")
+        ):
+            return TokenHealth(status="ok", expiry=None, scopes=[], detail="bridge key configured")
+        return TokenHealth(
+            status="auth", expiry=None, scopes=[],
+            detail="no bridge key: set bridge_token_file=<bridge>/store/api_token",
+        )
 
     if provider in ("gmail", "gcal"):
         from ts4k.auth.google import validate_token
@@ -2065,9 +2093,12 @@ def _append_setup(lines: list[str]) -> None:
     lines.append("    2. O365: same auth as O365 mail (calendar scopes added automatically)")
     lines.append("    3. ts4k cal setup                           (discover calendars, auto-adds sources)")
     lines.append("    4. ts4k cal                                 (verify — shows today's events)")
-    lines.append("  WhatsApp:")
-    lines.append('    1. ts4k src add w whatsapp mcp_cwd=/path/to/whatsapp-mcp-server server_command="uv run python main.py"')
+    lines.append("  WhatsApp (talks HTTP MCP to the Go bridge; no subprocess):")
+    lines.append("    1. ts4k src add w whatsapp bridge_token_file=/path/to/whatsapp-bridge/store/api_token")
+    lines.append("       (bridge_url defaults to http://127.0.0.1:18741/mcp)")
     lines.append("    2. ts4k list --source w --since 2d          (verify)")
+    lines.append("    Rollback to the Python stdio server:")
+    lines.append('       ts4k src add w whatsapp transport=stdio mcp_cwd=/path/to/whatsapp-mcp-server server_command="uv run python main.py"')
 
 
 def _append_errors(lines: list[str]) -> None:

--- a/src/ts4k/state/sources.py
+++ b/src/ts4k/state/sources.py
@@ -21,14 +21,17 @@ File format::
         },
         "w": {
             "provider": "whatsapp",
-            "mcp_cwd": "C:/path/to/whatsapp-mcp-server"
+            "bridge_url": "http://127.0.0.1:18741/mcp",
+            "bridge_token_file": "/path/to/whatsapp-bridge/store/api_token"
         }
     }
 
 Provider-specific fields:
 
 * **gmail**: ``email`` (required), ``mcp_url``, ``transport``
-* **whatsapp**: ``mcp_cwd`` (required), ``server_command``
+* **whatsapp**: ``transport`` (``http`` default, or ``stdio``).
+  ``http`` takes ``bridge_url``, ``bridge_token``, ``bridge_token_file``;
+  ``stdio`` takes ``mcp_cwd`` (required) and ``server_command``.
 
 Usage::
 

--- a/tests/test_auth_health.py
+++ b/tests/test_auth_health.py
@@ -37,9 +37,22 @@ class TestCheckTokenHealth:
         assert result.status == "ok"
         mock_validate.assert_called_once()
 
-    def test_whatsapp_returns_ok(self):
-        result = check_token_health("w", {"provider": "whatsapp"})
+    def test_whatsapp_stdio_returns_ok(self):
+        """The stdio server has no credential of its own — the session is the bridge's."""
+        result = check_token_health("w", {"provider": "whatsapp", "transport": "stdio"})
         assert result.status == "ok"
+
+    def test_whatsapp_http_with_a_bridge_key_returns_ok(self):
+        result = check_token_health(
+            "w", {"provider": "whatsapp", "bridge_token": "k"}
+        )
+        assert result.status == "ok"
+
+    def test_whatsapp_http_without_a_bridge_key_needs_auth(self, monkeypatch):
+        monkeypatch.delenv("WHATSAPP_API_TOKEN", raising=False)
+        monkeypatch.delenv("WHATSAPP_API_TOKEN_FILE", raising=False)
+        result = check_token_health("w", {"provider": "whatsapp"})
+        assert result.status == "auth"
 
     def test_unknown_provider_returns_na(self):
         result = check_token_health("x", {"provider": "unknown"})

--- a/tests/test_wa_bridge_auth.py
+++ b/tests/test_wa_bridge_auth.py
@@ -1,0 +1,385 @@
+"""Tests for the WhatsApp bridge's challenge-response auth (whatsapp-mcp#58).
+
+The exchange under test: an unauthenticated request is answered 401 with a
+single-use nonce, and the client re-sends carrying an HMAC over what it
+actually sent.  The shared secret is the HMAC key and never crosses the wire.
+
+Most of these assert properties an implementation could plausibly lose while
+still appearing to work against a friendly server — the retry landing on a
+fresh socket, exactly one retry, no replayable credential — so they run
+against a real HTTP server rather than a mock transport.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from ts4k.adapters import wa_bridge_auth as auth
+
+TOKEN = "s3cr3t-hmac-key"
+_NONCE = re.compile(r'nonce="([^"]*)"')
+_MAC = re.compile(r'mac="([^"]*)"')
+
+
+# ---------------------------------------------------------------------------
+# A bridge-shaped test server
+# ---------------------------------------------------------------------------
+
+
+class _Record:
+    def __init__(self, method, target, body, headers, client_port):
+        self.method = method
+        self.target = target
+        self.body = body
+        self.headers = headers
+        self.client_port = client_port
+
+
+class _BridgeServer:
+    """Minimal stand-in for the Go bridge's auth middleware.
+
+    Recomputes the MAC independently of the client under test, so a client
+    that signs the wrong canonical string fails here exactly as it would in
+    production.
+    """
+
+    def __init__(self, *, token=TOKEN, always_401=False, offer_challenge=True,
+                 challenge_header=None):
+        self.token = token
+        self.always_401 = always_401
+        self.offer_challenge = offer_challenge
+        self.challenge_header = challenge_header
+        self.requests: list[_Record] = []
+        self._nonce_seq = 0
+
+        server = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"  # keep-alive, so connection reuse is visible
+
+            def log_message(self, *args):  # keep pytest output clean
+                pass
+
+            def _handle(self):
+                length = int(self.headers.get("Content-Length") or 0)
+                body = self.rfile.read(length) if length else b""
+                server.requests.append(_Record(
+                    self.command, self.path, body, dict(self.headers),
+                    self.connection.getpeername()[1],
+                ))
+                authorized = server._authorized(
+                    self.command, self.path, body,
+                    self.headers.get("Authorization", ""),
+                )
+                if server.always_401 or not authorized:
+                    return self._challenge()
+                payload = json.dumps({"ok": True}).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def _challenge(self):
+                self.send_response(401)
+                if server.challenge_header is not None:
+                    self.send_header("WWW-Authenticate", server.challenge_header)
+                elif server.offer_challenge:
+                    self.send_header(
+                        "WWW-Authenticate",
+                        f'HMAC-SHA256 nonce="{server._issue_nonce()}"',
+                    )
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            do_GET = do_POST = do_DELETE = _handle
+
+        self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+
+    def _issue_nonce(self) -> str:
+        self._nonce_seq += 1
+        return f"nonce-{self._nonce_seq:064d}"
+
+    def _authorized(self, method: str, target: str, body: bytes, header: str) -> bool:
+        if not header.startswith("HMAC-SHA256 "):
+            return False
+        nonce, mac = _NONCE.search(header), _MAC.search(header)
+        if not nonce or not mac:
+            return False
+        expected = hmac.new(
+            self.token.encode(),
+            f"{method}\n{target}\n{nonce.group(1)}\n{hashlib.sha256(body).hexdigest()}".encode(),
+            hashlib.sha256,
+        ).hexdigest()
+        return hmac.compare_digest(expected, mac.group(1))
+
+    @property
+    def url(self) -> str:
+        host, port = self._httpd.server_address[:2]
+        return f"http://{host}:{port}"
+
+    def __enter__(self):
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=5)
+
+
+def _client(token: str | None = TOKEN):
+    return auth.bridge_client_factory(token)()
+
+
+# ---------------------------------------------------------------------------
+# Canonical string and signing
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_string_is_the_documented_four_line_form():
+    assert auth.canonical_string("POST", "/mcp?x=1", "abc", b"hi") == (
+        "POST\n/mcp?x=1\nabc\n" + hashlib.sha256(b"hi").hexdigest()
+    )
+
+
+def test_empty_body_hashes_the_empty_string_not_a_literal():
+    # sha256("") — not sha256("null"), not sha256("{}").
+    assert auth.canonical_string("GET", "/mcp", "n", b"").endswith(
+        hashlib.sha256(b"").hexdigest()
+    )
+
+
+def test_sign_matches_hmac_of_the_canonical_string():
+    expected = hmac.new(
+        TOKEN.encode(),
+        auth.canonical_string("POST", "/mcp", "n", b"{}").encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    assert auth.sign(TOKEN, "POST", "/mcp", "n", b"{}") == expected
+
+
+# ---------------------------------------------------------------------------
+# Challenge parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("header,expected", [
+    ('HMAC-SHA256 nonce="abc"', "abc"),
+    ('hmac-sha256 nonce="abc"', "abc"),       # scheme match is case-insensitive
+    ('Bearer realm="x"', ""),                  # not our scheme
+    ("HMAC-SHA256", ""),                       # scheme but no nonce
+])
+def test_challenge_nonce(header, expected):
+    assert auth.challenge_nonce({"WWW-Authenticate": header}) == expected
+
+
+def test_challenge_nonce_without_a_header():
+    assert auth.challenge_nonce({}) == ""
+
+
+# ---------------------------------------------------------------------------
+# The exchange
+# ---------------------------------------------------------------------------
+
+
+async def test_signed_retry_succeeds():
+    with _BridgeServer() as server:
+        async with _client() as client:
+            resp = await client.post(f"{server.url}/mcp", content=b'{"a":1}')
+        assert resp.status_code == 200
+        assert len(server.requests) == 2
+        assert "Authorization" not in server.requests[0].headers
+        assert server.requests[1].headers["Authorization"].startswith("HMAC-SHA256 ")
+
+
+async def test_retry_travels_over_a_fresh_connection():
+    """The signed answer must not reuse the socket the challenge came back on.
+
+    A squatter can accept the first connection, release only its *listening*
+    socket so the real bridge can bind, relay the challenge, and then receive
+    the signed answer over the still-open socket.  Reconnecting puts the
+    credential in front of whichever process owns the port now.
+    """
+    with _BridgeServer() as server:
+        async with _client() as client:
+            await client.post(f"{server.url}/mcp", content=b"{}")
+        assert len(server.requests) == 2
+        assert server.requests[0].client_port != server.requests[1].client_port
+
+
+async def test_a_second_401_is_reported_not_resigned():
+    """One retry, exactly.  A bridge holding a different key must not loop."""
+    with _BridgeServer(always_401=True) as server:
+        async with _client() as client:
+            resp = await client.post(f"{server.url}/mcp", content=b"{}")
+        assert resp.status_code == 401
+        assert len(server.requests) == 2
+
+
+async def test_no_token_means_no_retry():
+    with _BridgeServer() as server:
+        async with _client(token=None) as client:
+            resp = await client.post(f"{server.url}/mcp", content=b"{}")
+        assert resp.status_code == 401
+        assert len(server.requests) == 1
+
+
+async def test_a_401_without_our_scheme_is_not_answered():
+    with _BridgeServer(challenge_header='Basic realm="bridge"') as server:
+        async with _client() as client:
+            resp = await client.post(f"{server.url}/mcp", content=b"{}")
+        assert resp.status_code == 401
+        assert len(server.requests) == 1
+
+
+async def test_a_401_with_no_challenge_at_all_is_not_answered():
+    with _BridgeServer(offer_challenge=False) as server:
+        async with _client() as client:
+            resp = await client.post(f"{server.url}/mcp", content=b"{}")
+        assert resp.status_code == 401
+        assert len(server.requests) == 1
+
+
+async def test_no_replayable_credential_is_ever_sent():
+    """The token is an HMAC key.  It must not appear on the wire, in any form."""
+    with _BridgeServer() as server:
+        async with _client() as client:
+            await client.post(f"{server.url}/mcp", content=b"{}")
+        for record in server.requests:
+            blob = json.dumps(record.headers)
+            assert TOKEN not in blob
+            assert "Bearer" not in blob
+
+
+async def test_signature_covers_the_query_string_as_sent():
+    """request_target is path + query — the bridge signs r.URL.RequestURI()."""
+    with _BridgeServer() as server:
+        async with _client() as client:
+            resp = await client.post(f"{server.url}/mcp?session=7&x=y", content=b"{}")
+        # 200 means the server recomputed the same MAC over "/mcp?session=7&x=y".
+        assert resp.status_code == 200
+        assert server.requests[1].target == "/mcp?session=7&x=y"
+
+
+async def test_signature_covers_a_bodyless_get():
+    with _BridgeServer() as server:
+        async with _client() as client:
+            resp = await client.get(f"{server.url}/mcp")
+        assert resp.status_code == 200
+        assert server.requests[1].body == b""
+
+
+async def test_retry_resends_the_same_body():
+    body = b'{"jsonrpc":"2.0","method":"tools/list"}'
+    with _BridgeServer() as server:
+        async with _client() as client:
+            resp = await client.post(f"{server.url}/mcp", content=body)
+        assert resp.status_code == 200
+        assert server.requests[0].body == body
+        assert server.requests[1].body == body
+
+
+async def test_each_call_is_challenged_separately():
+    """Nonces are single-use, so there is nothing to carry between calls."""
+    with _BridgeServer() as server:
+        async with _client() as client:
+            assert (await client.post(f"{server.url}/mcp", content=b"{}")).status_code == 200
+            assert (await client.post(f"{server.url}/mcp", content=b"{}")).status_code == 200
+        assert len(server.requests) == 4
+        nonces = [_NONCE.search(r.headers["Authorization"]).group(1)
+                  for r in server.requests if "Authorization" in r.headers]
+        assert len(set(nonces)) == 2
+
+
+# ---------------------------------------------------------------------------
+# Client hardening
+# ---------------------------------------------------------------------------
+
+
+def test_client_does_not_trust_the_environment():
+    """Proxy env vars must not be able to route bridge traffic elsewhere."""
+    assert _client().trust_env is False
+
+
+def test_client_does_not_follow_redirects():
+    assert _client().follow_redirects is False
+
+
+async def test_env_proxy_is_ignored(monkeypatch):
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:9")  # a closed port
+    monkeypatch.setenv("ALL_PROXY", "http://127.0.0.1:9")
+    with _BridgeServer() as server:
+        async with _client() as client:
+            resp = await client.post(f"{server.url}/mcp", content=b"{}")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# URL pinning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("given,expected", [
+    ("http://localhost:18741/mcp", "http://127.0.0.1:18741/mcp"),
+    ("http://LOCALHOST:18741/mcp", "http://127.0.0.1:18741/mcp"),
+    ("http://localhost/mcp", "http://127.0.0.1/mcp"),
+    ("http://127.0.0.1:18741/mcp", "http://127.0.0.1:18741/mcp"),
+    ("http://bridge.internal:18741/mcp", "http://bridge.internal:18741/mcp"),
+    ("http://localhost.example.com/mcp", "http://localhost.example.com/mcp"),
+])
+def test_pin_loopback(given, expected):
+    assert auth.pin_loopback(given) == expected
+
+
+# ---------------------------------------------------------------------------
+# Token resolution
+# ---------------------------------------------------------------------------
+
+
+def test_token_from_config_wins(monkeypatch):
+    monkeypatch.setenv("WHATSAPP_API_TOKEN", "from-env")
+    assert auth.resolve_bridge_token(token="from-config") == "from-config"
+
+
+def test_token_from_config_file(monkeypatch, tmp_path):
+    monkeypatch.delenv("WHATSAPP_API_TOKEN", raising=False)
+    monkeypatch.delenv("WHATSAPP_API_TOKEN_FILE", raising=False)
+    path = tmp_path / "api_token"
+    path.write_text("  from-file\n")
+    assert auth.resolve_bridge_token(token_file=str(path)) == "from-file"
+
+
+def test_token_from_env(monkeypatch):
+    monkeypatch.setenv("WHATSAPP_API_TOKEN", "from-env")
+    assert auth.resolve_bridge_token() == "from-env"
+
+
+def test_token_from_env_file(monkeypatch, tmp_path):
+    monkeypatch.delenv("WHATSAPP_API_TOKEN", raising=False)
+    path = tmp_path / "api_token"
+    path.write_text("from-env-file")
+    monkeypatch.setenv("WHATSAPP_API_TOKEN_FILE", str(path))
+    assert auth.resolve_bridge_token() == "from-env-file"
+
+
+def test_token_missing_is_empty_not_an_exception(monkeypatch, tmp_path):
+    monkeypatch.delenv("WHATSAPP_API_TOKEN", raising=False)
+    monkeypatch.delenv("WHATSAPP_API_TOKEN_FILE", raising=False)
+    assert auth.resolve_bridge_token(token_file=str(tmp_path / "nope")) == ""
+
+
+def test_config_file_path_is_expanded(monkeypatch, tmp_path):
+    monkeypatch.delenv("WHATSAPP_API_TOKEN", raising=False)
+    monkeypatch.delenv("WHATSAPP_API_TOKEN_FILE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "api_token").write_text("tilde-token")
+    assert auth.resolve_bridge_token(token_file="~/api_token") == "tilde-token"

--- a/tests/test_wa_bridge_auth.py
+++ b/tests/test_wa_bridge_auth.py
@@ -377,6 +377,31 @@ def test_token_missing_is_empty_not_an_exception(monkeypatch, tmp_path):
     assert auth.resolve_bridge_token(token_file=str(tmp_path / "nope")) == ""
 
 
+def test_an_unreadable_file_does_not_shadow_the_environment(monkeypatch, tmp_path):
+    """A config copied to another host keeps a path that resolves to nothing.
+
+    If that dead path short-circuits, the documented env fallback is
+    unreachable exactly when it is the thing that would work.
+    """
+    monkeypatch.setenv("WHATSAPP_API_TOKEN", "from-env")
+    assert auth.resolve_bridge_token(token_file=str(tmp_path / "nope")) == "from-env"
+
+
+def test_an_empty_file_does_not_shadow_the_environment(monkeypatch, tmp_path):
+    monkeypatch.setenv("WHATSAPP_API_TOKEN", "from-env")
+    path = tmp_path / "api_token"
+    path.write_text("   \n")
+    assert auth.resolve_bridge_token(token_file=str(path)) == "from-env"
+
+
+def test_a_readable_file_still_beats_the_environment(monkeypatch, tmp_path):
+    """Precedence is unchanged when the file actually resolves."""
+    monkeypatch.setenv("WHATSAPP_API_TOKEN", "from-env")
+    path = tmp_path / "api_token"
+    path.write_text("from-file")
+    assert auth.resolve_bridge_token(token_file=str(path)) == "from-file"
+
+
 def test_config_file_path_is_expanded(monkeypatch, tmp_path):
     monkeypatch.delenv("WHATSAPP_API_TOKEN", raising=False)
     monkeypatch.delenv("WHATSAPP_API_TOKEN_FILE", raising=False)

--- a/tests/test_whatsapp_live_parity.py
+++ b/tests/test_whatsapp_live_parity.py
@@ -1,0 +1,112 @@
+"""Live parity between the HTTP and stdio WhatsApp transports (ts4k#71).
+
+Deselected by default (``-m 'not integration'``).  Run it against a real
+bridge and a real archive when changing either transport::
+
+    TS4K_WA_STDIO_CWD=~/ai/whatsapp-mcp/whatsapp-mcp-server \
+    TS4K_WA_TOKEN_FILE=~/ai/whatsapp-mcp/whatsapp-bridge/store/api_token \
+    uv run pytest tests/test_whatsapp_live_parity.py -m integration -v
+
+Both transports read the same SQLite archive through the same tool surface,
+so ts4k-level output should be identical.  Where it is not, that is the
+migration regressing — which is the whole question this file exists to answer.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import httpx
+import pytest
+
+from ts4k.adapters import wa_bridge_auth
+from ts4k.adapters.whatsapp import WhatsAppAdapter, WhatsAppAdapterConfig
+
+pytestmark = pytest.mark.integration
+
+BRIDGE_URL = os.environ.get("TS4K_WA_BRIDGE_URL", wa_bridge_auth.DEFAULT_BRIDGE_URL)
+TOKEN_FILE = os.environ.get("TS4K_WA_TOKEN_FILE", "")
+STDIO_CWD = os.environ.get("TS4K_WA_STDIO_CWD", "")
+
+
+def _require_bridge():
+    try:
+        httpx.post(BRIDGE_URL, timeout=3, trust_env=False)
+    except httpx.HTTPError as exc:
+        pytest.skip(f"bridge not reachable at {BRIDGE_URL}: {exc}")
+    if not wa_bridge_auth.resolve_bridge_token(token_file=TOKEN_FILE):
+        pytest.skip("no bridge token; set TS4K_WA_TOKEN_FILE or WHATSAPP_API_TOKEN")
+
+
+def _require_stdio():
+    if not STDIO_CWD or not Path(STDIO_CWD).expanduser().is_dir():
+        pytest.skip("set TS4K_WA_STDIO_CWD to the whatsapp-mcp-server checkout")
+
+
+def _http_adapter() -> WhatsAppAdapter:
+    return WhatsAppAdapter(
+        WhatsAppAdapterConfig(bridge_url=BRIDGE_URL, bridge_token_file=TOKEN_FILE),
+        prefix="w",
+    )
+
+
+def _stdio_adapter() -> WhatsAppAdapter:
+    return WhatsAppAdapter(
+        WhatsAppAdapterConfig(
+            transport="stdio", server_cwd=str(Path(STDIO_CWD).expanduser())
+        ),
+        prefix="w",
+    )
+
+
+async def _both(call):
+    _require_bridge()
+    _require_stdio()
+    async with _http_adapter() as http:
+        over_http = await call(http)
+    async with _stdio_adapter() as stdio:
+        over_stdio = await call(stdio)
+    return over_http, over_stdio
+
+
+async def test_http_transport_reaches_real_chats():
+    _require_bridge()
+    async with _http_adapter() as adapter:
+        chats = await adapter.list_messages(count=5)
+    assert chats, "no chats returned — the archive is empty or the call failed"
+    assert all(c["id"].startswith("w:") for c in chats)
+
+
+async def test_list_chats_matches_stdio():
+    over_http, over_stdio = await _both(lambda a: a.list_messages(count=10))
+    assert over_http == over_stdio
+
+
+async def test_whatsnew_matches_stdio():
+    # Fixed window: "last 24 hours" would drift between the two calls.
+    since = "2026-01-01T00:00:00+00:00"
+    over_http, over_stdio = await _both(lambda a: a.whatsnew(since=since))
+    assert over_http == over_stdio
+
+
+async def test_read_thread_matches_stdio():
+    _require_bridge()
+    async with _http_adapter() as adapter:
+        chats = await adapter.list_messages(count=1)
+    if not chats:
+        pytest.skip("no chats in the archive")
+    chat_id = chats[0]["id"]
+    over_http, over_stdio = await _both(lambda a: a.read_thread(chat_id))
+    assert over_http == over_stdio
+
+
+async def test_read_message_matches_stdio():
+    _require_bridge()
+    async with _http_adapter() as adapter:
+        msgs = await adapter.whatsnew(since="2026-01-01T00:00:00+00:00")
+    if not msgs:
+        pytest.skip("no recent messages in the archive")
+    msg_id = msgs[0]["id"]
+    over_http, over_stdio = await _both(lambda a: a.read_message(msg_id))
+    assert over_http == over_stdio

--- a/tests/test_whatsapp_transport.py
+++ b/tests/test_whatsapp_transport.py
@@ -220,3 +220,37 @@ def test_the_adapter_has_no_send_path():
     for name in forbidden:
         assert not hasattr(WhatsAppAdapter, name)
         assert f'"{name}"' not in source
+
+
+# ---------------------------------------------------------------------------
+# The key stays out of the terminal
+# ---------------------------------------------------------------------------
+
+
+def test_src_list_redacts_an_inline_bridge_token(ts4k_config, capsys):
+    """`src list` runs constantly in agent context — the HMAC key can't ride along.
+
+    Anyone who can read it can read the whole archive wherever the bridge is
+    reachable.  The pointer form stays visible: it is a path, not a secret.
+    """
+    import argparse
+
+    from ts4k import cli
+    from ts4k.state import sources
+
+    sources.add(
+        "w",
+        provider="whatsapp",
+        bridge_token="s3cr3t-hmac-key",
+        bridge_token_file="/keys/api_token",
+        bridge_url="http://127.0.0.1:18741/mcp",
+    )
+    cli._cmd_sources(argparse.Namespace(
+        action="list", prefix=None, provider=None, params=None,
+    ))
+
+    out = capsys.readouterr().out
+    assert "s3cr3t-hmac-key" not in out
+    assert "bridge_token: <redacted>" in out
+    assert "/keys/api_token" in out
+    assert "http://127.0.0.1:18741/mcp" in out

--- a/tests/test_whatsapp_transport.py
+++ b/tests/test_whatsapp_transport.py
@@ -254,3 +254,23 @@ def test_src_list_redacts_an_inline_bridge_token(ts4k_config, capsys):
     assert "bridge_token: <redacted>" in out
     assert "/keys/api_token" in out
     assert "http://127.0.0.1:18741/mcp" in out
+
+
+def test_src_add_redacts_an_inline_bridge_token(ts4k_config, capsys):
+    """`src add` echoes the saved entry — redacting only `list` moves the leak.
+
+    This is the branch that runs at the moment the key is first typed.
+    """
+    import argparse
+
+    from ts4k import cli
+
+    cli._cmd_sources(argparse.Namespace(
+        action="add", prefix="w", provider="whatsapp",
+        params=["bridge_token=s3cr3t-hmac-key", "bridge_token_file=/keys/api_token"],
+    ))
+
+    out = capsys.readouterr().out
+    assert "s3cr3t-hmac-key" not in out
+    assert "bridge_token: <redacted>" in out
+    assert "/keys/api_token" in out

--- a/tests/test_whatsapp_transport.py
+++ b/tests/test_whatsapp_transport.py
@@ -1,0 +1,222 @@
+"""Transport selection for the WhatsApp adapter (ts4k#71).
+
+The HTTP transport talks to the Go bridge directly; ``transport=stdio`` is the
+documented rollback that spawns the Python whatsapp-mcp-server.  These pin the
+wiring — which transport a config selects, and that the HTTP path never
+reaches for a subprocess.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+
+from ts4k import commands
+from ts4k.adapters import wa_bridge_auth, whatsapp
+from ts4k.adapters.whatsapp import WhatsAppAdapter, WhatsAppAdapterConfig
+
+
+# ---------------------------------------------------------------------------
+# Config → adapter
+# ---------------------------------------------------------------------------
+
+
+def test_http_is_the_default_transport():
+    adapter = commands._make_adapter("w", {"provider": "whatsapp"})
+    assert adapter._config.transport == "http"
+    assert adapter._config.bridge_url == wa_bridge_auth.DEFAULT_BRIDGE_URL
+
+
+def test_http_does_not_require_a_local_checkout():
+    """ts4k may run on a different host from the bridge."""
+    adapter = commands._make_adapter("w", {"provider": "whatsapp", "mcp_cwd": "/does/not/exist"})
+    assert adapter is not None
+    assert adapter._config.transport == "http"
+
+
+def test_http_carries_bridge_url_and_key_through():
+    adapter = commands._make_adapter("w", {
+        "provider": "whatsapp",
+        "bridge_url": "http://10.0.0.5:18741/mcp",
+        "bridge_token_file": "/keys/api_token",
+    })
+    assert adapter._config.bridge_url == "http://10.0.0.5:18741/mcp"
+    assert adapter._config.bridge_token_file == "/keys/api_token"
+
+
+def test_stdio_rollback(tmp_path):
+    adapter = commands._make_adapter("w", {
+        "provider": "whatsapp",
+        "transport": "stdio",
+        "mcp_cwd": str(tmp_path),
+        "server_command": "uv run python main.py",
+    })
+    assert adapter._config.transport == "stdio"
+    assert adapter._config.server_command == ["uv", "run", "python", "main.py"]
+    assert adapter._config.server_cwd == str(tmp_path)
+
+
+def test_stdio_without_a_checkout_is_unusable():
+    assert commands._make_adapter("w", {
+        "provider": "whatsapp", "transport": "stdio", "mcp_cwd": "/does/not/exist",
+    }) is None
+
+
+# ---------------------------------------------------------------------------
+# connect()
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    def __init__(self, *streams):
+        self.initialized = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return None
+
+    async def initialize(self):
+        self.initialized = True
+
+
+@pytest.fixture
+def no_subprocess(monkeypatch):
+    """Make any attempt to spawn the Python stdio server fail loudly."""
+    def boom(*args, **kwargs):
+        raise AssertionError("the HTTP transport must not spawn a subprocess")
+    monkeypatch.setattr(whatsapp, "stdio_client", boom)
+
+
+async def test_http_connect_never_spawns_a_subprocess(no_subprocess, monkeypatch):
+    seen = {}
+
+    @asynccontextmanager
+    async def fake_streamable(url, *, httpx_client_factory):
+        seen["url"] = url
+        seen["client"] = httpx_client_factory()
+        yield ("read", "write", lambda: None)
+
+    monkeypatch.setattr(whatsapp, "streamablehttp_client", fake_streamable)
+    monkeypatch.setattr(whatsapp, "ClientSession", _FakeSession)
+
+    adapter = WhatsAppAdapter(WhatsAppAdapterConfig(bridge_token="k"), prefix="w")
+    async with adapter:
+        assert adapter._session.initialized
+    assert seen["url"] == wa_bridge_auth.DEFAULT_BRIDGE_URL
+    assert seen["client"].trust_env is False
+
+
+async def test_http_connect_pins_localhost_to_the_ipv4_loopback(no_subprocess, monkeypatch):
+    seen = {}
+
+    @asynccontextmanager
+    async def fake_streamable(url, *, httpx_client_factory):
+        seen["url"] = url
+        yield ("read", "write", lambda: None)
+
+    monkeypatch.setattr(whatsapp, "streamablehttp_client", fake_streamable)
+    monkeypatch.setattr(whatsapp, "ClientSession", _FakeSession)
+
+    adapter = WhatsAppAdapter(
+        WhatsAppAdapterConfig(bridge_url="http://localhost:18741/mcp", bridge_token="k"),
+        prefix="w",
+    )
+    async with adapter:
+        pass
+    assert seen["url"] == "http://127.0.0.1:18741/mcp"
+
+
+async def test_a_failed_connect_leaves_no_half_open_adapter(monkeypatch):
+    @asynccontextmanager
+    async def fake_streamable(url, *, httpx_client_factory):
+        raise ConnectionRefusedError("bridge is down")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(whatsapp, "streamablehttp_client", fake_streamable)
+
+    adapter = WhatsAppAdapter(WhatsAppAdapterConfig(bridge_token="k"), prefix="w")
+    with pytest.raises(ConnectionRefusedError):
+        await adapter.connect()
+    assert adapter._session is None
+    assert adapter._exit_stack is None
+
+
+# ---------------------------------------------------------------------------
+# Connect failures
+# ---------------------------------------------------------------------------
+#
+# The HTTP transport runs inside an anyio task group: a failed request cancels
+# initialize(), and the error explaining why only surfaces when the group
+# unwinds during teardown.  Report either half naively and the operator is told
+# "Cancelled via cancel scope" or "unhandled errors in a TaskGroup", which name
+# nothing.
+
+
+def _adapter() -> WhatsAppAdapter:
+    return WhatsAppAdapter(WhatsAppAdapterConfig(bridge_token="k"), prefix="w")
+
+
+def test_a_401_names_the_bridge_key():
+    unauthorized = httpx.HTTPStatusError(
+        "Client error '401 Unauthorized'",
+        request=httpx.Request("POST", wa_bridge_auth.DEFAULT_BRIDGE_URL),
+        response=httpx.Response(401),
+    )
+    error = _adapter()._connect_error(
+        asyncio.CancelledError("Cancelled via cancel scope"),
+        ExceptionGroup("unhandled errors in a TaskGroup", [unauthorized]),
+    )
+    assert isinstance(error, RuntimeError)
+    assert "bridge_token" in str(error)
+    assert "401" in str(error)
+
+
+def test_the_real_cause_beats_the_cancellation():
+    refused = httpx.ConnectError("All connection attempts failed")
+    error = _adapter()._connect_error(
+        asyncio.CancelledError(),
+        ExceptionGroup("unhandled errors in a TaskGroup", [refused]),
+    )
+    assert error is refused
+
+
+def test_nested_groups_are_flattened():
+    refused = httpx.ConnectError("All connection attempts failed")
+    error = _adapter()._connect_error(
+        ExceptionGroup("outer", [ExceptionGroup("inner", [refused])]), None
+    )
+    assert error is refused
+
+
+def test_a_plain_error_is_left_alone():
+    boom = FileNotFoundError("uv")
+    assert _adapter()._connect_error(boom, None) is boom
+
+
+def test_a_genuine_cancellation_stays_a_cancellation():
+    """A caller-side timeout must not be relabelled as a bridge failure."""
+    cancelled = asyncio.CancelledError()
+    assert _adapter()._connect_error(cancelled, None) is cancelled
+
+
+# ---------------------------------------------------------------------------
+# The trifecta boundary (whatsapp-mcp#46)
+# ---------------------------------------------------------------------------
+
+
+def test_the_adapter_has_no_send_path():
+    """Read + tool-use + send is the trifecta; the third leg stays absent.
+
+    The bridge's MCP surface excludes the send tools and enforces that on its
+    own side.  This asserts ts4k does not reintroduce them from here.
+    """
+    forbidden = ("send_message", "send_file", "send_audio_message", "send")
+    source = (whatsapp.__file__ and open(whatsapp.__file__).read()) or ""
+    for name in forbidden:
+        assert not hasattr(WhatsAppAdapter, name)
+        assert f'"{name}"' not in source


### PR DESCRIPTION
Closes #71. Depends on whatsapp-mcp#45, which is live — this branch was developed and verified against the real endpoint.

## What changed

ts4k reached WhatsApp through four layers: ts4k → a spawned Python FastMCP subprocess (stdio) → SQLite + bridge HTTP → Go bridge. It now talks streamable HTTP MCP to the bridge directly. Two layers gone, no subprocess per consumer session.

`src/ts4k/adapters/wa_bridge_auth.py` is new and holds the whole auth surface. `whatsapp.py` gains a transport switch; everything downstream of `_call_tool` is unchanged.

## Auth

Challenge-response, ported from `_bridge_challenge` / `_bridge_auth_headers` / `_bridge_json_request` in whatsapp-mcp's `whatsapp-mcp-server/whatsapp.py` rather than re-derived. The token is an HMAC key and never crosses the wire: request goes out unauthenticated → 401 with a single-use nonce → re-send with an HMAC over `method \n request_target \n nonce \n sha256(body)`. **Exactly one retry** — a second 401 is reported, never re-signed.

No `Authorization: Bearer` path exists, deliberately.

Three properties are load-bearing rather than hygiene, and each has a test that fails if it is lost:

| Property | Test |
|---|---|
| Signed retry travels over a **fresh connection** (`max_keepalive_connections=0`) | `test_retry_travels_over_a_fresh_connection` — asserts the two requests arrive on different client ports |
| URL pins the literal `127.0.0.1`; `localhost` is rewritten | `test_pin_loopback` |
| `trust_env=False`, `follow_redirects=False` | `test_env_proxy_is_ignored`, `test_client_does_not_trust_the_environment` |

I mutation-checked the first one: flipping the limit back to a normal keepalive value makes it fail with two identical source ports, so it is measuring the real thing rather than a friendly server closing connections on its own.

The canonical string is built from `request.url.raw_path` and the serialized body — what was actually sent, not what the caller meant to send.

One deviation from the reference, deliberate: httpx does not apply `~/.netrc` automatically the way `requests` does, so that specific hazard cannot reach us. `trust_env=False` is set anyway, for the proxy and SSL-env class of problem.

## Config and rollback

```bash
ts4k src add w whatsapp bridge_token_file=/path/to/whatsapp-bridge/store/api_token
```

`bridge_url` defaults to `http://127.0.0.1:18741/mcp`. The key also resolves from `WHATSAPP_API_TOKEN` / `WHATSAPP_API_TOKEN_FILE`. No path is guessed from the stdio checkout — ts4k may run on a different host, where such a guess resolves to the wrong file or nothing.

Rollback, documented in `docs/setup-whatsapp.md`:

```bash
ts4k src add w whatsapp transport=stdio \
  mcp_cwd=/path/to/whatsapp-mcp/whatsapp-mcp-server \
  server_command="uv run main.py"
```

Nothing inside whatsapp-mcp is touched. The Python stdio server is unchanged and still works — that is what makes this reversible.

## Verification

`tests/test_whatsapp_live_parity.py` (integration-marked, deselected by default) runs both transports against the live bridge and a real 55k-message archive and diffs the ts4k-level output:

```
TS4K_WA_STDIO_CWD=... TS4K_WA_TOKEN_FILE=... uv run pytest tests/test_whatsapp_live_parity.py -m integration
5 passed
```

`list_chats`, `whatsnew`, `read_thread`, `read_message` — identical. CLI `list`, content search and thread reads are byte-identical too.

The "no subprocess" criterion is demonstrated rather than asserted: with `uv` removed from `PATH`, the HTTP path returns messages normally while the stdio path fails with `No such file or directory: 'uv'`.

Full suite: 941 passed, 4 skipped.

## Also in here

**Connect failures now name themselves.** The HTTP transport runs inside an anyio task group, so a failed request cancels `initialize()` and the error explaining why only surfaces at teardown. Reported naively the operator gets `Cancelled via cancel scope` or `unhandled errors in a TaskGroup` — strictly worse than the stdio path's `No such file or directory: 'uv'`. Both halves are flattened, and a 401 is translated into the config change that fixes it. `ts4k auth --check` now reports whether the bridge key resolves instead of claiming WhatsApp needs no auth.

## Not in here

No send path. `send_message` / `send_file` / `send_audio_message` stay absent; `test_the_adapter_has_no_send_path` asserts ts4k does not reintroduce them. Gated outbox is whatsapp-mcp#46.

## Two notes for the reviewer

1. **`transport` defaults to `http`**, so an existing `w` source flips over on upgrade and needs a key configured. That is the point of the migration, but it is a breaking config change for anyone whose bridge predates whatsapp-mcp#45 — they need `transport=stdio` explicitly. Flagging it rather than hiding it behind a silent fallback to the subprocess, which would make the whole switch decorative.

2. **Tool errors read slightly differently.** FastMCP prefixed them (`Error executing tool get_message_context: Message with ID X not found`); the Go surface does not (`Message with ID X not found`). Same underlying message, and the Go version is cleaner. Nothing in ts4k parses the prefix. Not worth a whatsapp-mcp issue in my view — say the word if you disagree.

**Follow-up, not done here:** `streamablehttp_client` is deprecated in favour of `streamable_http_client`, which takes a pre-built `httpx.AsyncClient` and would make the hardening more explicit. It landed between mcp 1.20 and 1.25, so adopting it means narrowing `mcp>=1.0,<2` to `>=1.25` — a dependency change beyond this issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)