### PR TITLE
test(tokens): restore the token-budget guard and make it run in CI

### DIFF
--- a/tests/test_token_efficiency.py
+++ b/tests/test_token_efficiency.py
@@ -1,24 +1,58 @@
 """Token efficiency regression tests for MCP tool/param naming.
 
-Uses the Anthropic token counting API to verify that tool names, parameter
-names, and overall MCP context stay within token budgets.  Skipped
-automatically when ANTHROPIC_API_KEY is not set.
+Two layers:
+
+* ``TestByteBudgets`` — coarse byte-count proxies that run **always**, including
+  in CI where no ANTHROPIC_API_KEY is set.  These catch large regressions
+  (the kind that go unnoticed for months) without an API call.
+* ``TestTokenEfficiency`` — precise budgets measured with the Anthropic token
+  counting API.  Skipped automatically when ANTHROPIC_API_KEY is not set, so
+  these run locally / manually.
 """
 
 from __future__ import annotations
 
+import json
 import os
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("ANTHROPIC_API_KEY"),
-    reason="No ANTHROPIC_API_KEY — skipping token efficiency tests",
-)
+# Token budgets below are TOKENIZER-DEPENDENT: they were measured against the
+# model pinned here and are not portable across tokenizer generations.  When
+# MODEL changes, re-measure every budget in this file and update it — do not
+# assume the old numbers still hold.
+#
+# claude-opus-5 is pinned because ts4k's consumers are Claude Code agents (the
+# `ts` skill) and MCP clients, which run Opus-tier by default.  Claude Sonnet 5
+# shares this tokenizer; measured name-level counts are identical and MCP tool
+# context differs by ~1%, so these budgets cover both.
+#
+# Last re-baselined: 2026-08-10 against claude-opus-5.
+MODEL = "claude-opus-5"
 
-MODEL = "claude-sonnet-4-20250514"
+# Names that exceed the 3-token budget.  Measured against MODEL; these are
+# tokenizer cost, not name bloat — `whatsnew` is already as short as the
+# command can be, and cal_* follow the established verb_noun convention.
+TOOL_NAME_EXCEPTIONS: dict[str, int] = {
+    "whatsnew": 5,
+    "cal_create": 4,
+    "cal_manage": 5,
+}
 
-TOOL_NAME_EXCEPTIONS: dict[str, int] = {}
+# Params that exceed the 2-token budget.  `fmt` / `cmd` are already
+# three-letter abbreviations and cost 3 tokens purely because of how the
+# tokenizer splits them; the snake_case compounds cost one token per word plus
+# the underscore.  Shortening these would hurt readability without saving
+# tokens, so they are documented exceptions rather than a raised budget.
+PARAM_NAME_EXCEPTIONS: dict[str, int] = {
+    "fmt": 3,
+    "cmd": 3,
+    "dry_run": 4,
+    "reply_to": 4,
+    "from_date": 3,
+    "to_date": 3,
+    "attendees": 3,
+}
 
 
 def _make_client():
@@ -48,13 +82,18 @@ def _get_baseline() -> int:
     return _baseline
 
 
-def _count_name_tokens(name: str) -> int:
-    """Count how many tokens a name uses, net of framing overhead.
+def _count_net_tokens(text: str) -> int:
+    """Count how many tokens *text* uses, net of framing overhead.
 
-    Measures by comparing a message containing the name vs a single-char
+    Measures by comparing a message containing *text* vs a single-char
     baseline.  The single char 'x' is 1 token, so we add 1 back.
