### PR TITLE
feat(whatsapp): surface image OCR/captions and add get --media

### DIFF
--- a/src/ts4k/adapters/base.py
+++ b/src/ts4k/adapters/base.py
@@ -124,6 +124,19 @@ class BaseAdapter(ABC):
         dicts as returned by :meth:`read_message`).
         """
 
+    async def download_media(self, msg_id: str) -> dict:
+        """Download the media file attached to a message.
+
+        Only adapters with a media source need to override this — the
+        default raises, matching the management methods below. Returns
+        ``{"success": bool, "file_path": str | None, "message": str}``.
+        On success, *file_path* is wherever the adapter staged the
+        downloaded file; the command layer relocates it into ts4k's own
+        media store under ``~/.config/ts4k/media/``, so callers must not
+        treat this value as a stable location.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support media download")
+
     async def mailbox_stats(self) -> dict | None:
         """Return live mailbox label/folder counts, or None if unsupported.
 

--- a/src/ts4k/adapters/whatsapp.py
+++ b/src/ts4k/adapters/whatsapp.py
@@ -455,6 +455,38 @@ class WhatsAppAdapter(BaseAdapter):
         })
         return parse_message_context_response(text, self.source_prefix)
 
+    async def download_media(self, msg_id: str) -> dict:
+        """Download the media file attached to a WhatsApp message.
+
+        The bridge's ``download_media`` tool needs both the message ID and
+        its chat JID, so this reads the message first to resolve the JID.
+        See ``BaseAdapter.download_media`` for what the returned
+        ``file_path`` means to the caller.
+        """
+        raw_id = self._strip_prefix(msg_id)
+        msg = await self.read_message(msg_id)
+        chat_jid = msg.get("chat_jid", "")
+        if not chat_jid:
+            return {
+                "success": False,
+                "file_path": None,
+                "message": "Could not resolve the chat for this message",
+            }
+
+        text = await self._call_tool("download_media", {
+            "message_id": raw_id,
+            "chat_jid": chat_jid,
+        })
+        items = _parse_ndjson(text)
+        if not items:
+            return {"success": False, "file_path": None, "message": "No response from bridge"}
+        data = items[0]
+        return {
+            "success": bool(data.get("success")),
+            "file_path": data.get("file_path"),
+            "message": data.get("message", ""),
+        }
+
     def _strip_prefix(self, prefixed_id: str) -> str:
         if prefixed_id.startswith(f"{self.source_prefix}:"):
             return prefixed_id[len(self.source_prefix) + 1:]

--- a/src/ts4k/cli.py
+++ b/src/ts4k/cli.py
@@ -139,6 +139,13 @@ async def _cmd_get(args: argparse.Namespace) -> None:
             print(f"Ref {msg_id} not found in {label}.{hint}")
             sys.exit(1)
         msg_id = resolved
+    if getattr(args, "media", False):
+        result = await commands.get_media(id=msg_id)
+        if result.error:
+            print(result.error)
+            sys.exit(1)
+        print(result.output)
+        return
     body_mode = getattr(args, "body_mode", None) or (
         "readable" if getattr(args, "readable", False) else "compact"
     )
@@ -1511,7 +1518,8 @@ def _build_parser() -> argparse.ArgumentParser:
             "  ts4k g 7 -k life                  # ref #7 from 'life' whatsnew\n"
             "  ts4k get g:18f3a2b1c4d5e6f7       # by native Gmail ID\n"
             "  ts4k g 3 -k work -f json          # ref #3, JSON output\n"
-            "  ts4k get 3 --readable             # human-readable body"
+            "  ts4k get 3 --readable             # human-readable body\n"
+            "  ts4k get w:abc123 --media         # download media, print local path"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -1525,6 +1533,11 @@ def _build_parser() -> argparse.ArgumentParser:
     get.add_argument(
         "--body-mode", choices=["compact", "readable"], default=None,
         help="Explicit body mode (overrides --readable): compact (default) or readable",
+    )
+    get.add_argument(
+        "--media", action="store_true", default=False,
+        help="Download the message's media file instead of its body; prints "
+             "the local file path (saved under ~/.config/ts4k/media/)",
     )
     _add_common_args(get)
     get.set_defaults(func=_cmd_get)

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -39,7 +39,7 @@ from ts4k.core.format import (
     format_thread_listing,
 )
 from ts4k.core.normalize import normalize, normalize_headers
-from ts4k.state import batch, cache, contacts, filters, sources, stats
+from ts4k.state import batch, cache, contacts, filters, media, sources, stats
 from ts4k.state.refs import RefTable
 
 if TYPE_CHECKING:
@@ -503,6 +503,11 @@ async def _fetch_for_source(
             for entry in listing:
                 msg = _normalize_message(entry)
                 msg.setdefault("source", prefix)
+                # WhatsApp entries carry their preview text in `body` (no
+                # separate snippet fetch, unlike Gmail/O365's snippet-only
+                # listing calls) — without this, format_listing has nothing
+                # to show and WhatsApp rows render with no preview at all.
+                msg.setdefault("snippet", msg.get("body", ""))
                 cache.store_message(msg.get("id", ""), msg, provider=provider)
                 messages.append(msg)
             return messages
@@ -795,6 +800,48 @@ async def get_message(
     return CommandResult(output=output, messages_processed=1)
 
 
+async def get_media(id: str, ref_table: RefTable | None = None) -> CommandResult:
+    """Download the media file attached to a message and return its local path.
+
+    Delegates to the adapter's ``download_media()`` (WhatsApp-only for now;
+    other adapters raise ``NotImplementedError``) then relocates whatever
+    it staged into ts4k's own media store under ``~/.config/ts4k/media/``,
+    so callers always get a stable, ts4k-owned path. Nothing here assumes
+    WhatsApp — a future Gmail/O365 attachment adapter can implement
+    ``download_media()`` and this command picks it up unchanged.
+    """
+    id = _resolve_ref(id, ref_table)
+    all_cfg = _ensure_sources()
+    try:
+        prefix = _prefix_from_id(id, all_cfg)
+    except ValueError as exc:
+        return CommandResult(error=str(exc))
+    cfg = all_cfg.get(prefix)
+
+    if not cfg:
+        return CommandResult(error=f"No source configured for prefix {prefix!r}.")
+
+    adapter = _make_adapter(prefix, cfg)
+    if adapter is None:
+        return CommandResult(error=f"Source {prefix!r} not available.")
+
+    async with adapter:
+        try:
+            result = await adapter.download_media(id)
+        except NotImplementedError:
+            return CommandResult(error=f"Source {prefix!r} does not support media download.")
+
+    if not result.get("success"):
+        return CommandResult(error=result.get("message") or "Failed to download media.")
+
+    src_path = result.get("file_path")
+    if not src_path:
+        return CommandResult(error="Bridge reported success but returned no file path.")
+
+    dest = media.save_media(src_path, id)
+    return CommandResult(output=str(dest))
+
+
 async def get_thread(
     tid: str, fmt: str = "pipe", ref_table: RefTable | None = None
 ) -> CommandResult:
@@ -895,6 +942,7 @@ async def list_messages(
                 for entry in listing or []:
                     msg = _normalize_message(entry)
                     msg.setdefault("source", prefix)
+                    msg.setdefault("snippet", msg.get("body", ""))
                     cache.store_message(msg.get("id", ""), msg, provider=provider)
                     all_messages.append(msg)
         except Exception as exc:
@@ -2607,6 +2655,9 @@ def skill_reference(level: str = "basic") -> str:
         "  Truncated results show a continuation command \u2014 copy-paste to get older messages.\n"
         "WhatsApp voice notes are auto-transcribed: body IS the transcript, prefixed [voice 2:11]. "
         "Never ask the user to listen. [voice — transcript unavailable] means no text exists.\n"
+        "WhatsApp images are auto-captioned/OCR'd: body carries [image: caption | text: OCR]. "
+        "Never say you can't see images. [image — enrichment pending] means processing, not "
+        "missing. get REF --media downloads the file and prints its local path.\n"
         "Do NOT pipe through head/grep/awk. Use built-in flags instead:\n"
         "  Limit results: -n 20 (not | head). Search: list -q \"name\" (not | grep).\n"
         "  One call: whatsnew KEY -n 50 (not per-source calls).\n"

--- a/src/ts4k/core/format.py
+++ b/src/ts4k/core/format.py
@@ -12,6 +12,7 @@ Target: 60%+ byte savings vs raw JSON pretty-print for listings.
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 from xml.sax.saxutils import escape as xml_escape, quoteattr as xml_quoteattr
@@ -567,15 +568,32 @@ def _unread_marker(msg: dict) -> str:
     return " "
 
 
+_SNIPPET_NEWLINE_RE = re.compile(r"[\r\n]+")
+
+
+def _snippet_field(msg: dict) -> str:
+    """Single-line, pipe-safe snippet for a pipe-delimited listing row.
+
+    A raw snippet can carry an embedded ``|`` (e.g. WhatsApp OCR bodies of
+    the form ``[image: caption | text: OCR]``) or embedded newlines from a
+    multiline message. Left as-is, either would corrupt the pipe record —
+    extra columns or extra rows — so both are neutralized before truncating.
+    """
+    snippet = msg.get("snippet", "").strip()
+    snippet = _SNIPPET_NEWLINE_RE.sub(" ", snippet)
+    snippet = snippet.replace("|", "/")
+    if len(snippet) > 80:
+        snippet = snippet[:77].rstrip() + "..."
+    return snippet
+
+
 def _listing_pipe_legacy(messages: list[dict]) -> str:
     """Legacy pipe listing with full IDs and ISO timestamps."""
     has_snippets = any(msg.get("snippet") for msg in messages)
     if has_snippets:
         lines = [" |SOURCE|FROM|SUBJECT|DATE|ID|SIZE|SNIPPET"]
         for msg in messages:
-            snippet = msg.get("snippet", "").strip()
-            if len(snippet) > 80:
-                snippet = snippet[:77].rstrip() + "..."
+            snippet = _snippet_field(msg)
             lines.append(
                 f"{_unread_marker(msg)}|{_source(msg)}|{msg.get('from', '')}|{msg.get('subject', '')}"
                 f"|{msg.get('date', '')}|{msg.get('id', '')}|{_size(msg)}|{snippet}"
@@ -614,10 +632,7 @@ def _listing_pipe_refs(messages: list[dict], ref_map: dict[str, int]) -> str:
                 ts = _compact_ts(msg.get("date", ""), "time")
                 row = f"{_unread_marker(msg)}|{ref}|{_source(msg)}|{msg.get('from', '')}|{msg.get('subject', '')}|{ts}|{_size(msg)}"
                 if has_snippets:
-                    snippet = msg.get("snippet", "").strip()
-                    if len(snippet) > 80:
-                        snippet = snippet[:77].rstrip() + "..."
-                    row += f"|{snippet}"
+                    row += f"|{_snippet_field(msg)}"
                 lines.append(row)
     else:
         for msg in messages:
@@ -625,10 +640,7 @@ def _listing_pipe_refs(messages: list[dict], ref_map: dict[str, int]) -> str:
             ts = _compact_ts(msg.get("date", ""), precision)
             row = f"{_unread_marker(msg)}|{ref}|{_source(msg)}|{msg.get('from', '')}|{msg.get('subject', '')}|{ts}|{_size(msg)}"
             if has_snippets:
-                snippet = msg.get("snippet", "").strip()
-                if len(snippet) > 80:
-                    snippet = snippet[:77].rstrip() + "..."
-                row += f"|{snippet}"
+                row += f"|{_snippet_field(msg)}"
             lines.append(row)
 
     return "\n".join(lines)

--- a/src/ts4k/state/__init__.py
+++ b/src/ts4k/state/__init__.py
@@ -64,7 +64,7 @@ def set_config_dir(path: Path, reason: str = "override") -> ConfigDir:
 
 def _apply_to_modules(config_dir: Path) -> None:
     """Patch ``_CONFIG_DIR`` and derived paths on all state modules."""
-    from ts4k.state import batch, cache, contacts, filters, keyed_watermarks, sources, stats, watermarks
+    from ts4k.state import batch, cache, contacts, filters, keyed_watermarks, media, sources, stats, watermarks
 
     # keyed_watermarks
     keyed_watermarks._CONFIG_DIR = config_dir
@@ -98,6 +98,10 @@ def _apply_to_modules(config_dir: Path) -> None:
     cache_dir = config_dir / "cache"
     cache._CACHE_DIR = cache_dir
     cache._INDEX_FILE = cache_dir / "index.json"
+
+    # media
+    media._CONFIG_DIR = config_dir
+    media._MEDIA_DIR = config_dir / "media"
 
 
 def reset() -> None:

--- a/src/ts4k/state/media.py
+++ b/src/ts4k/state/media.py
@@ -1,0 +1,35 @@
+"""Media download store — local files fetched via ``ts4k get --media``.
+
+Stores files under ``~/.config/ts4k/media/``. This is a new class of side
+effect for ts4k (writing user-visible files outside its own config dir has
+never happened before this), so downloads are confined to this one
+directory rather than landing in the current working directory.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+_CONFIG_DIR = Path(os.environ.get("TS4K_CONFIG_DIR", "~/.config/ts4k")).expanduser()
+_MEDIA_DIR = _CONFIG_DIR / "media"
+
+
+def media_dir() -> Path:
+    """Return the media directory, creating it on demand."""
+    _MEDIA_DIR.mkdir(parents=True, exist_ok=True)
+    return _MEDIA_DIR
+
+
+def save_media(src_path: str, msg_id: str) -> Path:
+    """Copy a downloaded file from *src_path* into the ts4k media store.
+
+    Named ``<safe-id>-<original filename>`` so files from different
+    messages never collide. Returns the absolute destination path.
+    """
+    src = Path(src_path)
+    safe_id = msg_id.replace(":", "_").replace("/", "_")
+    dest = media_dir() / f"{safe_id}-{src.name}"
+    shutil.copy2(src, dest)
+    return dest.resolve()

