### PR TITLE
Tell agents WhatsApp voice notes are already transcribed

### DIFF
--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -2150,6 +2150,8 @@ def skill_reference(level: str = "basic") -> str:
         "Sender/domain/time: --from alice@co.com, --domain co.com, --since 1w. All stack.\n"
         "  Find all from a domain: list --domain co.com --since 2023-01-01 -n 200\n"
         "  Truncated results show a continuation command \u2014 copy-paste to get older messages.\n"
+        "WhatsApp voice notes are auto-transcribed: body IS the transcript, prefixed [voice 2:11]. "
+        "Never ask the user to listen. [voice — transcript unavailable] means no text exists.\n"
         "Do NOT pipe through head/grep/awk. Use built-in flags instead:\n"
         "  Limit results: -n 20 (not | head). Search: list -q \"name\" (not | grep).\n"
         "  One call: whatsnew KEY -n 50 (not per-source calls).\n"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -206,3 +206,22 @@ class TestResolveRef:
         assert commands._resolve_ref("#1", None) == "#1"
         assert commands._resolve_ref("1", None) == "1"
         assert commands._resolve_ref("g:abc", None) == "g:abc"
+
+
+class TestSkillReference:
+    """Skill text is the agent's only self-documentation — pin what it must say."""
+
+    def test_voice_notes_are_declared_transcribed(self):
+        """Agents must not ask the user to listen to audio (ts4k#48).
+
+        The bridge folds the transcript into the message body; nothing in the
+        response shape says so, so the skill text is where an agent learns it.
+        """
+        text = commands.skill_reference("basic")
+        assert "[voice" in text
+        assert "transcript" in text.lower()
+
+    def test_voice_guidance_survives_in_one_line(self):
+        """It rides in every skill call — one line is the budget."""
+        lines = [ln for ln in commands.skill_reference("basic").splitlines() if "[voice" in ln]
+        assert len(lines) == 1, lines


### PR DESCRIPTION
Closes #48.

The issue is marked *"Blocked on the bridge work."* It isn't — the bridge side landed. Three of the four acceptance criteria were already satisfied; this PR closes the fourth.

## What I verified

`formatVoiceContent` in the bridge's `mcpformat.go` folds the transcript into the message body and handles every state:

| State | Body |
|---|---|
| `done` + text | `[voice 2:11] So I guess my basic question is…` |
| `done`, no speech | `[voice 2:11 — no speech detected]` |
| `failed` | `[voice — transcript unavailable]` |
| anything else | `[voice — transcript pending]` |

All four render correctly through `ts4k t` on both transports, against the real archive (39 done, 494 failed).

Worth noting: the `messages.content` column in SQLite is **empty** for those rows — the transcript lives in `transcriptions` and the MCP layer synthesizes the body at query time. Reading the DB directly gets you *less* than the tool surface does.

## What was actually missing

Nothing told an agent any of this. The response carries no field saying the body is a transcript, so an agent seeing an audio message has no way to know it shouldn't ask the user to go listen to it. The skill text is the only place that can say so — and it said nothing about voice notes at all.

```
WhatsApp voice notes are auto-transcribed: body IS the transcript, prefixed [voice 2:11].
Never ask the user to listen. [voice — transcript unavailable] means no text exists.
```

**+69 tokens.** It rides in every skill call, which is why it's one line rather than the four-state table I wrote first — that version cost +118 and the extra states are self-explanatory in context. Two tests pin the content and the one-line budget.

## Pre-existing, found while measuring — not fixed here

`tests/test_token_efficiency.py` pins `claude-sonnet-4-20250514`, which is retired and now returns 404. `test_skill_reference_under_200` has been **erroring rather than asserting** for a while. It skips in CI (no API key), so CI has stayed green.

Behind that failure, measured against `claude-sonnet-5`:

```
skill_reference("basic") = 1051 tokens   (budget: 200)
```

**Over by ~5×, independent of this change.** Either the budget is stale and should be re-set to something real, or the reference genuinely needs cutting — but that's a judgment call about ts4k's skill surface, not a WhatsApp fix, so I left both alone rather than bundling them in. Note also that Sonnet 5's tokenizer runs ~30% higher than Sonnet 4.6's, so re-baselining will move the number again. Happy to take it as its own issue.

Full suite: 893 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)