+
+    Caveat for short identifiers: a name tokenizes differently in isolation
+    than it does inside a JSON schema, so the per-name budgets are a proxy.
+    The exception tables above were measured with this same helper, so they
+    stay self-consistent.
     """
-    raw = _count_message_tokens(name)
+    raw = _count_message_tokens(text)
     return raw - _get_baseline() + 1
 
 
@@ -91,6 +130,37 @@ def _get_tool_schemas() -> list[dict]:
     return schemas
 
 
+class TestByteBudgets:
+    """Coarse guards that run without an API key (i.e. in CI).
+
+    Byte counts are a stand-in for tokens: across these payloads the ratio is
+    ~2.3 bytes/token, so a large token regression shows up as a proportional
+    byte regression.  Ceilings are the measured size plus roughly 15% headroom
+    — loose enough for incremental edits, tight enough that a multiple-x
+    overrun fails immediately instead of going unnoticed for months.
+    """
+
+    def test_skill_reference_bytes(self):
+        """Skill self-doc rides in every call; guard its size without an API key."""
+        from ts4k.commands import skill_reference
+
+        basic = len(skill_reference("basic"))  # 2874 bytes at time of writing
+        more = len(skill_reference("more"))  # 1197 bytes at time of writing
+
+        assert basic < 3300, f"Tier 1 skill ref is {basic} bytes (budget: 3300)"
+        assert more < 1400, f"Tier 2 skill ref is {more} bytes (budget: 1400)"
+
+    def test_mcp_schema_bytes(self):
+        """Serialized MCP tool schemas — proxy for the per-call tool context."""
+        payload = len(json.dumps(_get_tool_schemas()))  # 12872 bytes at time of writing
+
+        assert payload < 14800, f"MCP tool schemas are {payload} bytes (budget: 14800)"
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"),
+    reason="No ANTHROPIC_API_KEY — skipping token efficiency tests",
+)
 class TestTokenEfficiency:
     """Validate that MCP naming stays within token budgets."""
 
@@ -100,14 +170,14 @@ class TestTokenEfficiency:
         violations = []
         for d in defs:
             name = d["name"]
-            tokens = _count_name_tokens(name)
+            tokens = _count_net_tokens(name)
             limit = TOOL_NAME_EXCEPTIONS.get(name, 3)
             if tokens > limit:
                 violations.append(f"{name}: {tokens} tokens (limit: {limit})")
         assert not violations, f"Tool names exceed budget: {violations}"
 
     def test_params_max_2_tokens(self):
-        """All MCP parameter names should be <= 2 tokens."""
+        """All MCP parameter names should be <= 2 tokens (with documented exceptions)."""
         defs = _get_tool_definitions()
         violations = []
         seen: set[str] = set()
@@ -116,18 +186,24 @@ class TestTokenEfficiency:
                 if param_name in seen:
                     continue
                 seen.add(param_name)
-                tokens = _count_name_tokens(param_name)
-                if tokens > 2:
-                    violations.append(f"{param_name}: {tokens} tokens")
-        assert not violations, f"Param names exceed 2 tokens: {violations}"
+                tokens = _count_net_tokens(param_name)
+                limit = PARAM_NAME_EXCEPTIONS.get(param_name, 2)
+                if tokens > limit:
+                    violations.append(f"{param_name}: {tokens} tokens (limit: {limit})")
+        assert not violations, f"Param names exceed budget: {violations}"
 
     def test_mcp_context_under_budget(self):
         """Total MCP tool definition context should stay within budget.
 
         The API's native tool counting includes JSON schema wrapping and type
