### PR TITLE
ci: enforce ruff (pyflakes) and clear existing violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,24 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install "ruff>=0.16"
+
+      # Config lives in pyproject.toml ([tool.ruff.lint]). One version, not the
+      # matrix — lint results don't vary by interpreter.
+      - name: Run ruff
+        run: ruff check .
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "anthropic>=0.40",
+    "ruff>=0.16",
 ]
 
 [project.scripts]
@@ -46,6 +47,15 @@ ts4k-mcp = "ts4k.server:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/ts4k"]
+
+[tool.ruff.lint]
+# Pyflakes only. These are the checks with an unambiguous right answer —
+# unused imports and variables, undefined names — and they are the ones that
+# actually cost time here: a stale import removed on main breaks any in-flight
+# branch whose tests still need it, which is how #60 and #63 both broke.
+# Style rules (E402 late imports, E741 short names) are deliberate in this
+# codebase and are not enabled; add them only with the cleanup to match.
+select = ["F"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/ts4k/adapters/gcal.py
+++ b/src/ts4k/adapters/gcal.py
@@ -213,14 +213,7 @@ class GcalAdapter(BaseAdapter):
         # Recurring event ID
         recurring_id = event.get("recurringEventId")
 
-        # Meeting link
         location = event.get("location", "")
-        conference = event.get("conferenceData", {})
-        meeting_link = ""
-        for ep in conference.get("entryPoints", []):
-            if ep.get("entryPointType") == "video":
-                meeting_link = ep.get("uri", "")
-                break
 
         return {
             "id": f"{self._prefix}:{event['id']}",

--- a/src/ts4k/cli.py
+++ b/src/ts4k/cli.py
@@ -1289,8 +1289,8 @@ def _auth_interactive(targets: list[tuple[str, dict]], no_calendar: bool) -> Non
                 server_url = cfg.get("server_url", ICLOUD_CARDDAV_URL)
                 is_generic_carddav = provider == "carddav" and not is_icloud_carddav_url(server_url)
                 print(f"  {prefix}: {provider} — no OAuth; uses an app-specific password")
-                print(f"        Generate one at https://account.apple.com "
-                      f"(Sign-In and Security → App-Specific Passwords),")
+                print("        Generate one at https://account.apple.com "
+                      "(Sign-In and Security → App-Specific Passwords),")
                 if is_generic_carddav:
                     from ts4k.adapters.carddav import carddav_credential_key
                     key = carddav_credential_key(email, server_url)
@@ -1421,7 +1421,7 @@ def _auth_o365(prefix: str, cfg: dict, no_calendar: bool) -> None:
                 scopes.extend(s for s in cal_scopes if s not in scopes)
 
     try:
-        creds = get_ms_credentials(client_id, tenant_id=tenant_id, scopes=scopes or None)
+        get_ms_credentials(client_id, tenant_id=tenant_id, scopes=scopes or None)
         print(f"Authenticated {prefix} (client {client_id[:8]}...) successfully.")
 
     except Exception as exc:

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -16,7 +16,7 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ts4k.adapters.caldav_cal import CaldavAdapter, CaldavAdapterConfig
 from ts4k.adapters.gcal import GcalAdapter, GcalAdapterConfig
@@ -41,6 +41,9 @@ from ts4k.core.format import (
 from ts4k.core.normalize import normalize, normalize_headers
 from ts4k.state import batch, cache, contacts, filters, sources, stats
 from ts4k.state.refs import RefTable
+
+if TYPE_CHECKING:
+    from ts4k.auth.health import TokenHealth
 
 logger = logging.getLogger("ts4k")
 
@@ -603,7 +606,6 @@ async def _fetch_messages(
     # Track which sources had messages dropped by count truncation
     truncated_sources: set[str] = set()
     if has_more:
-        returned_ids = {m.get("id") for m in truncated}
         for m in all_messages[count:]:
             src = m.get("source", "")
             if src:

--- a/src/ts4k/core/format.py
+++ b/src/ts4k/core/format.py
@@ -13,7 +13,11 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 from xml.sax.saxutils import escape as xml_escape, quoteattr as xml_quoteattr
+
+if TYPE_CHECKING:
+    from ts4k.state.refs import RefTable
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -59,8 +59,7 @@ class TestUpdateJob:
 
     def test_update_sets_updated_at(self):
         job_id = batch.create_job("g", "test")
-        original = batch.get_job(job_id)["updated_at"]
-        # Force a time change by sleeping briefly is unreliable,
+        # Forcing a time change by sleeping briefly is unreliable,
         # so just verify it's set
         batch.update_job(job_id, pages_fetched=1)
         updated = batch.get_job(job_id)["updated_at"]

--- a/tests/test_gmail_adapter.py
+++ b/tests/test_gmail_adapter.py
@@ -693,8 +693,6 @@ class TestGmailAdapterListMessages:
             _make_api_message(msg_id="msg1", subject="Subject 1", internal_date=EPOCH_MS_2026_02_20_09_15, format="metadata"),
             _make_api_message(msg_id="msg2", subject="Subject 2", internal_date=EPOCH_MS_2026_02_19_14_30, format="metadata"),
         ]
-        batch_idx = [0]
-
         class MockBatch:
             def __init__(self, callback):
                 self.callback = callback

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -261,7 +261,7 @@ class TestGetCredentials:
             "ts4k.auth.google.InstalledAppFlow.from_client_secrets_file",
             return_value=mock_flow,
         ) as mock_from_file:
-            result = get_credentials("user@test.com", config_dir=tmp_path)
+            get_credentials("user@test.com", config_dir=tmp_path)
             # Should have used the shared path with the default scopes.
             mock_from_file.assert_called_once_with(
                 str(shared),

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -42,8 +42,6 @@ class TestSafeWriteJson:
     def test_no_temp_files_on_failure(self, tmp_path, monkeypatch):
         p = tmp_path / "out.json"
         # Make os.replace raise to simulate a failure after write
-        original_replace = os.replace
-
         def bad_replace(src, dst):
             raise OSError("disk full")
 

--- a/tests/test_manage_commands.py
+++ b/tests/test_manage_commands.py
@@ -51,7 +51,7 @@ class TestManageMessage:
         mock_adapter.source_prefix = "g"
 
         with patch("ts4k.commands._make_adapter", return_value=mock_adapter):
-            result = await manage_message(
+            await manage_message(
                 action="archive", msg_id="g:abc,g:def,g:ghi"
             )
         assert mock_adapter.archive_message.call_count == 3

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -89,15 +89,6 @@ class TestToolRegistration:
         props = schema.get("properties", {})
         assert "tid" in props
 
-    def test_list_params(self):
-        """list has source, query, count params."""
-        tool = mcp._tool_manager._tools["list"]
-        schema = tool.parameters
-        props = schema.get("properties", {})
-        assert "source" in props
-        assert "query" in props
-        assert "count" in props
-
     def test_overview_params(self):
         """overview has source, contact, period, fmt, top."""
         tool = mcp._tool_manager._tools["overview"]


### PR DESCRIPTION
Adds a ruff gate to CI so lint drift shows up as a red check on the PR that caused it, instead of as surprise breakage somewhere else.

## Why now

This bit twice in the last few days:

- **#77's lint sweep removed `import json` and `import pytest`** from `tests/test_commands.py` as unused on main. Both #60 and #63 then failed to merge until those imports were restored, because their new tests needed them. Nothing flagged it until the merge.
- **The same precompile-plus-lint PR has been regenerated three times** (#66, #67, #77). Enforcing lint continuously removes the reason it keeps being proposed.

## Scope: `select = ["F"]`

Pyflakes only — unused imports, unused variables, undefined names. Unambiguous, and exactly the class that caused the breakage above.

Ruff's remaining default rules are deliberately **not** enabled:

| Rule | Hits | Why not |
|---|---|---|
| `E402` module import not at top | 13 | Flags the intentional late imports used to break cycles |
| `E741` ambiguous name | 12 | Short names, cosmetic |

Turning those on means a churn-heavy rewrite across ~25 sites for no correctness gain. Easy to add later with the cleanup that would make them pass.

## Two things clearing the backlog turned up

**`test_list_params` was defined twice** in one class in `tests/test_server.py` — the second shadowed the first, so it never ran. The survivor asserts a superset, so removing the duplicate puts the previously-dead `since` / `sender` / `domain` / `fmt` / `filter` assertions back into effect.

**`meeting_link` in gcal `_normalize_event`** was computed and discarded. Before deleting it I checked whether listings were silently losing the field: `caldav_cal`, `o365cal` and `gcal` all set `meeting_link` in `read_event` only, and gcal's `read_event` recomputes it independently. So the block is vestigial rather than a listing-path bug, and removal is behaviour-preserving.

The rest: unused locals, two f-strings without placeholders, and two quoted forward refs (`TokenHealth`, `RefTable`) that now resolve through `TYPE_CHECKING` imports rather than naming types absent from the module.

## Shape

Lint is its own job on a single interpreter — results don't vary by Python version, and a separate check name tells a lint failure from a test failure at a glance.

## Verification

- `ruff check .` — clean
- Full suite: 1,145 passed, 4 skipped
- Gate confirmed live: appending a stray `import os` to a test file makes `ruff check` fail, so this catches rather than merely reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)