### PR TITLE
fix(carddav): reject http:// at setup and make credential keys collision-free

### DIFF
--- a/src/ts4k/adapters/carddav.py
+++ b/src/ts4k/adapters/carddav.py
@@ -16,6 +16,7 @@ Read-only by construction — every request is a PROPFIND or a REPORT.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import re
 import xml.etree.ElementTree as ET
@@ -265,22 +266,32 @@ def carddav_credential_key(email: str, server_url: str) -> str:
 
     The key is used as a directory name by ``credentials_path()``, so it
     must stay filesystem-safe — ``:`` is illegal in a Windows path, which
-    rules out both the ``#carddav:`` separator and a netloc carrying a
-    non-standard port (``host:port``), and ``/`` from the endpoint path.
-    ``#`` is used throughout instead, deterministically:
-    ``<email>#carddav#<netloc>[#<path segments>]``. The path is included
-    so two services under different paths on one origin (e.g. separate
-    Nextcloud instances) don't share a credential file.
+    rules out a netloc carrying a non-standard port (``host:port``), and
+    ``/`` from the endpoint path. A prior version substituted ``#`` for
+    both characters before concatenating, which is lossy: ``/a/b`` and
+    ``/a:b`` both became ``a#b``, so two distinct endpoints collided on
+    one credential file and the second source silently authenticated with
+    the first one's username/password. Hashing the *unmodified* endpoint
+    string (host + effective port + path, taken from ``_host_and_port``
+    before any character is replaced) avoids that: the hash input differs
+    for any two distinct endpoints, so the digest can't collide the way
+    the character-substituted string did.
+
+    NOTE: this changes the on-disk key for every already-configured
+    generic (non-iCloud) CardDAV source — the old ``#``-substituted key
+    won't be found under the new hash, so ``connect()`` reports "no
+    credentials" and the user is silently re-prompted for the
+    app-specific password on next use. That one-time re-prompt is
+    intentional and acceptable: silently fixing the key in place would
+    mean guessing which of two colliding old sources the recovered
+    password actually belongs to.
     """
     if is_icloud_carddav_url(server_url):
         return email
-    parts = urlsplit(server_url)
-    netloc = parts.netloc.replace(":", "#")
-    path = parts.path.strip("/").replace(":", "#").replace("/", "#")
-    key = f"{email}#carddav#{netloc}"
-    if path:
-        key = f"{key}#{path}"
-    return key
+    host, port = _host_and_port(server_url)
+    path = urlsplit(server_url).path.rstrip("/")
+    digest = hashlib.sha256(f"{host}:{port}{path}".encode()).hexdigest()[:16]
+    return f"{email}#carddav#{digest}"
 
 
 @dataclass

--- a/src/ts4k/cli.py
+++ b/src/ts4k/cli.py
@@ -32,6 +32,7 @@ import re
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from ts4k import commands, state
 from ts4k.adapters.o365 import O365Adapter, O365AdapterConfig
@@ -367,11 +368,12 @@ def _ensure_apple_password(
     poisoning a CalDAV source that later reuses the same email.
 
     ``credential_key`` overrides the credential file's directory name
-    (default: *email*).  Generic CardDAV setups pass a host-scoped key
-    (``<email>#carddav#<host>``) so they neither silently reuse a CalDAV
-    credential for the same email — which may be a different password for
-    a different service — nor collide with another generic CardDAV server
-    that happens to share the same email.
+    (default: *email*).  Generic CardDAV setups pass an endpoint-scoped key
+    (``<email>#carddav#<hash>``, see ``carddav_credential_key``) so they
+    neither silently reuse a CalDAV credential for the same email — which
+    may be a different password for a different service — nor collide
+    with another generic CardDAV server that happens to share the same
+    email.
     """
     from ts4k.auth.caldav import ICLOUD_CALDAV_URL, load_credentials, save_credentials
 
@@ -546,6 +548,11 @@ def _cmd_sources(args: argparse.Namespace) -> None:
                 print(f"Usage: ts4k src add {prefix} apple-contacts email=you@icloud.com")
                 return
             kwargs.setdefault("server_url", ICLOUD_CARDDAV_URL)
+            if urlsplit(kwargs["server_url"]).scheme != "https":
+                print(f"Error: {kwargs['server_url']} is not HTTPS — CardDAV requires "
+                      f"HTTPS, since credentials would otherwise be sent in cleartext. "
+                      f"Use an https:// URL for server_url.")
+                return
 
             from ts4k.adapters.carddav import carddav_credential_key
             is_icloud_contacts = is_icloud_carddav_url(kwargs["server_url"])