-        annotations beyond just names/descriptions.  Budget is set based on
-        measured baseline after the rename (2705 tokens at time of writing)
-        with headroom for minor additions.
+        annotations beyond just names/descriptions.  Measured at 5590 tokens
+        against MODEL for 12 tools; budget is that plus headroom for minor
+        additions.
+
+        This is a re-baseline, not a target that is being met: the old 2300
+        budget predates the calendar tools (cal, cal_create, cal_manage) and a
+        different tokenizer.  Trimming the tool surface back toward 2300 is
+        separate work — see the follow-up issue.
         """
         client = _make_client()
         tools = _get_tool_schemas()
@@ -142,17 +218,25 @@ class TestTokenEfficiency:
             messages=[{"role": "user", "content": "hello"}],
         )
         tool_cost = with_tools.input_tokens - without_tools.input_tokens
-        assert tool_cost < 2300, f"MCP context is {tool_cost} tokens (budget: 2300)"
+        assert tool_cost < 6000, f"MCP context is {tool_cost} tokens (budget: 6000)"
 
-    def test_skill_reference_under_200(self):
-        """Skill self-doc output should be under 200 tokens."""
+    def test_skill_reference_under_budget(self):
+        """Skill self-doc output should stay within budget.
+
+        Measured against MODEL: tier 1 is 1220 tokens, tier 2 is 505.  Budgets
+        are those plus headroom.
+
+        Like the MCP context above, this is an honest re-baseline of a budget
+        that was never being met, not a claim that 200 tokens was wrong as a
+        goal.  Cutting the skill text back is separate work — see the follow-up
+        issue.
+        """
         from ts4k.commands import skill_reference
 
-        basic = skill_reference("basic")
-        more = skill_reference("more")
+        basic_tokens = _count_net_tokens(skill_reference("basic"))
+        more_tokens = _count_net_tokens(skill_reference("more"))
 
-        basic_tokens = _count_name_tokens(basic)
-        more_tokens = _count_name_tokens(more)
-
-        assert basic_tokens < 200, f"Tier 1 skill ref is {basic_tokens} tokens (budget: 200)"
-        assert more_tokens < 200, f"Tier 2 skill ref is {more_tokens} tokens (budget: 200)"
+        assert basic_tokens < 1300, (
+            f"Tier 1 skill ref is {basic_tokens} tokens (budget: 1300)"
+        )
+        assert more_tokens < 600, f"Tier 2 skill ref is {more_tokens} tokens (budget: 600)"

--- a/tests/test_token_efficiency.py
+++ b/tests/test_token_efficiency.py
@@ -144,15 +144,15 @@ class TestByteBudgets:
         """Skill self-doc rides in every call; guard its size without an API key."""
         from ts4k.commands import skill_reference
 
-        basic = len(skill_reference("basic"))  # 2874 bytes at time of writing
-        more = len(skill_reference("more"))  # 1197 bytes at time of writing
+        basic = len(skill_reference("basic").encode("utf-8"))  # 2884 bytes at time of writing
+        more = len(skill_reference("more").encode("utf-8"))  # 1197 bytes at time of writing
 
         assert basic < 3300, f"Tier 1 skill ref is {basic} bytes (budget: 3300)"
         assert more < 1400, f"Tier 2 skill ref is {more} bytes (budget: 1400)"
 
     def test_mcp_schema_bytes(self):
         """Serialized MCP tool schemas — proxy for the per-call tool context."""
-        payload = len(json.dumps(_get_tool_schemas()))  # 12872 bytes at time of writing
+        payload = len(json.dumps(_get_tool_schemas()).encode("utf-8"))  # 12872 bytes at time of writing
 
         assert payload < 14800, f"MCP tool schemas are {payload} bytes (budget: 14800)"
 


### PR DESCRIPTION
Closes #76.

## The problem
`tests/test_token_efficiency.py` is the **only** automated guard on ts4k's token budgets — the thing this project exists to protect — and it had been silently dark. It pinned `claude-sonnet-4-20250514` (retired 2026-02-19), so every test raised `NotFoundError` instead of asserting. The whole file was also `skipif`'d on `ANTHROPIC_API_KEY`, which CI never sets, so **CI stayed green the entire time**.

## Changes

**(a) Pin a current model.** `claude-opus-5`, with a comment recording that these budgets are *tokenizer-dependent* and must be re-measured whenever `MODEL` changes — so the next retirement is a known task rather than a silent break. Sonnet 5 shares this tokenizer (name counts identical, MCP context differs ~1%), so the budgets cover both.

**(b) Budgets decided individually, not blanket-raised.** Name-level misses were tokenizer cost, not name bloat (`whatsnew` did not get longer) — those are documented as explicit per-name exception tables. The two large overruns are honest **re-baselines**, labelled as such in the docstrings rather than dressed up as targets being met:

| Budget | Old | Measured | New | Verdict |
|---|---|---|---|---|
| tool names | 3 | `whatsnew` 5, `cal_manage` 5, `cal_create` 4 | 3 + exceptions | tokenizer cost |
| param names | 2 | `fmt` 3, `cmd` 3, `dry_run` 4, … | 2 + exceptions | tokenizer cost |
| skill ref tier 1 | 200 | 1220 | 1300 | re-baseline — genuine drift |
| MCP tool context | 2300 | 5590 | 6000 | re-baseline — predates the cal tools |

**(c) The structural fix — a guard that runs in CI with no API key.** New `TestByteBudgets` asserts byte-count proxies unconditionally (`skill_reference` tier 1/2, serialized MCP schemas), with ~15% headroom. A 5× overrun now fails immediately instead of going unnoticed for months. The precise API-based tests remain for local runs, now `skipif`'d at class level rather than module level.

Also reconciled `test_mcp_context_under_budget`'s docstring (claimed a 2705 baseline) with its `assert < 2300` — those could not both hold.

## Verification
- Keyless (as CI runs it): `2 passed, 4 skipped` in this file — the byte guards genuinely execute without a key.
- With a key: `6 passed` against `claude-opus-5`.
- Full suite keyless: `1197 passed, 4 skipped` (baseline 1195/4 — the two new byte guards). `ruff check .` clean.

## Follow-up
Per the issue's scope guard, this is test repair only — no skill text was rewritten. The drift it exposes (`skill_reference` at 5.6× its old budget, on the surface that rides in *every* call) warrants its own issue to decide whether that surface should be cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)