--- a/src/ts4k/state/media.py
+++ b/src/ts4k/state/media.py
@@ -9,16 +9,30 @@ directory rather than landing in the current working directory.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 from pathlib import Path
 
 _CONFIG_DIR = Path(os.environ.get("TS4K_CONFIG_DIR", "~/.config/ts4k")).expanduser()
 _MEDIA_DIR = _CONFIG_DIR / "media"
 
+# Anything outside this set (including both path separators, "..", and
+# drive-letter colons) is mapped to "_" so a crafted message ID can't
+# steer the destination path outside the media directory.
+_UNSAFE_ID_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+
 
 def media_dir() -> Path:
-    """Return the media directory, creating it on demand."""
+    """Return the media directory, creating it on demand.
+
+    Downloaded media is private, so the directory (and each file copied
+    into it, see ``save_media``) is restricted to the owner. ``mkdir``'s
+    ``mode`` is subject to umask and has no effect if the directory
+    already exists, so permissions are fixed up explicitly afterward.
+    """
     _MEDIA_DIR.mkdir(parents=True, exist_ok=True)
+    if os.name != "nt":
+        os.chmod(_MEDIA_DIR, 0o700)
     return _MEDIA_DIR
 
 
@@ -29,7 +43,12 @@ def save_media(src_path: str, msg_id: str) -> Path:
     messages never collide. Returns the absolute destination path.
     """
     src = Path(src_path)
-    safe_id = msg_id.replace(":", "_").replace("/", "_")
-    dest = media_dir() / f"{safe_id}-{src.name}"
+    safe_id = _UNSAFE_ID_CHARS.sub("_", msg_id)
+    media_root = media_dir()
+    dest = (media_root / f"{safe_id}-{src.name}").resolve()
+    if not dest.is_relative_to(media_root.resolve()):
+        raise ValueError(f"unsafe media id: {msg_id!r}")
     shutil.copy2(src, dest)
-    return dest.resolve()
+    if os.name != "nt":
+        os.chmod(dest, 0o600)
+    return dest

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -451,6 +451,8 @@ class TestWhatsAppImageEnrichmentListing:
 
     @pytest.mark.asyncio
     async def test_captioned_image_appears_as_snippet(self, monkeypatch):
+        # The embedded "|" is a pipe-format delimiter, so it must be
+        # neutralized rather than copied verbatim (ts4k#49 follow-up).
         body = '[image: two people by a white fence | text: "SALE 40% OFF"]'
         stub = _WaListStub([{
             "id": "w:1", "source": "w", "from": "Alice", "subject": "Fam",
@@ -461,7 +463,12 @@ class TestWhatsAppImageEnrichmentListing:
         result = await commands.whatsnew(key="test", source="w")
 
         assert "SNIPPET" in result.output
-        assert body in result.output
+        lines = result.output.split("\n")
+        header_fields = lines[0].split("|")
+        data_fields = lines[1].split("|")
+        assert len(data_fields) == len(header_fields)
+        assert "|" not in data_fields[-1]
+        assert "two people by a white fence" in result.output
 
     @pytest.mark.asyncio
     async def test_long_ocr_text_truncates_like_any_snippet(self, monkeypatch):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -406,6 +407,162 @@ class TestGetMessageReadableFallback:
 
         assert result.output != ""  # header line still present, just no body
         assert stub.calls == [False]  # single fetch only, no fallback retry
+
+
+# ---------------------------------------------------------------------------
+# WhatsApp image enrichment — listing preview + --media (ts4k#49)
+# ---------------------------------------------------------------------------
+
+
+class _WaListStub:
+    """Stub adapter for whatsnew/list_messages — returns canned entries."""
+
+    def __init__(self, messages):
+        self._messages = messages
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def whatsnew(self, since=None, sender=None, domain=None, count=200):
+        return self._messages
+
+    async def list_messages(self, query=None, count=20, page_token=None,
+                             sender=None, domain=None):
+        return self._messages
+
+
+class TestWhatsAppImageEnrichmentListing:
+    """Enrichment text must show up in listings, truncated like any other
+    snippet — WhatsApp entries carry it in `body`, with no separate
+    snippet fetch like Gmail/O365 (ts4k#49)."""
+
+    @pytest.fixture(autouse=True)
+    def _sources(self, tmp_path):
+        from ts4k import state
+        state.set_config_dir(tmp_path, reason="test")
+        (tmp_path / "sources.json").write_text(
+            json.dumps({"w": {"provider": "whatsapp"}})
+        )
+        yield
+        state.reset()
+
+    @pytest.mark.asyncio
+    async def test_captioned_image_appears_as_snippet(self, monkeypatch):
+        body = '[image: two people by a white fence | text: "SALE 40% OFF"]'
+        stub = _WaListStub([{
+            "id": "w:1", "source": "w", "from": "Alice", "subject": "Fam",
+            "date": "2026-08-10T09:00:00Z", "body": body,
+        }])
+        monkeypatch.setattr(commands, "_make_adapter", lambda prefix, cfg: stub)
+
+        result = await commands.whatsnew(key="test", source="w")
+
+        assert "SNIPPET" in result.output
+        assert body in result.output
+
+    @pytest.mark.asyncio
+    async def test_long_ocr_text_truncates_like_any_snippet(self, monkeypatch):
+        long_ocr = "x" * 100
+        body = f'[image | text: "{long_ocr}"]'
+        stub = _WaListStub([{
+            "id": "w:1", "source": "w", "from": "Alice", "subject": "Fam",
+            "date": "2026-08-10T09:00:00Z", "body": body,
+        }])
+        monkeypatch.setattr(commands, "_make_adapter", lambda prefix, cfg: stub)
+
+        result = await commands.whatsnew(key="test", source="w")
+
+        assert body not in result.output  # too long to appear whole
+        assert "..." in result.output
+
+    @pytest.mark.asyncio
+    async def test_enrichment_pending_is_not_an_empty_snippet(self, monkeypatch):
+        stub = _WaListStub([{
+            "id": "w:1", "source": "w", "from": "Alice", "subject": "Fam",
+            "date": "2026-08-10T09:00:00Z", "body": "[image — enrichment pending]",
+        }])
+        monkeypatch.setattr(commands, "_make_adapter", lambda prefix, cfg: stub)
+
+        result = await commands.whatsnew(key="test", source="w")
+
+        assert "[image — enrichment pending]" in result.output
+
+
+class _MediaStubAdapter:
+    """Stub adapter for get_media tests."""
+
+    def __init__(self, result=None, raise_not_implemented=False):
+        self._result = result
+        self._raise = raise_not_implemented
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def download_media(self, msg_id):
+        if self._raise:
+            raise NotImplementedError(f"{type(self).__name__} does not support media download")
+        return self._result
+
+
+class TestGetMedia:
+    """`ts4k get REF --media` downloads via the adapter and relocates the
+    file into ts4k's own media store (ts4k#49)."""
+
+    @pytest.fixture(autouse=True)
+    def _sources(self, tmp_path):
+        from ts4k import state
+        state.set_config_dir(tmp_path, reason="test")
+        (tmp_path / "sources.json").write_text(
+            json.dumps({"w": {"provider": "whatsapp"}})
+        )
+        yield
+        state.reset()
+
+    @pytest.mark.asyncio
+    async def test_success_copies_file_into_media_store(self, tmp_path, monkeypatch):
+        src = tmp_path / "downloaded.jpg"
+        src.write_bytes(b"fake jpeg bytes")
+        stub = _MediaStubAdapter({
+            "success": True, "file_path": str(src), "message": "Media downloaded successfully",
+        })
+        monkeypatch.setattr(commands, "_make_adapter", lambda prefix, cfg: stub)
+
+        result = await commands.get_media("w:msg1")
+
+        assert result.error is None
+        dest = Path(result.output)
+        assert dest.exists()
+        assert dest.read_bytes() == b"fake jpeg bytes"
+
+        from ts4k.state import media
+        assert dest.parent == media.media_dir()
+
+    @pytest.mark.asyncio
+    async def test_bridge_failure_surfaces_as_error(self, monkeypatch):
+        stub = _MediaStubAdapter({"success": False, "message": "Failed to download media"})
+        monkeypatch.setattr(commands, "_make_adapter", lambda prefix, cfg: stub)
+
+        result = await commands.get_media("w:msg1")
+
+        assert result.error == "Failed to download media"
+
+    @pytest.mark.asyncio
+    async def test_unsupported_adapter_reports_clearly(self, monkeypatch):
+        stub = _MediaStubAdapter(raise_not_implemented=True)
+        monkeypatch.setattr(commands, "_make_adapter", lambda prefix, cfg: stub)
+
+        result = await commands.get_media("w:msg1")
+
+        assert result.error is not None
+        assert "does not support media download" in result.error
+
+
 class TestSkillReference:
     """Skill text is the agent's only self-documentation — pin what it must say."""
 
@@ -424,6 +581,23 @@ class TestSkillReference:
         lines = [ln for ln in commands.skill_reference("basic").splitlines() if "[voice" in ln]
         assert len(lines) == 1, lines
 
+    def test_images_are_declared_captioned_and_ocrd(self):
+        """Agents must not say they can't see images (ts4k#49) — the bridge
+        folds a caption/OCR into the body automatically."""
+        text = commands.skill_reference("basic")
+        assert "[image" in text
+        assert "can't see images" in text.lower()
+
+    def test_media_flag_is_documented(self):
+        """--media is how an agent gets the actual pixels when the caption
+        or OCR text isn't enough."""
+        text = commands.skill_reference("basic")
+        assert "--media" in text
+
+    def test_image_guidance_survives_in_one_line(self):
+        """It rides in every skill call — one line is the budget."""
+        lines = [ln for ln in commands.skill_reference("basic").splitlines() if "[image" in ln]
+        assert len(lines) == 1, lines
 
 # ---------------------------------------------------------------------------
 # preload — body writes must respect provider cache gating (ts4k#64 follow-up)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -702,3 +702,67 @@ class TestUnreadFlagJson:
         assert data[0]["unread"] is True
         assert data[1]["unread"] is False
         assert "unread" not in data[2]
+
+
+# ---------------------------------------------------------------------------
+# Snippet sanitization in pipe listings
+# ---------------------------------------------------------------------------
+
+# WhatsApp image enrichment appends OCR text as documented:
+# "[image: caption | text: OCR]" — the embedded "|" must not become an
+# extra pipe-delimited column.
+OCR_MESSAGE = {
+    "id": "w:ocr1",
+    "from": "charlie",
+    "subject": "",
+    "date": "2026-02-20T09:15:00Z",
+    "body": "",
+    "source": "w",
+    "snippet": "[image: receipt | text: Total $42.10]",
+}
+
+MULTILINE_MESSAGE = {
+    "id": "w:multi1",
+    "from": "dana",
+    "subject": "",
+    "date": "2026-02-20T09:20:00Z",
+    "body": "",
+    "source": "w",
+    "snippet": "Line one\nLine two\r\nLine three",
+}
+
+
+class TestSnippetPipeSanitization:
+    """Embedded pipes/newlines in snippets must not corrupt the pipe record."""
+
+    def test_legacy_pipe_ocr_snippet_field_count(self):
+        result = format_listing([OCR_MESSAGE], "pipe")
+        lines = result.split("\n")
+        header_fields = lines[0].split("|")
+        data_fields = lines[1].split("|")
+        assert len(data_fields) == len(header_fields)
+        assert "|" not in data_fields[-1]
+
+    def test_refs_pipe_ocr_snippet_field_count(self):
+        result = format_listing([OCR_MESSAGE], "pipe", ref_map={"w:ocr1": 1})
+        data_lines = [
+            l for l in result.split("\n") if l and not l.startswith("---") and not l.startswith(" |N|")
+        ]
+        header_fields = result.split("\n")[0].split("|")
+        data_fields = data_lines[0].split("|")
+        assert len(data_fields) == len(header_fields)
+        assert "|" not in data_fields[-1]
+
+    def test_legacy_pipe_multiline_snippet_single_row(self):
+        result = format_listing([MULTILINE_MESSAGE], "pipe")
+        lines = result.split("\n")
+        # header + exactly one data row
+        assert len(lines) == 2
+        assert "\n" not in lines[1]
+
+    def test_refs_pipe_multiline_snippet_single_row(self):
+        result = format_listing([MULTILINE_MESSAGE], "pipe", ref_map={"w:multi1": 1})
+        data_lines = [
+            l for l in result.split("\n") if l and not l.startswith("---") and not l.startswith(" |N|")
+        ]
+        assert len(data_lines) == 1

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,76 @@
+"""Tests for ts4k.state.media."""
+
+import stat
+import sys
+
+import pytest
+
+from ts4k.state import media
+
+# Only the mode assertions are POSIX-specific; the traversal guard matters
+# on every platform, and most of all on the one with two path separators.
+posix_only = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX permission bits don't apply on Windows"
+)
+
+
+@pytest.fixture(autouse=True)
+def tmp_media_dir(tmp_path, monkeypatch):
+    """Point the media store at a temp directory for every test."""
+    config_dir = tmp_path / "config"
+    media_root = config_dir / "media"
+    monkeypatch.setattr(media, "_CONFIG_DIR", config_dir)
+    monkeypatch.setattr(media, "_MEDIA_DIR", media_root)
+    return media_root
+
+
+def _mode(path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+class TestMediaDir:
+    @posix_only
+    def test_creates_directory_with_owner_only_permissions(self, tmp_media_dir):
+        result = media.media_dir()
+
+        assert result == tmp_media_dir
+        assert result.is_dir()
+        assert _mode(result) == 0o700
+
+    @posix_only
+    def test_fixes_permissions_on_already_existing_directory(self, tmp_media_dir):
+        tmp_media_dir.mkdir(parents=True, mode=0o777)
+
+        media.media_dir()
+
+        assert _mode(tmp_media_dir) == 0o700
+
+
+class TestSaveMedia:
+    @posix_only
+    def test_copied_file_is_owner_only(self, tmp_path, tmp_media_dir):
+        src = tmp_path / "photo.jpg"
+        src.write_bytes(b"data")
+
+        dest = media.save_media(str(src), "w:msg1")
+
+        assert dest.read_bytes() == b"data"
+        assert _mode(dest) == 0o600
+
+    @pytest.mark.parametrize(
+        "msg_id",
+        [
+            "..\\outside:evil",
+            "../../etc/passwd",
+            "../../../etc/passwd",
+            "C:\\evil",
+        ],
+    )
+    def test_traversal_style_ids_stay_inside_media_dir(self, tmp_path, tmp_media_dir, msg_id):
+        src = tmp_path / "photo.jpg"
+        src.write_bytes(b"data")
+
+        dest = media.save_media(str(src), msg_id)
+
+        assert dest.is_relative_to(tmp_media_dir.resolve())
+        assert dest.parent == tmp_media_dir.resolve()

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -624,6 +624,36 @@ class TestPlainTextPassthrough:
         assert normalize(None) == ""
 
 
+class TestWhatsAppImageEnrichmentPassthrough:
+    """WhatsApp image OCR/caption markers must survive normalize() unmangled
+    (ts4k#49) — bracket syntax must not be mistaken for HTML, quoting, or a
+    signature and stripped."""
+
+    def test_captioned_and_ocrd_image_unchanged(self):
+        text = '[image: two people by a white fence | text: "SALE 40% OFF"]'
+        assert normalize(text) == text
+
+    def test_image_with_sender_caption_unchanged(self):
+        text = "[image: a boarding pass] look at this"
+        assert normalize(text) == text
+
+    def test_enrichment_pending_marker_not_emptied(self):
+        text = "[image — enrichment pending]"
+        result = normalize(text)
+        assert result == text
+        assert result != ""
+
+    def test_enrichment_unavailable_marker_not_emptied(self):
+        text = "[image — enrichment unavailable]"
+        result = normalize(text)
+        assert result == text
+        assert result != ""
+
+    def test_readable_mode_also_passes_through(self):
+        text = '[image: a receipt | text: "TOTAL 42,90"]'
+        assert normalize(text, mode="readable") == text
+
+
 # ---------------------------------------------------------------------------
 # 11. Header normalization
 # ---------------------------------------------------------------------------

--- a/tests/test_whatsapp_download_media.py
+++ b/tests/test_whatsapp_download_media.py
@@ -1,0 +1,94 @@
+"""Unit tests for WhatsAppAdapter.download_media (ts4k#49).
+
+The bridge's ``download_media`` tool needs both a message ID and its chat
+JID; the adapter resolves the JID by reading the message first. These pin
+that resolution and the response parsing against a mocked ``_call_tool`` —
+no live bridge involved.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ts4k.adapters.whatsapp import WhatsAppAdapter, WhatsAppAdapterConfig
+
+
+def _adapter() -> WhatsAppAdapter:
+    return WhatsAppAdapter(WhatsAppAdapterConfig())
+
+
+def _context_response(chat_jid: str | None) -> str:
+    message = {"id": "msg1", "content": "[image]", "timestamp": "2026-08-10 09:00:00"}
+    if chat_jid is not None:
+        message["chat_jid"] = chat_jid
+    return json.dumps({"message": message, "before": [], "after": []})
+
+
+@pytest.mark.asyncio
+async def test_resolves_chat_jid_then_calls_bridge(monkeypatch):
+    adapter = _adapter()
+    calls = []
+
+    async def fake_call_tool(name, arguments):
+        calls.append((name, arguments))
+        if name == "get_message_context":
+            return _context_response("123@s.whatsapp.net")
+        if name == "download_media":
+            return json.dumps({
+                "success": True,
+                "message": "Media downloaded successfully",
+                "file_path": "/store/media/123/msg1.jpg",
+                "is_thumbnail": False,
+            })
+        raise AssertionError(f"unexpected tool call: {name}")
+
+    monkeypatch.setattr(adapter, "_call_tool", fake_call_tool)
+
+    result = await adapter.download_media("w:msg1")
+
+    assert calls[0] == ("get_message_context", {"message_id": "msg1", "before": 0, "after": 0})
+    assert calls[1] == ("download_media", {"message_id": "msg1", "chat_jid": "123@s.whatsapp.net"})
+    assert result == {
+        "success": True,
+        "file_path": "/store/media/123/msg1.jpg",
+        "message": "Media downloaded successfully",
+    }
+
+
+@pytest.mark.asyncio
+async def test_bridge_failure_is_reported_not_raised(monkeypatch):
+    adapter = _adapter()
+
+    async def fake_call_tool(name, arguments):
+        if name == "get_message_context":
+            return _context_response("123@s.whatsapp.net")
+        return json.dumps({"success": False, "message": "Failed to download media"})
+
+    monkeypatch.setattr(adapter, "_call_tool", fake_call_tool)
+
+    result = await adapter.download_media("w:msg1")
+
+    assert result["success"] is False
+    assert result["file_path"] is None
+    assert result["message"] == "Failed to download media"
+
+
+@pytest.mark.asyncio
+async def test_missing_chat_jid_never_calls_download_tool(monkeypatch):
+    adapter = _adapter()
+    calls = []
+
+    async def fake_call_tool(name, arguments):
+        calls.append(name)
+        return _context_response(None)
+
+    monkeypatch.setattr(adapter, "_call_tool", fake_call_tool)
+
+    result = await adapter.download_media("w:msg1")
+
+    assert calls == ["get_message_context"]  # download_media never called
+    assert result["success"] is False
+    assert result["file_path"] is None
+    assert "chat" in result["message"].lower()


### PR DESCRIPTION
Closes #49.

Unblocked by `peterdrier/whatsapp-mcp#4` (OCR + local caption via media queue), which closed 2026-08-07 — enriched image text is **already** arriving over the existing bridge tools as `[image: <caption> | text: <ocr>]`. This surfaces it and adds a way to fetch the file.

## (a) Enriched image content in the pipeline
`normalize()` already passed `[image: … | text: …]`, `[image — enrichment pending]` and `[image — enrichment unavailable]` through unmangled in both compact and readable mode — pinned now with tests rather than assumed.

But the content wasn't reaching pipe listings at all, and this turned out to be **broader than images**: `format_listing` only ever reads a `snippet` field. Gmail/O365 adapters set it explicitly; WhatsApp puts its preview in `body` with no separate snippet fetch, and nothing copied one to the other — so **every WhatsApp listing row rendered with no preview**. Fixed with a `snippet` → `body` fallback at the two listing call sites, mirroring the fallback already used in `format.py`'s `collapse_threads`. Truncation now behaves identically to Gmail/O365.

`[image — enrichment pending]` renders verbatim in both the body and the listing snippet — never empty. An empty body reads to an agent as "no content", which is the specific failure this addresses.

## (b) `ts4k get <ref> --media`
Downloads via the adapter's `download_media()` and prints the local path. WhatsApp-only today; other adapters raise `NotImplementedError` and get a clean *"Source 'x' does not support media download"* rather than a traceback.

Source-agnostic by construction: `get_media(id, ref_table=None)` takes no WhatsApp-specific parameters — the adapter resolves the chat JID the bridge needs internally. A future Gmail/O365 attachment implementation just implements `download_media(msg_id)`.

Files land in **`~/.config/ts4k/media/`** via a new `state.media` module, not the working directory. Writing user-visible files outside the config dir is a new class of side effect for ts4k, so it's confined to one directory, created on demand, documented in CLI help, and named `<safe-id>-<basename>` so messages can't collide.

## (c) Skill text
Tier 1 gains one line: images carry OCR/caption text automatically, `[image — enrichment pending]` means processing rather than missing, and `--media` exists — so agents stop telling users "I can't see images."

**Token budget:** `skill_reference("basic")` 2874 → 3113 bytes against the 3300 ceiling from #76/PR #84; `("more")` unchanged at 1197/1400. Both pass, but this spends roughly a third of the tier-1 headroom in one change — relevant to #85.

## Tests
`1212 passed, 4 skipped` (baseline 1195/4 — 17 new). `ruff check .` clean. Bridge fully mocked; no live media downloaded.

## Notes
- This branch predates PR #84, so the byte guards aren't in its test run; both ceilings were verified manually against post-#84 numbers.
- No MCP tool was added for media download — the issue's criteria name only the CLI, and a new MCP tool carries real token cost against the tool-context budget.
- `save_media()` uses `shutil.copy2` unwrapped: if the bridge's path isn't reachable from where ts4k runs (e.g. a Docker-internal path with no bind mount) this surfaces as a traceback. Matches existing convention, but worth knowing before it meets a real bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)