--- a/tests/test_carddav_adapter.py
+++ b/tests/test_carddav_adapter.py
@@ -116,7 +116,8 @@ class TestConnect:
 
     async def test_generic_server_uses_its_own_scoped_credential(self, tmp_path: Path):
         save_credentials(
-            "test@fastmail.com#carddav#carddav.fastmail.com", username="test@fastmail.com",
+            carddav_credential_key("test@fastmail.com", "https://carddav.fastmail.com/"),
+            username="test@fastmail.com",
             app_password="carddav-pw", server_url="",
             config_dir=tmp_path,
         )
@@ -180,7 +181,9 @@ class TestCredentialKey:
 
     def test_generic_server_key_is_scoped_by_email_and_host(self):
         key = carddav_credential_key("me@fastmail.com", "https://carddav.fastmail.com/")
-        assert key == "me@fastmail.com#carddav#carddav.fastmail.com"
+        assert key.startswith("me@fastmail.com#carddav#")
+        # The host/path portion is now a hash, not a readable hostname.
+        assert key != "me@fastmail.com#carddav#carddav.fastmail.com"
 
     def test_same_email_different_hosts_get_distinct_keys(self):
         """Two generic CardDAV sources sharing an email but pointed at
@@ -744,6 +747,15 @@ class TestIcloudUrlPorts:
 
 
 class TestCredentialKeyPaths:
+    def test_slash_vs_colon_in_path_get_distinct_keys(self):
+        """A prior version built the key by replacing both '/' and ':'
+        with '#', so paths '/a/b' and '/a:b' collapsed to the same
+        string and collided on one credential file — the second source
+        would silently authenticate with the first source's password."""
+        a = carddav_credential_key("me@x.com", "https://cloud.example.com/a/b")
+        b = carddav_credential_key("me@x.com", "https://cloud.example.com/a:b")
+        assert a != b
+
     def test_same_origin_different_paths_get_distinct_keys(self):
         """Two services under different paths on one origin (e.g. separate
         Nextcloud instances) must not share a credential file."""
@@ -752,8 +764,9 @@ class TestCredentialKeyPaths:
         assert a != b
         assert "/" not in a and ":" not in a.split("#", 1)[1]
 
-    def test_root_path_key_is_unchanged(self):
-        assert (
-            carddav_credential_key("me@fastmail.com", "https://carddav.fastmail.com/")
-            == "me@fastmail.com#carddav#carddav.fastmail.com"
-        )
+    def test_root_path_key_is_deterministic(self):
+        """Same email/endpoint must hash to the same key every call, or a
+        source would be re-prompted for a password on every use."""
+        key_a = carddav_credential_key("me@fastmail.com", "https://carddav.fastmail.com/")
+        key_b = carddav_credential_key("me@fastmail.com", "https://carddav.fastmail.com/")
+        assert key_a == key_b

--- a/tests/test_carddav_cli.py
+++ b/tests/test_carddav_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 
 from ts4k import cli
+from ts4k.adapters.carddav import carddav_credential_key
 from ts4k.auth.caldav import (
     ICLOUD_CALDAV_URL,
     ICLOUD_CARDDAV_URL,
@@ -14,6 +15,7 @@ from ts4k.auth.caldav import (
 from ts4k.state import sources
 
 PASSWORD = "abcd-efgh-ijkl-mnop"
+FASTMAIL_KEY = carddav_credential_key("me@fastmail.com", "https://carddav.fastmail.com/")
 
 
 def _args(provider: str, params: list[str]) -> argparse.Namespace:
@@ -77,7 +79,7 @@ class TestSrcAddAppleContacts:
         assert cfg["server_url"] == "https://carddav.fastmail.com/"
         # Non-Apple servers skip the xxxx-xxxx-xxxx-xxxx format check.
         # Credentials land under a service-scoped key, not the plain email.
-        assert load_credentials("me@fastmail.com#carddav#carddav.fastmail.com")["app_password"] == "any-password"
+        assert load_credentials(FASTMAIL_KEY)["app_password"] == "any-password"
 
     def test_generic_carddav_setup_does_not_poison_the_shared_credential(
         self, ts4k_config, monkeypatch
@@ -132,7 +134,7 @@ class TestSrcAddAppleContacts:
         assert caldav_creds["app_password"] == "caldav-pw"
         assert caldav_creds["server_url"] == "https://caldav.fastmail.com/"
 
-        carddav_creds = load_credentials("me@fastmail.com#carddav#carddav.fastmail.com")
+        carddav_creds = load_credentials(FASTMAIL_KEY)
         assert carddav_creds is not None
         assert carddav_creds["app_password"] == "carddav-pw"
 
@@ -143,7 +145,7 @@ class TestSrcAddAppleContacts:
         reused, same as the iCloud shared-credential case."""
         from ts4k.auth.caldav import save_credentials
 
-        save_credentials("me@fastmail.com#carddav#carddav.fastmail.com", username="me@fastmail.com",
+        save_credentials(FASTMAIL_KEY, username="me@fastmail.com",
                          app_password="existing-pw",
                          server_url="")
         monkeypatch.setattr(cli, "_prompt_password", _refuse_prompt)
@@ -152,7 +154,7 @@ class TestSrcAddAppleContacts:
             "email=me@fastmail.com", "server_url=https://carddav.fastmail.com/",
         ]))
 
-        creds = load_credentials("me@fastmail.com#carddav#carddav.fastmail.com")
+        creds = load_credentials(FASTMAIL_KEY)
         assert creds["app_password"] == "existing-pw"
 
     def test_two_generic_sources_same_email_different_hosts_both_prompt(
@@ -177,8 +179,8 @@ class TestSrcAddAppleContacts:
         ]))
 
         assert len(prompts) == 2  # both setups prompted; neither reused the other
-        creds_a = load_credentials("me@example.com#carddav#carddav.example-a.com")
-        creds_b = load_credentials("me@example.com#carddav#carddav.example-b.com")
+        creds_a = load_credentials(carddav_credential_key("me@example.com", "https://carddav.example-a.com/"))
+        creds_b = load_credentials(carddav_credential_key("me@example.com", "https://carddav.example-b.com/"))
         assert creds_a is not None and creds_a["app_password"] == "pw-server-a"
         assert creds_b is not None and creds_b["app_password"] == "pw-server-b"
 
@@ -191,7 +193,7 @@ class TestSrcAddAppleContacts:
         cli._cmd_sources(_args("carddav", [
             "email=me@fastmail.com", "server_url=https://carddav.fastmail.com/",
         ]))
-        creds = load_credentials("me@fastmail.com#carddav#carddav.fastmail.com")
+        creds = load_credentials(FASTMAIL_KEY)
         assert creds["app_password"] == "pass with spaces"
 
     def test_icloud_carddav_password_whitespace_is_still_normalized(
@@ -202,6 +204,41 @@ class TestSrcAddAppleContacts:
         cli._cmd_sources(_args("apple-contacts", ["email=a@icloud.com"]))
         creds = load_credentials("a@icloud.com")
         assert creds["app_password"] == "abcd-efgh-ijkl-mnop"
+
+
+class TestSrcAddGenericCarddavRejectsHttp:
+    def test_http_server_url_is_rejected_before_any_prompt(self, ts4k_config):
+        """An http:// endpoint can never connect (CarddavAdapter.connect
+        refuses it), so setup must fail here, before a password is prompted
+        for and a now-useless credential file is written."""
+        cli._cmd_sources(_args("carddav", [
+            "email=me@fastmail.com", "server_url=http://carddav.fastmail.com/",
+        ]))
+        assert "ic" not in sources.list_all()
+        key = carddav_credential_key("me@fastmail.com", "http://carddav.fastmail.com/")
+        assert load_credentials(key) is None
+
+    def test_http_server_url_error_names_the_problem(self, ts4k_config, capsys):
+        cli._cmd_sources(_args("carddav", [
+            "email=me@fastmail.com", "server_url=http://carddav.fastmail.com/",
+        ]))
+        out = capsys.readouterr().out
+        assert "https" in out.lower()
+
+    def test_http_server_url_does_not_prompt(self, ts4k_config, monkeypatch):
+        monkeypatch.setattr(cli, "_prompt_password", _refuse_prompt)
+        cli._cmd_sources(_args("carddav", [
+            "email=me@fastmail.com", "server_url=http://carddav.fastmail.com/",
+        ]))
+
+    def test_http_apple_contacts_preset_is_also_rejected(self, ts4k_config, capsys):
+        """The apple-contacts alias resolves to the iCloud HTTPS URL by
+        default, but an explicit http:// override must still be caught."""
+        cli._cmd_sources(_args("apple-contacts", [
+            "email=a@icloud.com", "server_url=http://contacts.icloud.com/",
+        ]))
+        assert "ic" not in sources.list_all()
+        assert load_credentials("a@icloud.com") is None
 
 
 class TestContactsSyncParser:
@@ -259,7 +296,7 @@ class TestAuthCarddav:
         assert "apple-contacts" not in out
         assert "ts4k src add fm carddav email=me@fastmail.com " \
                "server_url=https://carddav.fastmail.com/" in out
-        assert str(credentials_path("me@fastmail.com#carddav#carddav.fastmail.com")) in out
+        assert str(credentials_path(FASTMAIL_KEY)) in out
         assert str(credentials_path("me@fastmail.com")) not in out
 
     def test_icloud_carddav_guidance_is_unchanged(self, ts4k_config, capsys):
@@ -281,5 +318,5 @@ class TestGenericPasswordVerbatim:
         cli._cmd_sources(_args("carddav", [
             "email=me@fastmail.com", "server_url=https://carddav.fastmail.com/",
         ]))
-        creds = load_credentials("me@fastmail.com#carddav#carddav.fastmail.com")
+        creds = load_credentials(FASTMAIL_KEY)
         assert creds["app_password"] == "abcdefghijklmnop"

--- a/tests/test_carddav_commands.py
+++ b/tests/test_carddav_commands.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ts4k import commands
+from ts4k.adapters.carddav import carddav_credential_key
 from ts4k.state import contacts, sources
 
 CARDDAV_CFG = {
@@ -56,8 +57,10 @@ class TestTokenHealth:
             "provider": "carddav", "email": "me@fastmail.com",
             "server_url": "https://carddav.fastmail.com/",
         }
-        save_credentials("me@fastmail.com#carddav#carddav.fastmail.com", username="me@fastmail.com",
-                         app_password="carddav-pw", server_url="")
+        save_credentials(
+            carddav_credential_key("me@fastmail.com", "https://carddav.fastmail.com/"),
+            username="me@fastmail.com", app_password="carddav-pw", server_url="",
+        )
 
         health = commands.check_token_health("fm", cfg)
         assert health.status == "ok"


### PR DESCRIPTION
Closes #79. Two independent setup-path defects.

## 1. `http://` accepted at setup, rejected at connect time
Adding a generic CardDAV source with an `http://` server URL still prompted for the password, saved it, and registered the source as if setup had succeeded. `CarddavAdapter.connect()` then unconditionally rejected that same URL before syncing — so the source could never work, and a credential file was left behind for nothing.

The scheme is now validated in `cli.py` **after** the preset URL is resolved (so the `apple-contacts` / `icloud-contacts` aliases are covered too) and **before** `_ensure_apple_password` runs. No prompt, no credential write, no source registered — and the error names the URL and says to use `https://`.

## 2. Credential keys could collide across endpoints
`carddav_credential_key` mapped both `/` and `:` to `#` before concatenating, which is lossy: `/a/b` and `/a:b` both became `a#b`. Adding the second source saw the first credential as already existing, **skipped the prompt, and silently authenticated to the second endpoint with the first one's username and password.** That is credential misdirection, not a cosmetic key clash.

The key is now `<email>#carddav#<sha256(host:port + path)[:16]>`, hashing the **unmodified** endpoint so distinct endpoints cannot collide. A hash was chosen over a reversible encoding to avoid having to design and validate a full escaping scheme; the digest is deterministic and filesystem-safe on Windows and Linux alike.

## ⚠️ Migration impact
This changes the on-disk key for **already-configured generic (non-iCloud) CardDAV sources**. The old `#`-substituted key won't be found, so `connect()` reports no credentials and the user is re-prompted once for the same app-specific password.

- **iCloud CardDAV is unaffected** — it keys on plain email and returns before the hash.
- **All CalDAV sources are unaffected.**
- Migrating old keys forward was rejected deliberately: for a previously-*colliding* pair there is no way to know which source a recovered password belongs to, and handing over the wrong one is precisely the bug being fixed.

## Tests
`1200 passed, 4 skipped` (baseline 1195/4 — five new tests). `ruff check .` clean.
- `test_slash_vs_colon_in_path_get_distinct_keys` — the core collision repro
- `TestSrcAddGenericCarddavRejectsHttp` — rejected before any prompt, no credential written, prompt fn never called, and the `apple-contacts` preset path likewise

Pre-existing tests that hardcoded the old literal key string now compute it via `carddav_credential_key(...)`, so they stay correct independent of the encoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)