### PR TITLE
feat(github): add GitHub adapter for notifications, issues and PRs

### DIFF
--- a/src/ts4k/adapters/github.py
+++ b/src/ts4k/adapters/github.py
@@ -17,11 +17,11 @@ it touches the notification inbox, never an issue, PR, or repository.
 
 All IDs are native, in one of these forms::
 
-    gh:2984571234                 a notification thread ID (from whatsnew)
-    gh:owner/repo#42              an issue or PR (from list_messages/search)
-    gh:owner/repo/comments/9      an issue-style conversation comment (read_thread)
-    gh:owner/repo/reviews/9       a PR review submission — approve/request-changes/comment
-    gh:owner/repo/pull-comments/9 a PR inline review comment, on the diff (read_thread)
+    gh:2984571234                     a notification thread ID (from whatsnew)
+    gh:owner/repo#42                  an issue or PR (from list_messages/search)
+    gh:owner/repo/comments/9          an issue-style conversation comment (read_thread)
+    gh:owner/repo/pulls/42/reviews/9  a PR review submission — approve/request-changes/comment
+    gh:owner/repo/pull-comments/9     a PR inline review comment, on the diff (read_thread)
 
 Review submissions and inline review comments are surfaced only when
 ``read_thread`` is called on a pull request — a plain issue has neither.
@@ -169,6 +169,11 @@ _COMMENT_ID = re.compile(r"^([^/\s]+)/([^/#\s]+)/comments/(\d+)$")
 # issue comment's — the two ranges overlap, and a shared shape would send
 # one to the wrong endpoint.
 _REVIEW_COMMENT_ID = re.compile(r"^([^/\s]+)/([^/#\s]+)/pull-comments/(\d+)$")
+# A review submission's single-item endpoint is nested under its pull
+# request (/pulls/{number}/reviews/{id}), so the ID must carry the PR
+# number as well — unlike an issue comment or inline review comment, whose
+# endpoints are addressable by comment ID alone.
+_REVIEW_ID = re.compile(r"^([^/\s]+)/([^/#\s]+)/pulls/(\d+)/reviews/(\d+)$")
 _NOTIFICATION_ID = re.compile(r"^\d+$")
 
 
@@ -183,16 +188,19 @@ def parse_id(raw_id: str) -> tuple[str, tuple[str, ...]]:
     """Classify a de-prefixed ID.
 
     Returns ``("notification", (id,))``, ``("issue", (owner, repo, number))``,
-    ``("comment", (owner, repo, comment_id))`` or ``("review_comment",
-    (owner, repo, comment_id))``.  Raises ``ValueError`` for anything else,
-    so a mistyped ID fails loudly rather than being sent to GitHub as a
-    guess.
+    ``("comment", (owner, repo, comment_id))``, ``("review_comment",
+    (owner, repo, comment_id))`` or ``("review", (owner, repo, number,
+    review_id))``.  Raises ``ValueError`` for anything else, so a mistyped
+    ID fails loudly rather than being sent to GitHub as a guess.
     """
     if _NOTIFICATION_ID.match(raw_id):
         return "notification", (raw_id,)
     m = _REVIEW_COMMENT_ID.match(raw_id)
     if m:
         return "review_comment", m.groups()
+    m = _REVIEW_ID.match(raw_id)
+    if m:
+        return "review", m.groups()
     m = _COMMENT_ID.match(raw_id)
     if m:
         return "comment", m.groups()
@@ -314,7 +322,9 @@ def _comment_to_dict(
     }
 
 
-def _review_to_dict(review: dict, prefix: str, repo: str, subject: str) -> dict:
+def _review_to_dict(
+    review: dict, prefix: str, repo: str, number: str, subject: str
+) -> dict:
     """Convert a pull-request review submission to a normalised message dict.
 
     A review can carry no prose at all — a bare "Approve" or "Request
@@ -323,6 +333,11 @@ def _review_to_dict(review: dict, prefix: str, repo: str, subject: str) -> dict:
     bracketed tag, the same way notification categories are (see
     ``_notification_to_dict``), so it survives even the pipe format,
     which renders nothing but ``from``, ``date``, and ``body``.
+
+    The ID carries *number* (the pull request it belongs to) because
+    GitHub's single-review endpoint is nested under the PR
+    (``/pulls/{pull_number}/reviews/{review_id}``) — a review ID with no PR
+    number has nothing for ``read_message``/``parse_id`` to resolve.
     """
     rid = review.get("id", "")
     state = (review.get("state") or "").upper()
@@ -330,8 +345,8 @@ def _review_to_dict(review: dict, prefix: str, repo: str, subject: str) -> dict:
     if state:
         body = f"[{state}] {body}".strip()
     return {
-        "id": f"{prefix}:{repo}/reviews/{rid}",
-        "raw_id": f"{repo}/reviews/{rid}",
+        "id": f"{prefix}:{repo}/pulls/{number}/reviews/{rid}",
+        "raw_id": f"{repo}/pulls/{number}/reviews/{rid}",
         "source": prefix,
         "from": (review.get("user") or {}).get("login", ""),
         "subject": subject,
@@ -496,6 +511,11 @@ class GitHubAdapter(BaseAdapter):
         *sender* and *domain* are email filters; a GitHub notification has
         no email sender, so a query scoped to one returns nothing here
         rather than flooding it with unrelated rows.
+
+        Defaults *since* to the last 24 hours when not given — that default
+        is specific to this "what's new" entry point; ``list_messages``'s
+        queryless path calls ``_fetch_notifications`` directly to read the
+        full unread feed without it.
         """
         if sender or domain:
             return []
@@ -504,21 +524,30 @@ class GitHubAdapter(BaseAdapter):
             yesterday = datetime.now(timezone.utc) - timedelta(days=1)
             since = yesterday.strftime("%Y-%m-%dT%H:%M:%SZ")
 
+        return await self._fetch_notifications(since, count)
+
+    async def _fetch_notifications(self, since: str | None, count: int) -> list[dict]:
+        """Page through ``/notifications``, optionally filtered by *since*.
+
+        *since* is ``None`` when the caller wants the unread feed
+        unfiltered by recency — GitHub's ``/notifications`` has no implicit
+        time cutoff of its own; that only exists because ``whatsnew``
+        chooses to apply one.
+        """
         results: list[dict] = []
         page = 1
         while len(results) < count:
-            data = await self._get(
-                "/notifications",
-                {
-                    # Explicit rather than relying on GitHub's default:
-                    # mark_read only removes an item from this feed while
-                    # it stays scoped to unread.
-                    "all": "false",
-                    "since": since,
-                    "per_page": _NOTIFICATIONS_PAGE_SIZE,
-                    "page": page,
-                },
-            )
+            params: dict[str, Any] = {
+                # Explicit rather than relying on GitHub's default:
+                # mark_read only removes an item from this feed while
+                # it stays scoped to unread.
+                "all": "false",
+                "per_page": _NOTIFICATIONS_PAGE_SIZE,
+                "page": page,
+            }
+            if since:
+                params["since"] = since
+            data = await self._get("/notifications", params)
             if not isinstance(data, list) or not data:
                 break
             results.extend(_notification_to_dict(n, self._prefix) for n in data)
@@ -547,17 +576,21 @@ class GitHubAdapter(BaseAdapter):
 
         if not query:
             # No query to search with — the notification feed is the only
-            # thing GitHub can list without one.
-            return await self.whatsnew(count=count)
+            # thing GitHub can list without one. Fetch it directly rather
+            # than through whatsnew(), which applies a 24-hour cutoff that
+            # would make anything unread for longer silently disappear
+            # from this listing.
+            return await self._fetch_notifications(None, count)
 
         page = int(page_token) if page_token and page_token.isdigit() else 1
+        per_page = min(count, _SEARCH_PAGE_SIZE)
         data = await self._get(
             "/search/issues",
             {
                 "q": query,
                 "sort": "updated",
                 "order": "desc",
-                "per_page": min(count, _SEARCH_PAGE_SIZE),
+                "per_page": per_page,
                 "page": page,
             },
         )
@@ -567,7 +600,11 @@ class GitHubAdapter(BaseAdapter):
         results = [r for r in results if r][:count]
 
         total = data.get("total_count", 0) if isinstance(data, dict) else 0
-        if results and page * count < total:
+        # Use the actual page size, not the requested count: when count
+        # exceeds GitHub's 100-item cap, per_page is capped but count isn't,
+        # so comparing against count would understate how many pages remain
+        # and drop the continuation token before all matches are fetched.
+        if results and page * per_page < total:
             results[-1]["_next_page_token"] = str(page + 1)
 
         return results
@@ -594,6 +631,13 @@ class GitHubAdapter(BaseAdapter):
                 segment="pull-comments" if review else "comments",
             )
 
+        if kind == "review":
+            owner, repo, number, rid = parts
+            review_obj = await self._get(
+                f"/repos/{owner}/{repo}/pulls/{number}/reviews/{rid}"
+            )
+            return _review_to_dict(review_obj, self._prefix, f"{owner}/{repo}", number, "")
+
         owner, repo, number = parts
         ref = f"{owner}/{repo}#{number}"
         issue = await self._get(f"/repos/{owner}/{repo}/issues/{number}")
@@ -614,7 +658,7 @@ class GitHubAdapter(BaseAdapter):
         if kind == "notification":
             ref = await self._issue_ref_for_notification(parts[0])
             parts = tuple(re.split(r"[/#]", ref))
-        elif kind in ("comment", "review_comment"):
+        elif kind in ("comment", "review_comment", "review"):
             raise ValueError(
                 f"{thread_id!r} is a comment, not a thread — use the issue ID "
                 "(gh:owner/repo#42)."
@@ -671,18 +715,24 @@ class GitHubAdapter(BaseAdapter):
         """
         feedback: list[dict] = []
 
-        reviews = await self._get(
-            f"/repos/{owner}/{repo}/pulls/{number}/reviews",
-            {"per_page": _COMMENTS_PAGE_SIZE},
-        )
-        if isinstance(reviews, list):
+        page = 1
+        while True:
+            reviews = await self._get(
+                f"/repos/{owner}/{repo}/pulls/{number}/reviews",
+                {"per_page": _COMMENTS_PAGE_SIZE, "page": page},
+            )
+            if not isinstance(reviews, list) or not reviews:
+                break
             feedback.extend(
-                _review_to_dict(r, self._prefix, f"{owner}/{repo}", subject)
+                _review_to_dict(r, self._prefix, f"{owner}/{repo}", number, subject)
                 for r in reviews
                 # PENDING is the reviewer's own draft, not yet submitted —
                 # nothing to notify anyone about until it's submitted.
                 if (r.get("state") or "").upper() != "PENDING"
             )
+            if len(reviews) < _COMMENTS_PAGE_SIZE:
+                break
+            page += 1
 
         page = 1
         while True:

--- a/src/ts4k/adapters/github.py
+++ b/src/ts4k/adapters/github.py
@@ -1,0 +1,632 @@
+"""GitHub adapter — direct REST API client via httpx.
+
+Calls ``api.github.com`` directly with a personal access token, following
+the same shape as the O365 adapter (``httpx.AsyncClient`` built in
+``connect()``, converters that turn API JSON into normalised ts4k dicts).
+
+GitHub is a *notification* source, not a mailbox: ``whatsnew`` reads
+``/notifications`` (the same feed as github.com/notifications) and each
+row is classified into a category — ``ci``, ``review``, ``mention``,
+``assignment``, ``dependabot``, ``release``, or the raw GitHub *reason*
+when none of those fit.  Categories are suppressible through the normal
+filter config (``ts4k filter add-category ci``).
+
+ts4k reads GitHub, it never writes to it.  The only mutating call in this
+adapter is ``mark_read``, which marks a *notification thread* as read —
+it touches the notification inbox, never an issue, PR, or repository.
+
+Two ID forms are returned, both native::
+
+    gh:2984571234            a notification thread ID (from whatsnew)
+    gh:owner/repo#42         an issue or PR (from list_messages/search)
+    gh:owner/repo/comments/9 a single issue comment (from read_thread)
+
+Usage::
+
+    adapter = GitHubAdapter(GitHubAdapterConfig(token="<pat>"))
+    async with adapter:
+        notifications = await adapter.whatsnew()
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from ts4k.adapters.base import BaseAdapter
+
+logger = logging.getLogger(__name__)
+
+API_BASE = "https://api.github.com"
+
+# Pinning the API version keeps response shapes stable across GitHub's
+# rolling changes (https://docs.github.com/rest/overview/api-versions).
+API_VERSION = "2022-11-28"
+
+# The notifications endpoint caps per_page at 50; search caps at 100.
+_NOTIFICATIONS_PAGE_SIZE = 50
+_SEARCH_PAGE_SIZE = 100
+_COMMENTS_PAGE_SIZE = 100
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GitHubAdapterConfig:
+    """All knobs for the GitHub adapter."""
+
+    token: str = ""
+    """Personal access token.  Prefer *token_file* or the environment."""
+
+    token_file: str | None = None
+    """Path to a file holding the PAT — keeps it out of sources.json."""
+
+    level: str | None = None
+    """Access level: readonly (default), modify (allows mark_read)."""
+
+
+def resolve_token(token: str | None = None, token_file: str | None = None) -> str:
+    """Resolve the PAT, or ``""`` when none is configured.
+
+    Order: explicit config value, config file, then ``GITHUB_TOKEN`` /
+    ``GH_TOKEN`` — the two variables the ``gh`` CLI itself reads.  The
+    token is never logged; only whether one was found.
+    """
+    if token and token.strip():
+        return token.strip()
+    if token_file and token_file.strip():
+        from_file = _read_token_file(token_file.strip())
+        if from_file:
+            return from_file
+    for var in ("GITHUB_TOKEN", "GH_TOKEN"):
+        env = os.environ.get(var, "").strip()
+        if env:
+            return env
+    return ""
+
+
+def _read_token_file(path: str) -> str:
+    try:
+        return Path(path).expanduser().read_text(encoding="utf-8").strip()
+    except OSError:
+        logger.warning("GitHub token file %s is unreadable", path)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Categories
+# ---------------------------------------------------------------------------
+
+# GitHub's notification `reason` → ts4k category.  Reasons with no entry
+# here pass through unchanged (comment, author, subscribed, state_change,
+# ...), so nothing is silently collapsed into a bucket it doesn't belong in.
+_REASON_CATEGORIES = {
+    "ci_activity": "ci",
+    "review_requested": "review",
+    "approval_requested": "review",
+    "mention": "mention",
+    "team_mention": "mention",
+    "assign": "assignment",
+    "security_alert": "dependabot",
+    "security_advisory_credit": "dependabot",
+}
+
+# `subject.type` → category, checked before the reason map: a release or a
+# check-suite notification is that regardless of why it was delivered.
+_SUBJECT_CATEGORIES = {
+    "Release": "release",
+    "CheckSuite": "ci",
+    "RepositoryVulnerabilityAlert": "dependabot",
+}
+
+# Dependabot's PR titles use a fixed template ("Bump foo from 1.0 to 1.1").
+# The notification payload carries no author, so the title is the only
+# signal available without spending an extra API call per row.
+_DEPENDABOT_TITLE = re.compile(r"^Bump \S+ from \S+ to \S+", re.IGNORECASE)
+
+
+def classify(notification: dict) -> str:
+    """Return the ts4k category for a GitHub notification object."""
+    subject = notification.get("subject") or {}
+    subject_type = subject.get("type", "")
+
+    category = _SUBJECT_CATEGORIES.get(subject_type)
+    if category:
+        return category
+
+    if subject_type == "PullRequest" and _DEPENDABOT_TITLE.match(
+        subject.get("title", "") or ""
+    ):
+        return "dependabot"
+
+    reason = notification.get("reason", "") or ""
+    return _REASON_CATEGORIES.get(reason, reason or "other")
+
+
+# ---------------------------------------------------------------------------
+# ID handling
+# ---------------------------------------------------------------------------
+
+_ISSUE_ID = re.compile(r"^([^/\s]+)/([^/#\s]+)#(\d+)$")
+_COMMENT_ID = re.compile(r"^([^/\s]+)/([^/#\s]+)/comments/(\d+)$")
+_NOTIFICATION_ID = re.compile(r"^\d+$")
+
+
+def _strip_prefix(prefixed_id: str, prefix: str) -> str:
+    """Remove the source prefix from an ID if present."""
+    if prefixed_id.startswith(f"{prefix}:"):
+        return prefixed_id[len(prefix) + 1:]
+    return prefixed_id
+
+
+def parse_id(raw_id: str) -> tuple[str, tuple[str, ...]]:
+    """Classify a de-prefixed ID.
+
+    Returns ``("notification", (id,))``, ``("issue", (owner, repo, number))``
+    or ``("comment", (owner, repo, comment_id))``.  Raises ``ValueError``
+    for anything else, so a mistyped ID fails loudly rather than being
+    sent to GitHub as a guess.
+    """
+    if _NOTIFICATION_ID.match(raw_id):
+        return "notification", (raw_id,)
+    m = _COMMENT_ID.match(raw_id)
+    if m:
+        return "comment", m.groups()
+    m = _ISSUE_ID.match(raw_id)
+    if m:
+        return "issue", m.groups()
+    raise ValueError(
+        f"Unrecognised GitHub ID {raw_id!r} — expected a notification ID "
+        "(gh:2984571234) or an issue/PR (gh:owner/repo#42)."
+    )
+
+
+def _repo_from_url(url: str) -> tuple[str, str]:
+    """Extract ``(owner, repo)`` from any api.github.com repo URL."""
+    parts = httpx.URL(url).path.strip("/").split("/")
+    if len(parts) >= 3 and parts[0] == "repos":
+        return parts[1], parts[2]
+    raise ValueError(f"Cannot derive a repository from {url!r}")
+
+
+def _issue_ref_from_url(url: str) -> str:
+    """Turn ``.../repos/o/r/pulls/42`` into ``o/r#42``.
+
+    Only issue and PR URLs convert.  Releases, commits, and check suites
+    have no issue number, and guessing one from the trailing path segment
+    would build an ID pointing at an unrelated issue.
+    """
+    parts = httpx.URL(url).path.strip("/").split("/")
+    if (
+        len(parts) >= 5
+        and parts[0] == "repos"
+        and parts[3] in ("issues", "pulls")
+        and parts[4].isdigit()
+    ):
+        return f"{parts[1]}/{parts[2]}#{parts[4]}"
+    raise ValueError(f"Cannot derive an issue reference from {url!r}")
+
+
+# ---------------------------------------------------------------------------
+# Response converters
+# ---------------------------------------------------------------------------
+
+
+def _notification_to_dict(notification: dict, prefix: str) -> dict:
+    """Convert one ``/notifications`` entry to a normalised header dict.
+
+    ``from`` is the repository, which is what a GitHub notification is
+    actually "from" — and it makes ``ts4k filter add-sender owner/repo``
+    suppress a noisy repository with no new machinery.
+    """
+    raw_id = str(notification.get("id", ""))
+    subject = notification.get("subject") or {}
+    repo = (notification.get("repository") or {}).get("full_name", "")
+    category = classify(notification)
+
+    thread_id = ""
+    subject_url = subject.get("url") or ""
+    if subject_url:
+        try:
+            thread_id = f"{prefix}:{_issue_ref_from_url(subject_url)}"
+        except ValueError:
+            # Commit / Release / Discussion subjects have no issue number.
+            thread_id = ""
+
+    return {
+        "id": f"{prefix}:{raw_id}",
+        "raw_id": raw_id,
+        "source": prefix,
+        "thread_id": thread_id,
+        "from": repo,
+        # The category leads the subject so it is visible in every output
+        # format without widening the pipe listing by a column.
+        "subject": f"[{category}] {subject.get('title', '')}".strip(),
+        "date": notification.get("updated_at", ""),
+        "category": category,
+        "unread": bool(notification.get("unread", False)),
+    }
+
+
+def _issue_to_dict(issue: dict, prefix: str, ref: str) -> dict:
+    """Convert an issue or PR object to a normalised message dict."""
+    return {
+        "id": f"{prefix}:{ref}",
+        "raw_id": ref,
+        "source": prefix,
+        "thread_id": f"{prefix}:{ref}",
+        "from": (issue.get("user") or {}).get("login", ""),
+        "subject": issue.get("title", ""),
+        "date": issue.get("created_at", ""),
+        "body": issue.get("body") or "",
+        "state": issue.get("state", ""),
+        "url": issue.get("html_url", ""),
+        "comment_count": issue.get("comments", 0),
+        "is_pull_request": "pull_request" in issue,
+    }
+
+
+def _comment_to_dict(comment: dict, prefix: str, repo: str, subject: str) -> dict:
+    """Convert an issue comment to a normalised message dict."""
+    cid = comment.get("id", "")
+    return {
+        "id": f"{prefix}:{repo}/comments/{cid}",
+        "raw_id": f"{repo}/comments/{cid}",
+        "source": prefix,
+        "from": (comment.get("user") or {}).get("login", ""),
+        "subject": subject,
+        "date": comment.get("created_at", ""),
+        "body": comment.get("body") or "",
+        "url": comment.get("html_url", ""),
+    }
+
+
+def _search_item_to_dict(item: dict, prefix: str) -> dict:
+    """Convert a ``/search/issues`` hit to a normalised header dict."""
+    try:
+        ref = _issue_ref_from_url(item.get("url", ""))
+    except ValueError:
+        repo_url = item.get("repository_url", "")
+        try:
+            owner, repo = _repo_from_url(repo_url)
+        except ValueError:
+            return {}
+        ref = f"{owner}/{repo}#{item.get('number', '')}"
+
+    return {
+        "id": f"{prefix}:{ref}",
+        "raw_id": ref,
+        "source": prefix,
+        "thread_id": f"{prefix}:{ref}",
+        "from": (item.get("user") or {}).get("login", ""),
+        "subject": item.get("title", ""),
+        "date": item.get("updated_at", "") or item.get("created_at", ""),
+        "snippet": (item.get("body") or "")[:200],
+        "state": item.get("state", ""),
+        "is_pull_request": "pull_request" in item,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class GitHubAdapter(BaseAdapter):
+    """GitHub adapter using direct REST API calls via httpx."""
+
+    def __init__(self, config: GitHubAdapterConfig, prefix: str = "gh") -> None:
+        self._config = config
+        self._prefix = prefix
+        self._client: httpx.AsyncClient | None = None
+        from ts4k.core.levels import parse_level
+        self._access_level = parse_level(config.level)
+
+    @property
+    def source_prefix(self) -> str:
+        return self._prefix
+
+    # -- Lifecycle ----------------------------------------------------------
+
+    async def connect(self) -> None:
+        if self._client is not None:
+            return
+
+        token = resolve_token(self._config.token, self._config.token_file)
+        if not token:
+            raise RuntimeError(
+                "No GitHub token configured. Create a fine-grained PAT with "
+                "Notifications: read (plus Contents/Issues: read for the repos "
+                "you follow), then: ts4k src add "
+                f"{self._prefix} github token_file=<path>"
+            )
+
+        self._client = httpx.AsyncClient(
+            base_url=API_BASE,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": API_VERSION,
+            },
+            timeout=httpx.Timeout(30.0),
+        )
+        logger.info("GitHubAdapter connected")
+
+    async def disconnect(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+            logger.info("GitHubAdapter disconnected")
+
+    async def __aenter__(self) -> GitHubAdapter:
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.disconnect()
+
+    def _require_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            raise RuntimeError(
+                "GitHubAdapter is not connected. Call connect() or use "
+                "'async with adapter:' first."
+            )
+        return self._client
+
+    # -- Transport ----------------------------------------------------------
+
+    def _check(self, resp: httpx.Response) -> None:
+        """Turn GitHub's error responses into actionable exceptions.
+
+        A bad token and an exhausted rate limit are the two failures an
+        operator actually hits, and ``raise_for_status`` names neither.
+        Anything else falls through to httpx's own error.
+        """
+        status = resp.status_code
+        if status == 401:
+            raise RuntimeError(
+                "GitHub rejected the token (401). Check that the PAT is "
+                "current and has Notifications: read."
+            )
+        if status in (403, 429) and resp.headers.get("X-RateLimit-Remaining") == "0":
+            reset = resp.headers.get("X-RateLimit-Reset", "")
+            when = ""
+            if reset.isdigit():
+                when = datetime.fromtimestamp(int(reset), timezone.utc).strftime(
+                    " (resets %Y-%m-%dT%H:%M:%SZ)"
+                )
+            raise RuntimeError(f"GitHub rate limit exceeded{when}.")
+        resp.raise_for_status()
+
+    async def _get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        """GET *path* and return the parsed JSON body."""
+        client = self._require_client()
+        resp = await client.get(path, params=params or None)
+        self._check(resp)
+        try:
+            return resp.json()
+        except ValueError as exc:
+            # A proxy or a maintenance page can answer 200 with HTML; that
+            # must not surface as a bare JSONDecodeError from deep inside.
+            raise RuntimeError(
+                f"GitHub returned a non-JSON response for {path}"
+            ) from exc
+
+    # -- BaseAdapter data methods -------------------------------------------
+
+    async def whatsnew(
+        self,
+        since: str | None = None,
+        sender: str | None = None,
+        domain: str | None = None,
+        count: int = 200,
+    ) -> list[dict]:
+        """Return notifications updated since *since*.
+
+        Only unread notifications are returned — that is GitHub's own
+        default for this endpoint, and it is what makes ``mark_read``
+        remove an item from the feed.
+
+        *sender* and *domain* are email filters; a GitHub notification has
+        no email sender, so a query scoped to one returns nothing here
+        rather than flooding it with unrelated rows.
+        """
+        if sender or domain:
+            return []
+
+        if not since:
+            yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+            since = yesterday.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        results: list[dict] = []
+        page = 1
+        while len(results) < count:
+            data = await self._get(
+                "/notifications",
+                {
+                    # Explicit rather than relying on GitHub's default:
+                    # mark_read only removes an item from this feed while
+                    # it stays scoped to unread.
+                    "all": "false",
+                    "since": since,
+                    "per_page": _NOTIFICATIONS_PAGE_SIZE,
+                    "page": page,
+                },
+            )
+            if not isinstance(data, list) or not data:
+                break
+            results.extend(_notification_to_dict(n, self._prefix) for n in data)
+            if len(data) < _NOTIFICATIONS_PAGE_SIZE:
+                break
+            page += 1
+
+        results.sort(key=lambda m: m.get("date", ""), reverse=True)
+        return results[:count]
+
+    async def list_messages(
+        self,
+        query: str | None = None,
+        count: int = 20,
+        page_token: str | None = None,
+        sender: str | None = None,
+        domain: str | None = None,
+    ) -> list[dict]:
+        """Search issues and PRs, or list notifications when *query* is empty.
+
+        *query* is GitHub search syntax (``repo:owner/name is:open``).
+        *page_token* is a 1-based page number.
+        """
+        if sender or domain:
+            return []
+
+        if not query:
+            # No query to search with — the notification feed is the only
+            # thing GitHub can list without one.
+            return await self.whatsnew(count=count)
+
+        page = int(page_token) if page_token and page_token.isdigit() else 1
+        data = await self._get(
+            "/search/issues",
+            {
+                "q": query,
+                "sort": "updated",
+                "order": "desc",
+                "per_page": min(count, _SEARCH_PAGE_SIZE),
+                "page": page,
+            },
+        )
+
+        items = data.get("items", []) if isinstance(data, dict) else []
+        results = [_search_item_to_dict(i, self._prefix) for i in items]
+        results = [r for r in results if r][:count]
+
+        total = data.get("total_count", 0) if isinstance(data, dict) else 0
+        if results and page * count < total:
+            results[-1]["_next_page_token"] = str(page + 1)
+
+        return results
+
+    async def read_message(self, msg_id: str, prefer_html: bool = False) -> dict:
+        """Read an issue, PR, or comment.
+
+        *prefer_html* is ignored — GitHub bodies are markdown, and there is
+        no alternative representation to choose between.
+        """
+        kind, parts = parse_id(_strip_prefix(msg_id, self._prefix))
+
+        if kind == "notification":
+            ref = await self._issue_ref_for_notification(parts[0])
+            kind, parts = "issue", tuple(re.split(r"[/#]", ref))
+
+        if kind == "comment":
+            owner, repo, cid = parts
+            comment = await self._get(
+                f"/repos/{owner}/{repo}/issues/comments/{cid}"
+            )
+            return _comment_to_dict(comment, self._prefix, f"{owner}/{repo}", "")
+
+        owner, repo, number = parts
+        ref = f"{owner}/{repo}#{number}"
+        issue = await self._get(f"/repos/{owner}/{repo}/issues/{number}")
+        return _issue_to_dict(issue, self._prefix, ref)
+
+    async def read_thread(self, thread_id: str) -> dict:
+        """Read an issue or PR together with its comments.
+
+        The issue body is the first message; comments follow in the order
+        GitHub returns them (oldest first).
+        """
+        kind, parts = parse_id(_strip_prefix(thread_id, self._prefix))
+
+        if kind == "notification":
+            ref = await self._issue_ref_for_notification(parts[0])
+            parts = tuple(re.split(r"[/#]", ref))
+        elif kind == "comment":
+            raise ValueError(
+                f"{thread_id!r} is a comment, not a thread — use the issue ID "
+                "(gh:owner/repo#42)."
+            )
+
+        owner, repo, number = parts
+        ref = f"{owner}/{repo}#{number}"
+
+        issue = await self._get(f"/repos/{owner}/{repo}/issues/{number}")
+        head = _issue_to_dict(issue, self._prefix, ref)
+
+        messages = [head]
+        page = 1
+        while True:
+            comments = await self._get(
+                f"/repos/{owner}/{repo}/issues/{number}/comments",
+                {"per_page": _COMMENTS_PAGE_SIZE, "page": page},
+            )
+            if not isinstance(comments, list) or not comments:
+                break
+            messages.extend(
+                _comment_to_dict(
+                    c, self._prefix, f"{owner}/{repo}", head.get("subject", "")
+                )
+                for c in comments
+            )
+            if len(comments) < _COMMENTS_PAGE_SIZE:
+                break
+            page += 1
+
+        return {
+            "thread_id": f"{self._prefix}:{ref}",
+            "subject": head.get("subject", ""),
+            "message_count": len(messages),
+            "messages": messages,
+        }
+
+    async def _issue_ref_for_notification(self, notification_id: str) -> str:
+        """Resolve a notification thread ID to its ``owner/repo#N`` subject."""
+        data = await self._get(f"/notifications/threads/{notification_id}")
+        subject = (data or {}).get("subject") or {}
+        subject_url = subject.get("url") or ""
+        try:
+            return _issue_ref_from_url(subject_url)
+        except ValueError as exc:
+            # Commits, releases, check suites, and discussions are real
+            # notification subjects with no issue behind them — discussions
+            # in particular are GraphQL-only, so REST cannot read them.
+            raise ValueError(
+                f"Notification {notification_id} is a "
+                f"{subject.get('type', 'non-issue')} — ts4k can list it but "
+                "not read its body. Only issues and pull requests are readable."
+            ) from exc
+
+    # -- Management methods (require level >= MODIFY) -----------------------
+
+    async def mark_read(self, msg_id: str) -> dict:
+        """Mark a notification thread as read.
+
+        This is the only call in this adapter that changes anything, and
+        it changes only the notification inbox — the issue, its comments,
+        and the repository are untouched.
+        """
+        from ts4k.core.levels import AccessLevel, check_level
+        check_level(self._access_level, AccessLevel.MODIFY, "mark_read")
+
+        raw_id = _strip_prefix(msg_id, self._prefix)
+        kind, parts = parse_id(raw_id)
+        if kind != "notification":
+            raise ValueError(
+                f"{msg_id!r} is an issue or comment, not a notification. "
+                "mark_read needs the notification ID from whatsnew."
+            )
+
+        client = self._require_client()
+        resp = await client.patch(f"/notifications/threads/{parts[0]}")
+        self._check(resp)
+        return {"id": f"{self._prefix}:{parts[0]}", "status": "marked_read"}

--- a/src/ts4k/adapters/github.py
+++ b/src/ts4k/adapters/github.py
@@ -15,11 +15,16 @@ ts4k reads GitHub, it never writes to it.  The only mutating call in this
 adapter is ``mark_read``, which marks a *notification thread* as read —
 it touches the notification inbox, never an issue, PR, or repository.
 
-Two ID forms are returned, both native::
+All IDs are native, in one of these forms::
 
-    gh:2984571234            a notification thread ID (from whatsnew)
-    gh:owner/repo#42         an issue or PR (from list_messages/search)
-    gh:owner/repo/comments/9 a single issue comment (from read_thread)
+    gh:2984571234                 a notification thread ID (from whatsnew)
+    gh:owner/repo#42              an issue or PR (from list_messages/search)
+    gh:owner/repo/comments/9      an issue-style conversation comment (read_thread)
+    gh:owner/repo/reviews/9       a PR review submission — approve/request-changes/comment
+    gh:owner/repo/pull-comments/9 a PR inline review comment, on the diff (read_thread)
+
+Review submissions and inline review comments are surfaced only when
+``read_thread`` is called on a pull request — a plain issue has neither.
 
 Usage::
 
@@ -159,6 +164,11 @@ def classify(notification: dict) -> str:
 
 _ISSUE_ID = re.compile(r"^([^/\s]+)/([^/#\s]+)#(\d+)$")
 _COMMENT_ID = re.compile(r"^([^/\s]+)/([^/#\s]+)/comments/(\d+)$")
+# Inline PR review comments are numbered in their own sequence and are only
+# readable via /pulls/comments/{id}, so they need an ID distinct from an
+# issue comment's — the two ranges overlap, and a shared shape would send
+# one to the wrong endpoint.
+_REVIEW_COMMENT_ID = re.compile(r"^([^/\s]+)/([^/#\s]+)/pull-comments/(\d+)$")
 _NOTIFICATION_ID = re.compile(r"^\d+$")
 
 
@@ -172,13 +182,17 @@ def _strip_prefix(prefixed_id: str, prefix: str) -> str:
 def parse_id(raw_id: str) -> tuple[str, tuple[str, ...]]:
     """Classify a de-prefixed ID.
 
-    Returns ``("notification", (id,))``, ``("issue", (owner, repo, number))``
-    or ``("comment", (owner, repo, comment_id))``.  Raises ``ValueError``
-    for anything else, so a mistyped ID fails loudly rather than being
-    sent to GitHub as a guess.
+    Returns ``("notification", (id,))``, ``("issue", (owner, repo, number))``,
+    ``("comment", (owner, repo, comment_id))`` or ``("review_comment",
+    (owner, repo, comment_id))``.  Raises ``ValueError`` for anything else,
+    so a mistyped ID fails loudly rather than being sent to GitHub as a
+    guess.
     """
     if _NOTIFICATION_ID.match(raw_id):
         return "notification", (raw_id,)
+    m = _REVIEW_COMMENT_ID.match(raw_id)
+    if m:
+        return "review_comment", m.groups()
     m = _COMMENT_ID.match(raw_id)
     if m:
         return "comment", m.groups()
@@ -276,18 +290,54 @@ def _issue_to_dict(issue: dict, prefix: str, ref: str) -> dict:
     }
 
 
-def _comment_to_dict(comment: dict, prefix: str, repo: str, subject: str) -> dict:
-    """Convert an issue comment to a normalised message dict."""
+def _comment_to_dict(
+    comment: dict, prefix: str, repo: str, subject: str,
+    segment: str = "comments",
+) -> dict:
+    """Convert an issue comment to a normalised message dict.
+
+    Also used for pull-request inline review comments — both resources
+    share the same ``id`` / ``user`` / ``body`` / ``created_at`` /
+    ``html_url`` shape — but those pass ``segment="pull-comments"`` so the
+    resulting ID reads back from the endpoint it actually came from.
+    """
     cid = comment.get("id", "")
     return {
-        "id": f"{prefix}:{repo}/comments/{cid}",
-        "raw_id": f"{repo}/comments/{cid}",
+        "id": f"{prefix}:{repo}/{segment}/{cid}",
+        "raw_id": f"{repo}/{segment}/{cid}",
         "source": prefix,
         "from": (comment.get("user") or {}).get("login", ""),
         "subject": subject,
         "date": comment.get("created_at", ""),
         "body": comment.get("body") or "",
         "url": comment.get("html_url", ""),
+    }
+
+
+def _review_to_dict(review: dict, prefix: str, repo: str, subject: str) -> dict:
+    """Convert a pull-request review submission to a normalised message dict.
+
+    A review can carry no prose at all — a bare "Approve" or "Request
+    changes" click — in which case the state, not the empty body, is the
+    entire point of the notification. It is folded into the body as a
+    bracketed tag, the same way notification categories are (see
+    ``_notification_to_dict``), so it survives even the pipe format,
+    which renders nothing but ``from``, ``date``, and ``body``.
+    """
+    rid = review.get("id", "")
+    state = (review.get("state") or "").upper()
+    body = review.get("body") or ""
+    if state:
+        body = f"[{state}] {body}".strip()
+    return {
+        "id": f"{prefix}:{repo}/reviews/{rid}",
+        "raw_id": f"{repo}/reviews/{rid}",
+        "source": prefix,
+        "from": (review.get("user") or {}).get("login", ""),
+        "subject": subject,
+        "date": review.get("submitted_at", ""),
+        "body": body,
+        "url": review.get("html_url", ""),
     }
 
 
@@ -344,9 +394,15 @@ class GitHubAdapter(BaseAdapter):
 
         token = resolve_token(self._config.token, self._config.token_file)
         if not token:
+            from ts4k.core.levels import AccessLevel
+            scope = (
+                "Notifications: write"
+                if self._access_level >= AccessLevel.MODIFY
+                else "Notifications: read"
+            )
             raise RuntimeError(
-                "No GitHub token configured. Create a fine-grained PAT with "
-                "Notifications: read (plus Contents/Issues: read for the repos "
+                f"No GitHub token configured. Create a fine-grained PAT with "
+                f"{scope} (plus Contents/Issues: read for the repos "
                 "you follow), then: ts4k src add "
                 f"{self._prefix} github token_file=<path>"
             )
@@ -528,12 +584,15 @@ class GitHubAdapter(BaseAdapter):
             ref = await self._issue_ref_for_notification(parts[0])
             kind, parts = "issue", tuple(re.split(r"[/#]", ref))
 
-        if kind == "comment":
+        if kind in ("comment", "review_comment"):
             owner, repo, cid = parts
-            comment = await self._get(
-                f"/repos/{owner}/{repo}/issues/comments/{cid}"
+            review = kind == "review_comment"
+            path = "pulls" if review else "issues"
+            comment = await self._get(f"/repos/{owner}/{repo}/{path}/comments/{cid}")
+            return _comment_to_dict(
+                comment, self._prefix, f"{owner}/{repo}", "",
+                segment="pull-comments" if review else "comments",
             )
-            return _comment_to_dict(comment, self._prefix, f"{owner}/{repo}", "")
 
         owner, repo, number = parts
         ref = f"{owner}/{repo}#{number}"
@@ -543,15 +602,19 @@ class GitHubAdapter(BaseAdapter):
     async def read_thread(self, thread_id: str) -> dict:
         """Read an issue or PR together with its comments.
 
-        The issue body is the first message; comments follow in the order
-        GitHub returns them (oldest first).
+        The issue body is the first message; comments follow in
+        chronological order. For a pull request that also includes review
+        submissions (approve / request-changes / comment verdicts) and
+        inline review comments — those live under separate endpoints from
+        the issue-style conversation comments, so without them a PR thread
+        would silently omit reviewer feedback.
         """
         kind, parts = parse_id(_strip_prefix(thread_id, self._prefix))
 
         if kind == "notification":
             ref = await self._issue_ref_for_notification(parts[0])
             parts = tuple(re.split(r"[/#]", ref))
-        elif kind == "comment":
+        elif kind in ("comment", "review_comment"):
             raise ValueError(
                 f"{thread_id!r} is a comment, not a thread — use the issue ID "
                 "(gh:owner/repo#42)."
@@ -562,8 +625,9 @@ class GitHubAdapter(BaseAdapter):
 
         issue = await self._get(f"/repos/{owner}/{repo}/issues/{number}")
         head = _issue_to_dict(issue, self._prefix, ref)
+        subject = head.get("subject", "")
 
-        messages = [head]
+        replies: list[dict] = []
         page = 1
         while True:
             comments = await self._get(
@@ -572,22 +636,74 @@ class GitHubAdapter(BaseAdapter):
             )
             if not isinstance(comments, list) or not comments:
                 break
-            messages.extend(
-                _comment_to_dict(
-                    c, self._prefix, f"{owner}/{repo}", head.get("subject", "")
-                )
+            replies.extend(
+                _comment_to_dict(c, self._prefix, f"{owner}/{repo}", subject)
                 for c in comments
             )
             if len(comments) < _COMMENTS_PAGE_SIZE:
                 break
             page += 1
 
+        if head.get("is_pull_request"):
+            replies.extend(
+                await self._pull_request_feedback(owner, repo, number, subject)
+            )
+            # Comments, reviews, and review comments each arrive sorted
+            # within their own endpoint but not against each other —
+            # merge into one chronological conversation.
+            replies.sort(key=lambda m: m.get("date", ""))
+
+        messages = [head, *replies]
+
         return {
             "thread_id": f"{self._prefix}:{ref}",
-            "subject": head.get("subject", ""),
+            "subject": subject,
             "message_count": len(messages),
             "messages": messages,
         }
+
+    async def _pull_request_feedback(
+        self, owner: str, repo: str, number: str, subject: str
+    ) -> list[dict]:
+        """Fetch PR review submissions and inline review comments.
+
+        Only called for pull requests — issues have neither endpoint.
+        """
+        feedback: list[dict] = []
+
+        reviews = await self._get(
+            f"/repos/{owner}/{repo}/pulls/{number}/reviews",
+            {"per_page": _COMMENTS_PAGE_SIZE},
+        )
+        if isinstance(reviews, list):
+            feedback.extend(
+                _review_to_dict(r, self._prefix, f"{owner}/{repo}", subject)
+                for r in reviews
+                # PENDING is the reviewer's own draft, not yet submitted —
+                # nothing to notify anyone about until it's submitted.
+                if (r.get("state") or "").upper() != "PENDING"
+            )
+
+        page = 1
+        while True:
+            review_comments = await self._get(
+                f"/repos/{owner}/{repo}/pulls/{number}/comments",
+                {"per_page": _COMMENTS_PAGE_SIZE, "page": page},
+            )
+            if not isinstance(review_comments, list) or not review_comments:
+                break
+            feedback.extend(
+                _comment_to_dict(
+                    c, self._prefix, f"{owner}/{repo}", subject,
+                    segment="pull-comments",
+                )
+                for c in review_comments
+            )
+            if len(review_comments) < _COMMENTS_PAGE_SIZE:
+                break
+            page += 1
+
+        return feedback
 
     async def _issue_ref_for_notification(self, notification_id: str) -> str:
         """Resolve a notification thread ID to its ``owner/repo#N`` subject."""

--- a/src/ts4k/cli.py
+++ b/src/ts4k/cli.py
@@ -43,7 +43,7 @@ from ts4k.state.refs import RefTable
 # Source config keys holding a secret rather than a pointer to one. `src list`
 # runs constantly in agent context and in terminal scrollback, so the value
 # itself never gets printed — `bridge_token_file` (a path) still does.
-_SECRET_SOURCE_KEYS = frozenset({"bridge_token"})
+_SECRET_SOURCE_KEYS = frozenset({"bridge_token", "token"})
 
 
 def _shown(key: str, value: object) -> object:
@@ -578,6 +578,14 @@ def _cmd_sources(args: argparse.Namespace) -> None:
                 print(f"Reusing the app-specific password already stored for {email}.")
             # Falls through to generic sources.add — contacts are imported by
             # `ts4k contacts sync`, not by any message command.
+
+        if provider == "github":
+            from ts4k.adapters.github import resolve_token
+            if not resolve_token(kwargs.get("token"), kwargs.get("token_file")):
+                print("Error: a GitHub personal access token is required.")
+                print(f"Usage: ts4k src add {prefix} github token_file=<path>")
+                print("       (or token=<pat>, or set GITHUB_TOKEN)")
+                return
 
         # For O365: inherit client_id/tenant_id from existing O365 source
         # if not explicitly provided (same app registration for all mailboxes).
@@ -1615,6 +1623,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "  whatsapp: bridge_url, bridge_token, bridge_token_file, transport (http|stdio)\n"
             "            transport=stdio also needs mcp_cwd, server_command\n"
             "  o365:     client_id (required), tenant_id, mailbox\n"
+            "  github:   token or token_file (required unless GITHUB_TOKEN is set)\n"
             "  apple/icloud: email (required), calendar_id, calendar_name  → generic caldav provider\n"
             "  apple-contacts: email (required)  → generic carddav provider (ts4k c sync)\n"
             "\n"
@@ -1630,7 +1639,7 @@ def _build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     sr_add.add_argument("prefix", help="Source prefix (e.g. g, gn, w)")
-    sr_add.add_argument("provider", help="Provider: gmail, o365, whatsapp, apple/icloud/caldav, apple-contacts/carddav")
+    sr_add.add_argument("provider", help="Provider: gmail, o365, whatsapp, github, apple/icloud/caldav, apple-contacts/carddav")
     sr_add.add_argument("params", nargs="*", help="key=value pairs or bare email")
 
     sr_rm = sr_sub.add_parser("rm", help="Remove a source",
@@ -1720,6 +1729,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "  ts4k filter add-sender noreply@spam.com\n"
             "  ts4k f add-domain newsletters.example.com\n"
             "  ts4k f add-pattern '^Out of office'\n"
+            "  ts4k f add-category ci           # skip GitHub CI notifications\n"
             "  ts4k f skip-groups true          # skip group chats\n"
             "  ts4k f show                      # show current config\n"
             "  ts4k wn life -F                  # apply filters to whatsnew"
@@ -1735,6 +1745,8 @@ def _build_parser() -> argparse.ArgumentParser:
         ("rm-domain", "Remove domain from skip list"),
         ("add-pattern", "Add regex pattern to skip"),
         ("rm-pattern", "Remove pattern from skip list"),
+        ("add-category", "Add message category to skip list (e.g. ci)"),
+        ("rm-category", "Remove category from skip list"),
         ("skip-groups", "Set group chat skip (true/false)"),
     ]:
         sub = fl_sub.add_parser(action_name, help=help_text)

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -1501,6 +1501,17 @@ async def preload(
     provider = cfg.get("provider", "").lower()
     cacheable = provider in cache.CACHEABLE_PROVIDERS
 
+    if prefix not in cache.CACHEABLE_SOURCES:
+        # Fail closed: cache.CACHEABLE_SOURCES only recognizes "g"/"o"
+        # today (issue #64), so a GitHub source's headers are silently
+        # discarded and its bodies would end up as unreachable orphan
+        # files if we let this proceed — reject instead of reporting a
+        # fake success.
+        return (
+            f"Error: source {prefix!r} ({provider}) doesn't support preload — "
+            "only Gmail and O365 messages are cached locally."
+        )
+
     # Contact auto-expand
     if contact:
         resolved_query = _contact_to_query(contact, prefix, provider)
@@ -2594,6 +2605,7 @@ def _append_setup(lines: list[str]) -> None:
     lines.append("    5. ts4k list --source o --since 2d          (verify)")
     lines.append("  GitHub (notifications, issues, PRs — read + mark-read only):")
     lines.append("    1. Create a fine-grained PAT: github.com/settings/tokens — Notifications: read, Issues/Pull requests: read")
+    lines.append("       (use Notifications: write instead of read if you'll set level=modify, below, to mark notifications read)")
     lines.append("    2. ts4k src add gh github token_file=<path>   (or GITHUB_TOKEN env; level=modify to allow mark-read)")
     lines.append("    3. ts4k whatsnew dev --source gh             (verify)")
     lines.append("    Categories: ci, review, mention, assignment, dependabot, release — suppress with: ts4k filter add-category ci")

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -1501,7 +1501,12 @@ async def preload(
     provider = cfg.get("provider", "").lower()
     cacheable = provider in cache.CACHEABLE_PROVIDERS
 
-    if prefix not in cache.CACHEABLE_SOURCES:
+    # Gate on the provider, not the prefix: prefixes are user-chosen, so a
+    # GitHub source named "g" or "o" would otherwise collide with
+    # cache.CACHEABLE_SOURCES and slip through this guard even though
+    # nothing about it is actually cacheable (see _ACTIVITY_TRACKED_PROVIDERS,
+    # which gates the same providers by name for the same reason).
+    if provider not in _ACTIVITY_TRACKED_PROVIDERS or prefix not in cache.CACHEABLE_SOURCES:
         # Fail closed: cache.CACHEABLE_SOURCES only recognizes "g"/"o"
         # today (issue #64), so a GitHub source's headers are silently
         # discarded and its bodies would end up as unreachable orphan

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 from ts4k.adapters.caldav_cal import CaldavAdapter, CaldavAdapterConfig
 from ts4k.adapters.gcal import GcalAdapter, GcalAdapterConfig
 from ts4k.adapters.o365cal import O365CalAdapter, O365CalAdapterConfig
+from ts4k.adapters.github import GitHubAdapter, GitHubAdapterConfig
 from ts4k.adapters.gmail import GmailAdapter, GmailAdapterConfig
 from ts4k.adapters.o365 import O365Adapter, O365AdapterConfig
 from ts4k.adapters import wa_bridge_auth
@@ -86,7 +87,7 @@ _NON_MESSAGE_PROVIDERS = (*_CAL_PROVIDERS, "carddav")
 
 def _make_adapter(
     prefix: str, cfg: dict[str, Any]
-) -> GmailAdapter | WhatsAppAdapter | O365Adapter | GcalAdapter | O365CalAdapter | CaldavAdapter | None:
+) -> GmailAdapter | WhatsAppAdapter | O365Adapter | GitHubAdapter | GcalAdapter | O365CalAdapter | CaldavAdapter | None:
     """Create an adapter instance from a source config entry."""
     provider = cfg.get("provider", "").lower()
 
@@ -142,6 +143,20 @@ def _make_adapter(
                 tenant_id=cfg.get("tenant_id", "common"),
                 mailbox=cfg.get("mailbox"),
                 config_dir=Path(cfg["config_dir"]) if cfg.get("config_dir") else None,
+                level=cfg.get("level"),
+            ),
+            prefix=prefix,
+        )
+
+    if provider == "github":
+        from ts4k.adapters.github import resolve_token
+        if not resolve_token(cfg.get("token"), cfg.get("token_file")):
+            logger.warning("GitHub source %r has no resolvable token", prefix)
+            return None
+        return GitHubAdapter(
+            GitHubAdapterConfig(
+                token=cfg.get("token", ""),
+                token_file=cfg.get("token_file"),
                 level=cfg.get("level"),
             ),
             prefix=prefix,
@@ -226,6 +241,7 @@ def _resolve_prefixes(source: str | None) -> list[str]:
 
     provider_map = {
         "wa": "whatsapp", "outlook": "o365", "office": "o365", "365": "o365",
+        "gh": "github",
         "google-calendar": "gcal", "calendar": "gcal", "cal": "gcal",
         "o365-calendar": "o365cal", "outlook-calendar": "o365cal",
         "apple": "caldav", "icloud": "caldav", "apple-calendar": "caldav",
@@ -1116,7 +1132,7 @@ def get_status(
     total_msgs = st.get("total_messages", 0)
     pct = stats.savings_pct()
 
-    _provider_labels = {"gmail": "Gmail", "whatsapp": "WhatsApp", "o365": "O365", "o365cal": "O365 Cal", "gcal": "GCal", "caldav": "CalDAV", "carddav": "CardDAV"}
+    _provider_labels = {"gmail": "Gmail", "whatsapp": "WhatsApp", "o365": "O365", "github": "GitHub", "o365cal": "O365 Cal", "gcal": "GCal", "caldav": "CalDAV", "carddav": "CardDAV"}
 
     lines.append("")
     lines.append("Stats:")
@@ -1433,6 +1449,12 @@ def manage_filters(action: str | None = None, value: str | None = None) -> str:
     elif action == "rm-pattern":
         result = filters.remove_pattern(value or "")
         return f"skip_patterns: {', '.join(result) or '(empty)'}"
+    elif action == "add-category":
+        result = filters.add_category(value or "")
+        return f"skip_categories: {', '.join(result)}"
+    elif action == "rm-category":
+        result = filters.remove_category(value or "")
+        return f"skip_categories: {', '.join(result) or '(empty)'}"
     elif action == "skip-groups":
         val = (value or "").lower() in ("true", "yes", "on", "1")
         result = filters.set_skip_groups(val)
@@ -1447,6 +1469,7 @@ def manage_filters(action: str | None = None, value: str | None = None) -> str:
             f"skip_domains:  {', '.join(config['skip_domains']) or '(none)'}",
             f"skip_groups:   {config['skip_groups']}",
             f"skip_patterns: {', '.join(config['skip_patterns']) or '(none)'}",
+            f"skip_categories: {', '.join(config['skip_categories']) or '(none)'}",
         ]
         return "\n".join(lines)
 
@@ -2466,6 +2489,18 @@ def check_token_health(prefix: str, cfg: dict[str, Any]) -> "TokenHealth":
         required = scopes_for(provider, parse_level(cfg.get("level")))
         return validate_token(client_id, tenant_id=tenant_id, scopes=required or None, username=username)
 
+    if provider == "github":
+        # A PAT can only be validated by spending an API call, and this runs
+        # on every `ts4k status` — report whether one resolves, not whether
+        # GitHub still accepts it.  A revoked token surfaces as a 401 on use.
+        from ts4k.adapters.github import resolve_token
+        if resolve_token(cfg.get("token"), cfg.get("token_file")):
+            return TokenHealth(status="ok", expiry=None, scopes=[], detail="PAT configured")
+        return TokenHealth(
+            status="auth", expiry=None, scopes=[],
+            detail=f"no token — run: ts4k src add {prefix} github token_file=<path>",
+        )
+
     if provider in ("caldav", "carddav"):
         # Both share one app-specific password per Apple ID — except a
         # generic (non-iCloud) CardDAV source, which is keyed separately.
@@ -2557,6 +2592,11 @@ def _append_setup(lines: list[str]) -> None:
     lines.append("    3. ts4k auth o                              (device code flow)")
     lines.append("    4. ts4k src discover                        (find mailboxes)")
     lines.append("    5. ts4k list --source o --since 2d          (verify)")
+    lines.append("  GitHub (notifications, issues, PRs — read + mark-read only):")
+    lines.append("    1. Create a fine-grained PAT: github.com/settings/tokens — Notifications: read, Issues/Pull requests: read")
+    lines.append("    2. ts4k src add gh github token_file=<path>   (or GITHUB_TOKEN env; level=modify to allow mark-read)")
+    lines.append("    3. ts4k whatsnew dev --source gh             (verify)")
+    lines.append("    Categories: ci, review, mention, assignment, dependabot, release — suppress with: ts4k filter add-category ci")
     lines.append("  Calendar (Google & O365):")
     lines.append("    1. Google: same OAuth credentials as Gmail (shared token)")
     lines.append("    2. O365: same auth as O365 mail (calendar scopes added automatically)")
@@ -2608,7 +2648,8 @@ def skill_reference(level: str = "basic") -> str:
             "contacts link ALIAS ID [ID...]|Link identifiers to alias\n"
             "contacts unlink|find|list|Manage contacts\n"
             "contacts sync [--apply]|Import iCloud address book (preview by default)\n"
-            "filter show|add-sender|rm-sender|add-domain|rm-domain|add-pattern|rm-pattern|skip-groups|reset\n"
+            "filter show|add-sender|rm-sender|add-domain|rm-domain|add-pattern|rm-pattern|add-category|rm-category|skip-groups|reset\n"
+            "  GitHub categories: ci|review|mention|assignment|dependabot|release\n"
             "cache stats|clear [--source S] [--stale]|Manage cache\n"
             "manage actions: archive, unarchive, label, unlabel, read, unread, trash, move, list-labels\n"
             "  manage archive 1,2,3|Batch archive by ref\n"
@@ -2671,7 +2712,7 @@ def skill_template() -> str:
         '---\n'
         'name: ts\n'
         'description: "Token-efficient messaging and calendar gateway for Gmail, WhatsApp,'
-        ' O365, and Google Calendar. Use when the user asks about email, messages, inbox,'
+        ' O365, GitHub, and Google Calendar. Use when the user asks about email, messages, inbox,'
         ' communications, mail, calendar, events, meetings, schedule, or wants to check,'
         ' read, search, or manage their messages or calendar across platforms. Always use'
         ' this skill for any email, messaging, or calendar task — even if the user doesn\'t'

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -1501,17 +1501,14 @@ async def preload(
     provider = cfg.get("provider", "").lower()
     cacheable = provider in cache.CACHEABLE_PROVIDERS
 
-    # Gate on the provider, not the prefix: prefixes are user-chosen, so a
-    # GitHub source named "g" or "o" would otherwise collide with
-    # cache.CACHEABLE_SOURCES and slip through this guard even though
-    # nothing about it is actually cacheable (see _ACTIVITY_TRACKED_PROVIDERS,
-    # which gates the same providers by name for the same reason).
-    if provider not in _ACTIVITY_TRACKED_PROVIDERS or prefix not in cache.CACHEABLE_SOURCES:
-        # Fail closed: cache.CACHEABLE_SOURCES only recognizes "g"/"o"
-        # today (issue #64), so a GitHub source's headers are silently
-        # discarded and its bodies would end up as unreachable orphan
-        # files if we let this proceed — reject instead of reporting a
-        # fake success.
+    # Gate on the provider, never the prefix: prefixes are user-chosen, so
+    # a GitHub source could be named "g" or "o" and slip through a
+    # prefix-based check even though nothing about it is cacheable.
+    if not cacheable:
+        # Fail closed: only gmail/o365 messages reach the cache, so any
+        # other provider's headers would be discarded and its bodies left
+        # as unreachable orphan files — reject rather than report a fake
+        # success.
         return (
             f"Error: source {prefix!r} ({provider}) doesn't support preload — "
             "only Gmail and O365 messages are cached locally."

--- a/src/ts4k/core/filter.py
+++ b/src/ts4k/core/filter.py
@@ -33,10 +33,14 @@ def apply_filters(
     skip_domains = {d.lower() for d in config.get("skip_domains", [])}
     skip_groups = config.get("skip_groups", False)
     skip_patterns = _compile_patterns(config.get("skip_patterns", []))
+    skip_categories = {c.lower() for c in config.get("skip_categories", [])}
 
     result: list[dict] = []
     for msg in messages:
-        if _should_skip(msg, skip_senders, skip_domains, skip_groups, skip_patterns):
+        if _should_skip(
+            msg, skip_senders, skip_domains, skip_groups, skip_patterns,
+            skip_categories,
+        ):
             continue
         result.append(msg)
     return result
@@ -90,9 +94,16 @@ def _should_skip(
     skip_domains: set[str],
     skip_groups: bool,
     skip_patterns: list[re.Pattern],
+    skip_categories: set[str] | None = None,
 ) -> bool:
     """Return True if the message should be filtered out."""
     sender = (msg.get("from") or "").strip().lower()
+
+    # Skip by adapter-assigned category (e.g. GitHub's ci / dependabot)
+    if skip_categories:
+        category = (msg.get("category") or "").strip().lower()
+        if category and category in skip_categories:
+            return True
 
     # Skip by exact sender
     if sender and sender in skip_senders:

--- a/src/ts4k/server.py
+++ b/src/ts4k/server.py
@@ -174,7 +174,7 @@ async def admin(cmd: str) -> str:
     Commands:
       contacts list|link|unlink|find    Cross-platform identity map
       contacts sync [--apply]           Import a CardDAV address book (preview by default)
-      filter show|add-sender|rm-sender|add-domain|rm-domain|add-pattern|rm-pattern|reset
+      filter show|add-sender|rm-sender|add-domain|rm-domain|add-pattern|rm-pattern|add-category|rm-category|reset
       cache stats|clear [--source S]    Manage message cache
       preload -s SOURCE [--query Q] [--since 30d] [--bg]
       preload --status|--cancel JOB_ID

--- a/src/ts4k/state/filters.py
+++ b/src/ts4k/state/filters.py
@@ -12,8 +12,13 @@ File format::
         "skip_senders": ["noreply@linkedin.com", "notifications@github.com"],
         "skip_domains": ["marketing.example.com"],
         "skip_groups": false,
-        "skip_patterns": ["unsubscribe.*click here"]
+        "skip_patterns": ["unsubscribe.*click here"],
+        "skip_categories": ["ci", "dependabot"]
     }
+
+``skip_categories`` matches a message's ``category`` field — set by
+adapters that classify their own traffic (GitHub notifications: ``ci``,
+``review``, ``mention``, ``assignment``, ``dependabot``, ``release``).
 
 All fields are optional.  Missing fields use safe defaults (empty / false).
 """
@@ -34,6 +39,7 @@ _DEFAULTS: dict[str, Any] = {
     "skip_domains": [],
     "skip_groups": False,
     "skip_patterns": [],
+    "skip_categories": [],
 }
 
 
@@ -142,6 +148,26 @@ def remove_pattern(pattern: str) -> list[str]:
         data["skip_patterns"].remove(pattern)
         _save(data)
     return data["skip_patterns"]
+
+
+def add_category(category: str) -> list[str]:
+    """Add a message category to the skip list.  Returns the updated list."""
+    data = _load()
+    category = category.strip().lower()
+    if category and category not in data["skip_categories"]:
+        data["skip_categories"].append(category)
+        _save(data)
+    return data["skip_categories"]
+
+
+def remove_category(category: str) -> list[str]:
+    """Remove a category from the skip list.  Returns the updated list."""
+    data = _load()
+    category = category.strip().lower()
+    if category in data["skip_categories"]:
+        data["skip_categories"].remove(category)
+        _save(data)
+    return data["skip_categories"]
 
 
 def set_skip_groups(skip: bool) -> bool:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -617,6 +617,9 @@ class TestPreloadBodyGating:
         """preload --bodies against WhatsApp must not orphan a body file,
         must not cache the header either, and must not claim the message
         was cached — only gmail/o365 are cacheable (cache.CACHEABLE_PROVIDERS).
+
+        ts4k#22 turned the silent no-op into an explicit rejection, which
+        is the stronger guarantee: it can't be mistaken for "nothing new".
         """
         sources.add("w", provider="whatsapp")
 
@@ -631,6 +634,7 @@ class TestPreloadBodyGating:
         with patch("ts4k.commands._make_adapter", return_value=mock_adapter):
             result = await commands.preload(source="w", bodies=True, pages=1, throttle=0)
 
-        assert "0 messages cached" in result
+        assert "doesn't support preload" in result
+        assert "0 messages cached" not in result
         assert not (ts4k_config / "cache" / "bodies" / "w_1.json").exists()
         assert cache.get_header("w:1") is None

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -225,6 +225,62 @@ class TestSkipPatterns:
         assert len(apply_filters(msgs, config)) == 0
 
 
+class TestSkipCategories:
+    """Adapter-assigned categories (GitHub: ci, review, dependabot, ...)."""
+
+    def _gh(self, category: str) -> dict:
+        return {
+            "id": f"gh:{category}",
+            "from": "peterdrier/ts4k",
+            "subject": f"[{category}] something happened",
+            "date": "2026-08-09T14:30:00Z",
+            "category": category,
+        }
+
+    def test_skips_matching_category(self):
+        config = {"skip_categories": ["ci"]}
+        msgs = [self._gh("ci"), self._gh("review")]
+        result = apply_filters(msgs, config)
+        assert [m["category"] for m in result] == ["review"]
+
+    def test_ci_suppression_keeps_reviews_and_mentions(self):
+        config = {"skip_categories": ["ci", "dependabot"]}
+        msgs = [
+            self._gh("ci"),
+            self._gh("dependabot"),
+            self._gh("review"),
+            self._gh("mention"),
+            self._gh("assignment"),
+        ]
+        result = apply_filters(msgs, config)
+        assert [m["category"] for m in result] == ["review", "mention", "assignment"]
+
+    def test_case_insensitive(self):
+        assert apply_filters([self._gh("ci")], {"skip_categories": ["CI"]}) == []
+
+    def test_messages_without_a_category_are_kept(self):
+        config = {"skip_categories": ["ci"]}
+        msgs = [_msg(sender="alice@example.com")]
+        assert len(apply_filters(msgs, config)) == 1
+
+    def test_empty_skip_list_keeps_all(self):
+        assert len(apply_filters([self._gh("ci")], {"skip_categories": []})) == 1
+
+    def test_config_roundtrip(self):
+        assert filters.get_config()["skip_categories"] == []
+        filters.add_category("CI")
+        assert filters.get_config()["skip_categories"] == ["ci"]
+        filters.add_category("ci")
+        assert filters.get_config()["skip_categories"] == ["ci"]
+        filters.remove_category("ci")
+        assert filters.get_config()["skip_categories"] == []
+
+    def test_applies_through_the_real_config(self):
+        filters.add_category("ci")
+        result = apply_filters([self._gh("ci"), self._gh("review")], filters.get_config())
+        assert [m["category"] for m in result] == ["review"]
+
+
 class TestCombinedFilters:
     def test_any_rule_skips(self):
         """A message is skipped if ANY rule matches."""

--- a/tests/test_github_adapter.py
+++ b/tests/test_github_adapter.py
@@ -261,6 +261,16 @@ class TestParseId:
             "comment", ("peterdrier", "ts4k", "991")
         )
 
+    def test_review_comment_id(self):
+        assert parse_id("peterdrier/ts4k/pull-comments/6001") == (
+            "review_comment", ("peterdrier", "ts4k", "6001")
+        )
+
+    def test_review_id(self):
+        assert parse_id("peterdrier/ts4k/pulls/42/reviews/5001") == (
+            "review", ("peterdrier", "ts4k", "42", "5001")
+        )
+
     def test_garbage_raises(self):
         with pytest.raises(ValueError, match="Unrecognised GitHub ID"):
             parse_id("not-an-id")
@@ -439,6 +449,18 @@ class TestListMessages:
         assert results[0]["id"] == "gh:2984571234"
 
     @pytest.mark.asyncio
+    async def test_no_query_does_not_apply_whatsnew_one_day_cutoff(self):
+        """A notification that's been unread for more than 24 hours must
+        still show up in a plain queryless list — only whatsnew() applies
+        the 24-hour "since" default."""
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(NOTIFICATIONS))
+        await adapter.list_messages()
+        params = adapter._client.get.call_args[1]["params"]
+        assert "since" not in params
+        assert params["all"] == "false"
+
+    @pytest.mark.asyncio
     async def test_page_token_selects_page(self):
         adapter = _make_adapter()
         adapter._client.get = AsyncMock(return_value=_mock_response(SEARCH_RESPONSE))
@@ -451,6 +473,19 @@ class TestListMessages:
         data = dict(SEARCH_RESPONSE, total_count=50)
         adapter._client.get = AsyncMock(return_value=_mock_response(data))
         results = await adapter.list_messages(query="x", count=2)
+        assert results[-1]["_next_page_token"] == "2"
+
+    @pytest.mark.asyncio
+    async def test_next_page_token_uses_actual_page_size_not_count(self):
+        """count=200 exceeds GitHub's 100-item search cap, so per_page is
+        capped at 100. If the pagination check compared against count
+        instead of the real page size, 200 < 150 would be False and the
+        next-page token would be dropped even though 50 matches remain."""
+        adapter = _make_adapter()
+        data = dict(SEARCH_RESPONSE, total_count=150)
+        adapter._client.get = AsyncMock(return_value=_mock_response(data))
+        results = await adapter.list_messages(query="x", count=200)
+        assert adapter._client.get.call_args[1]["params"]["per_page"] == 100
         assert results[-1]["_next_page_token"] == "2"
 
     @pytest.mark.asyncio
@@ -558,6 +593,26 @@ class TestReadMessage:
             await adapter.read_thread("gh:peterdrier/ts4k/pull-comments/6001")
 
     @pytest.mark.asyncio
+    async def test_reads_a_review_by_its_id(self):
+        """A review ID returned from a thread read (gh:owner/repo/pulls/N/
+        reviews/M) must resolve back through read_message rather than
+        raising 'Unrecognised GitHub ID'."""
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(REVIEWS[0]))
+        msg = await adapter.read_message("gh:peterdrier/ts4k/pulls/42/reviews/5001")
+        assert adapter._client.get.call_args[0][0] == (
+            "/repos/peterdrier/ts4k/pulls/42/reviews/5001"
+        )
+        assert msg["from"] == "alice"
+        assert msg["id"] == "gh:peterdrier/ts4k/pulls/42/reviews/5001"
+
+    @pytest.mark.asyncio
+    async def test_review_id_is_not_a_thread(self):
+        adapter = _make_adapter()
+        with pytest.raises(ValueError, match="is a comment, not a thread"):
+            await adapter.read_thread("gh:peterdrier/ts4k/pulls/42/reviews/5001")
+
+    @pytest.mark.asyncio
     async def test_bad_id_raises(self):
         adapter = _make_adapter()
         with pytest.raises(ValueError, match="Unrecognised GitHub ID"):
@@ -650,6 +705,11 @@ class TestReadThread:
         # back from /pulls/comments, not /issues/comments.
         assert thread["messages"][3]["id"] == "gh:peterdrier/ts4k/pull-comments/6001"
 
+        # Review IDs carry the PR number so read_message can resolve them
+        # back through /pulls/{number}/reviews/{id}.
+        assert thread["messages"][2]["id"] == "gh:peterdrier/ts4k/pulls/42/reviews/5001"
+        assert thread["messages"][4]["id"] == "gh:peterdrier/ts4k/pulls/42/reviews/5002"
+
     @pytest.mark.asyncio
     async def test_pull_request_calls_the_review_endpoints(self):
         adapter = _make_adapter()
@@ -665,6 +725,41 @@ class TestReadThread:
         paths = [c[0][0] for c in adapter._client.get.call_args_list]
         assert "/repos/peterdrier/ts4k/pulls/42/reviews" in paths
         assert "/repos/peterdrier/ts4k/pulls/42/comments" in paths
+
+    @pytest.mark.asyncio
+    async def test_paginates_past_100_reviews(self):
+        """A PR with more than 100 submitted reviews must not silently lose
+        the later ones to a single-page fetch — the inline review-comment
+        endpoint already paginates; reviews need the same loop."""
+        adapter = _make_adapter()
+        full_page = [
+            {
+                "id": 9000 + i,
+                "user": {"login": "carol"},
+                "state": "APPROVED",
+                "body": "",
+                "submitted_at": "2026-08-02T12:00:00Z",
+            }
+            for i in range(100)
+        ]
+        adapter._client.get = AsyncMock(
+            side_effect=[
+                _mock_response(PULL_REQUEST),
+                _mock_response([]),
+                _mock_response(full_page),
+                _mock_response(REVIEWS),  # second page, short — stops pagination
+                _mock_response([]),
+            ]
+        )
+        thread = await adapter.read_thread("gh:peterdrier/ts4k#42")
+        # 100 from the first page + 2 from the short second page.
+        assert thread["message_count"] == 1 + 100 + 2
+        review_paths = [
+            c[1]["params"]
+            for c in adapter._client.get.call_args_list
+            if c[0][0] == "/repos/peterdrier/ts4k/pulls/42/reviews"
+        ]
+        assert [p["page"] for p in review_paths] == [1, 2]
 
     @pytest.mark.asyncio
     async def test_empty_body_review_keeps_its_state_visible(self):

--- a/tests/test_github_adapter.py
+++ b/tests/test_github_adapter.py
@@ -538,10 +538,60 @@ class TestReadMessage:
         assert msg["id"] == "gh:peterdrier/ts4k/comments/991"
 
     @pytest.mark.asyncio
+    async def test_reads_a_pull_request_review_comment(self):
+        """Inline review comments are numbered in their own sequence and
+        only exist under /pulls/comments — an issue-comment ID of the same
+        number is a different object entirely."""
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(REVIEW_COMMENTS[0]))
+        msg = await adapter.read_message("gh:peterdrier/ts4k/pull-comments/6001")
+        assert adapter._client.get.call_args[0][0] == (
+            "/repos/peterdrier/ts4k/pulls/comments/6001"
+        )
+        assert msg["from"] == "bob"
+        assert msg["id"] == "gh:peterdrier/ts4k/pull-comments/6001"
+
+    @pytest.mark.asyncio
+    async def test_review_comment_is_not_a_thread(self):
+        adapter = _make_adapter()
+        with pytest.raises(ValueError, match="is a comment, not a thread"):
+            await adapter.read_thread("gh:peterdrier/ts4k/pull-comments/6001")
+
+    @pytest.mark.asyncio
     async def test_bad_id_raises(self):
         adapter = _make_adapter()
         with pytest.raises(ValueError, match="Unrecognised GitHub ID"):
             await adapter.read_message("gh:nonsense")
+
+
+REVIEWS = [
+    {
+        "id": 5001,
+        "user": {"login": "alice"},
+        "state": "APPROVED",
+        "body": "",
+        "submitted_at": "2026-08-02T12:00:00Z",
+        "html_url": "https://github.com/peterdrier/ts4k/pull/42#pullrequestreview-5001",
+    },
+    {
+        "id": 5002,
+        "user": {"login": "bob"},
+        "state": "CHANGES_REQUESTED",
+        "body": "Please add a test.",
+        "submitted_at": "2026-08-02T14:00:00Z",
+        "html_url": "https://github.com/peterdrier/ts4k/pull/42#pullrequestreview-5002",
+    },
+]
+
+REVIEW_COMMENTS = [
+    {
+        "id": 6001,
+        "user": {"login": "bob"},
+        "created_at": "2026-08-02T13:00:00Z",
+        "body": "Missing null check here.",
+        "html_url": "https://github.com/peterdrier/ts4k/pull/42#discussion_r6001",
+    },
+]
 
 
 class TestReadThread:
@@ -556,6 +606,118 @@ class TestReadThread:
         assert thread["subject"] == "Add GitHub adapter"
         assert thread["message_count"] == 3
         assert [m["from"] for m in thread["messages"]] == ["peterdrier", "alice", "bob"]
+
+    @pytest.mark.asyncio
+    async def test_issue_thread_makes_no_pull_request_calls(self):
+        """A plain issue has no /pulls endpoints — read_thread must not probe them."""
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            side_effect=[_mock_response(ISSUE), _mock_response(COMMENTS)]
+        )
+        await adapter.read_thread("gh:peterdrier/ts4k#42")
+        assert adapter._client.get.call_count == 2
+        paths = [c[0][0] for c in adapter._client.get.call_args_list]
+        assert not any("/pulls/" in p for p in paths)
+
+    @pytest.mark.asyncio
+    async def test_pull_request_thread_includes_reviews_and_review_comments(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            side_effect=[
+                _mock_response(PULL_REQUEST),
+                _mock_response(COMMENTS),
+                _mock_response(REVIEWS),
+                _mock_response(REVIEW_COMMENTS),
+            ]
+        )
+        thread = await adapter.read_thread("gh:peterdrier/ts4k#42")
+
+        # Chronological across all three endpoints: alice's issue comment
+        # (10:00), alice's approval (12:00), bob's inline review comment
+        # (13:00), bob's changes-requested review (14:00), bob's issue
+        # comment the next day (11:00).
+        froms = [m["from"] for m in thread["messages"]]
+        assert froms == ["peterdrier", "alice", "alice", "bob", "bob", "bob"]
+        assert thread["message_count"] == 6
+
+        bodies = [m["body"] for m in thread["messages"]]
+        # A bare approval has no prose — the state is the whole message.
+        assert "[APPROVED]" in bodies[2]
+        assert bodies[3] == "Missing null check here."
+        assert bodies[4] == "[CHANGES_REQUESTED] Please add a test."
+
+        # Inline review comments get their own ID namespace so they read
+        # back from /pulls/comments, not /issues/comments.
+        assert thread["messages"][3]["id"] == "gh:peterdrier/ts4k/pull-comments/6001"
+
+    @pytest.mark.asyncio
+    async def test_pull_request_calls_the_review_endpoints(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            side_effect=[
+                _mock_response(PULL_REQUEST),
+                _mock_response([]),
+                _mock_response(REVIEWS),
+                _mock_response([]),
+            ]
+        )
+        await adapter.read_thread("gh:peterdrier/ts4k#42")
+        paths = [c[0][0] for c in adapter._client.get.call_args_list]
+        assert "/repos/peterdrier/ts4k/pulls/42/reviews" in paths
+        assert "/repos/peterdrier/ts4k/pulls/42/comments" in paths
+
+    @pytest.mark.asyncio
+    async def test_empty_body_review_keeps_its_state_visible(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            side_effect=[
+                _mock_response(PULL_REQUEST),
+                _mock_response([]),
+                _mock_response(REVIEWS),
+                _mock_response([]),
+            ]
+        )
+        thread = await adapter.read_thread("gh:peterdrier/ts4k#42")
+        approved = next(m for m in thread["messages"] if "APPROVED" in m["body"])
+        assert approved["body"] == "[APPROVED]"
+        requested = next(m for m in thread["messages"] if "CHANGES_REQUESTED" in m["body"])
+        assert requested["body"] == "[CHANGES_REQUESTED] Please add a test."
+
+    @pytest.mark.asyncio
+    async def test_pending_review_is_excluded(self):
+        adapter = _make_adapter()
+        pending = [{
+            "id": 5003, "user": {"login": "carol"}, "state": "PENDING",
+            "body": "", "submitted_at": "2026-08-02T15:00:00Z",
+        }]
+        adapter._client.get = AsyncMock(
+            side_effect=[
+                _mock_response(PULL_REQUEST),
+                _mock_response([]),
+                _mock_response(pending),
+                _mock_response([]),
+            ]
+        )
+        thread = await adapter.read_thread("gh:peterdrier/ts4k#42")
+        assert thread["message_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_replies_are_chronologically_merged(self):
+        """Conversation comments, reviews, and review comments are merged
+        into a single date-ordered sequence rather than left as separate
+        blocks in endpoint order."""
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            side_effect=[
+                _mock_response(PULL_REQUEST),
+                _mock_response(COMMENTS),  # 10:00, 11:00
+                _mock_response(REVIEWS),  # 12:00, 14:00
+                _mock_response(REVIEW_COMMENTS),  # 13:00
+            ]
+        )
+        thread = await adapter.read_thread("gh:peterdrier/ts4k#42")
+        dates = [m["date"] for m in thread["messages"][1:]]
+        assert dates == sorted(dates)
 
     @pytest.mark.asyncio
     async def test_comment_ids_are_unique_and_native(self):

--- a/tests/test_github_adapter.py
+++ b/tests/test_github_adapter.py
@@ -1,0 +1,747 @@
+"""Tests for the GitHub REST API adapter.
+
+Every HTTP call is mocked — nothing in this file ever reaches
+api.github.com.  That matters most for ``mark_read``, which mutates the
+real notification inbox when it is not mocked.
+
+Converter and classification tests are pure functions.  Adapter tests
+mock ``httpx.AsyncClient`` the same way ``test_o365_adapter.py`` does.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from ts4k.adapters.github import (
+    GitHubAdapter,
+    GitHubAdapterConfig,
+    classify,
+    parse_id,
+    resolve_token,
+    _issue_ref_from_url,
+    _notification_to_dict,
+    _search_item_to_dict,
+    _strip_prefix,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — realistic GitHub REST responses
+# ---------------------------------------------------------------------------
+
+
+def _notification(
+    nid: str = "2984571234",
+    reason: str = "review_requested",
+    subject_type: str = "PullRequest",
+    title: str = "Add GitHub adapter",
+    url: str = "https://api.github.com/repos/peterdrier/ts4k/pulls/42",
+    repo: str = "peterdrier/ts4k",
+    updated_at: str = "2026-08-09T14:30:00Z",
+    unread: bool = True,
+) -> dict:
+    return {
+        "id": nid,
+        "unread": unread,
+        "reason": reason,
+        "updated_at": updated_at,
+        "subject": {"title": title, "url": url, "type": subject_type},
+        "repository": {"full_name": repo, "name": repo.split("/")[-1]},
+        "url": f"https://api.github.com/notifications/threads/{nid}",
+    }
+
+
+NOTIFICATIONS = [
+    _notification(),
+    _notification(
+        nid="2984571235",
+        reason="ci_activity",
+        subject_type="CheckSuite",
+        title="ci workflow run failed for main branch",
+        url="https://api.github.com/repos/peterdrier/ts4k/actions/runs/9",
+        updated_at="2026-08-09T13:00:00Z",
+    ),
+]
+
+ISSUE = {
+    "number": 42,
+    "title": "Add GitHub adapter",
+    "body": "We should surface notifications in ts4k.",
+    "user": {"login": "peterdrier"},
+    "created_at": "2026-08-01T09:00:00Z",
+    "updated_at": "2026-08-09T14:30:00Z",
+    "state": "open",
+    "comments": 2,
+    "html_url": "https://github.com/peterdrier/ts4k/issues/42",
+}
+
+PULL_REQUEST = dict(ISSUE, pull_request={"url": "https://api.github.com/x"})
+
+COMMENTS = [
+    {
+        "id": 991,
+        "user": {"login": "alice"},
+        "created_at": "2026-08-02T10:00:00Z",
+        "body": "Sounds good.",
+        "html_url": "https://github.com/peterdrier/ts4k/issues/42#issuecomment-991",
+    },
+    {
+        "id": 992,
+        "user": {"login": "bob"},
+        "created_at": "2026-08-03T11:00:00Z",
+        "body": "Which endpoint?",
+        "html_url": "https://github.com/peterdrier/ts4k/issues/42#issuecomment-992",
+    },
+]
+
+SEARCH_RESPONSE = {
+    "total_count": 2,
+    "items": [
+        {
+            "url": "https://api.github.com/repos/peterdrier/ts4k/issues/42",
+            "repository_url": "https://api.github.com/repos/peterdrier/ts4k",
+            "number": 42,
+            "title": "Add GitHub adapter",
+            "body": "We should surface notifications in ts4k.",
+            "user": {"login": "peterdrier"},
+            "updated_at": "2026-08-09T14:30:00Z",
+            "state": "open",
+        },
+        {
+            "url": "https://api.github.com/repos/peterdrier/ts4k/pulls/43",
+            "repository_url": "https://api.github.com/repos/peterdrier/ts4k",
+            "number": 43,
+            "title": "Fix normalize regression",
+            "body": "",
+            "user": {"login": "alice"},
+            "updated_at": "2026-08-08T08:00:00Z",
+            "state": "open",
+            "pull_request": {"url": "https://api.github.com/x"},
+        },
+    ],
+}
+
+
+def _mock_response(
+    data: object = None,
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+    json_error: bool = False,
+) -> httpx.Response:
+    """Create a mock httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    if json_error:
+        resp.json.side_effect = ValueError("not json")
+    else:
+        resp.json.return_value = data
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            message=f"HTTP {status_code}",
+            request=MagicMock(spec=httpx.Request),
+            response=resp,
+        )
+    return resp
+
+
+def _make_adapter(prefix: str = "gh", level: str | None = None) -> GitHubAdapter:
+    """Create a GitHubAdapter whose httpx client is a mock.
+
+    The token is a literal placeholder — no real credential is read here.
+    """
+    adapter = GitHubAdapter(
+        GitHubAdapterConfig(token="test-token-not-real", level=level), prefix=prefix
+    )
+    adapter._client = AsyncMock(spec=httpx.AsyncClient)
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Token resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveToken:
+    def test_explicit_token_wins(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "from-env")
+        assert resolve_token("from-config") == "from-config"
+
+    def test_token_file(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        path = tmp_path / "pat"
+        path.write_text("from-file\n", encoding="utf-8")
+        assert resolve_token(None, str(path)) == "from-file"
+
+    def test_unreadable_file_falls_back_to_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "from-env")
+        assert resolve_token(None, str(tmp_path / "missing")) == "from-env"
+
+    def test_gh_token_env(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GH_TOKEN", "from-gh")
+        assert resolve_token() == "from-gh"
+
+    def test_nothing_configured(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        assert resolve_token() == ""
+
+
+# ---------------------------------------------------------------------------
+# Category classification
+# ---------------------------------------------------------------------------
+
+
+class TestClassify:
+    def test_review_requested(self):
+        assert classify(_notification(reason="review_requested")) == "review"
+
+    def test_approval_requested(self):
+        assert classify(_notification(reason="approval_requested")) == "review"
+
+    def test_ci_activity(self):
+        assert classify(_notification(reason="ci_activity", subject_type="Issue")) == "ci"
+
+    def test_check_suite_subject_is_ci(self):
+        assert classify(_notification(reason="subscribed", subject_type="CheckSuite")) == "ci"
+
+    def test_mention(self):
+        assert classify(_notification(reason="mention")) == "mention"
+
+    def test_team_mention(self):
+        assert classify(_notification(reason="team_mention")) == "mention"
+
+    def test_assignment(self):
+        assert classify(_notification(reason="assign")) == "assignment"
+
+    def test_release_subject(self):
+        assert classify(_notification(reason="subscribed", subject_type="Release")) == "release"
+
+    def test_security_alert_is_dependabot(self):
+        assert classify(_notification(reason="security_alert", subject_type="Issue")) == "dependabot"
+
+    def test_vulnerability_alert_subject_is_dependabot(self):
+        n = _notification(reason="subscribed", subject_type="RepositoryVulnerabilityAlert")
+        assert classify(n) == "dependabot"
+
+    def test_dependabot_bump_pr_title(self):
+        n = _notification(reason="subscribed", title="Bump httpx from 0.27.0 to 0.28.1")
+        assert classify(n) == "dependabot"
+
+    def test_bump_title_on_issue_is_not_dependabot(self):
+        n = _notification(reason="comment", subject_type="Issue", title="Bump httpx from 1 to 2")
+        assert classify(n) == "comment"
+
+    def test_unmapped_reason_passes_through(self):
+        assert classify(_notification(reason="state_change")) == "state_change"
+
+    def test_missing_reason_is_other(self):
+        assert classify({"subject": {"type": "Issue"}}) == "other"
+
+
+# ---------------------------------------------------------------------------
+# ID parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseId:
+    def test_notification_id(self):
+        assert parse_id("2984571234") == ("notification", ("2984571234",))
+
+    def test_issue_id(self):
+        assert parse_id("peterdrier/ts4k#42") == ("issue", ("peterdrier", "ts4k", "42"))
+
+    def test_comment_id(self):
+        assert parse_id("peterdrier/ts4k/comments/991") == (
+            "comment", ("peterdrier", "ts4k", "991")
+        )
+
+    def test_garbage_raises(self):
+        with pytest.raises(ValueError, match="Unrecognised GitHub ID"):
+            parse_id("not-an-id")
+
+    def test_strip_prefix(self):
+        assert _strip_prefix("gh:peterdrier/ts4k#42", "gh") == "peterdrier/ts4k#42"
+        assert _strip_prefix("peterdrier/ts4k#42", "gh") == "peterdrier/ts4k#42"
+
+    def test_issue_ref_from_pull_url(self):
+        assert _issue_ref_from_url(
+            "https://api.github.com/repos/peterdrier/ts4k/pulls/42"
+        ) == "peterdrier/ts4k#42"
+
+    def test_issue_ref_from_non_issue_url_raises(self):
+        with pytest.raises(ValueError):
+            _issue_ref_from_url("https://api.github.com/repos/peterdrier/ts4k/releases/9")
+
+
+# ---------------------------------------------------------------------------
+# Converters
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationToDict:
+    def test_prefixes_id(self):
+        d = _notification_to_dict(_notification(), "gh")
+        assert d["id"] == "gh:2984571234"
+        assert d["raw_id"] == "2984571234"
+        assert d["source"] == "gh"
+
+    def test_thread_id_points_at_the_issue(self):
+        d = _notification_to_dict(_notification(), "gh")
+        assert d["thread_id"] == "gh:peterdrier/ts4k#42"
+
+    def test_from_is_the_repository(self):
+        assert _notification_to_dict(_notification(), "gh")["from"] == "peterdrier/ts4k"
+
+    def test_subject_carries_the_category(self):
+        d = _notification_to_dict(_notification(), "gh")
+        assert d["subject"] == "[review] Add GitHub adapter"
+        assert d["category"] == "review"
+
+    def test_date_is_updated_at(self):
+        assert _notification_to_dict(_notification(), "gh")["date"] == "2026-08-09T14:30:00Z"
+
+    def test_unread_flag(self):
+        assert _notification_to_dict(_notification(unread=False), "gh")["unread"] is False
+
+    def test_non_issue_subject_has_no_thread_id(self):
+        n = _notification(
+            subject_type="Release",
+            url="https://api.github.com/repos/peterdrier/ts4k/releases/9",
+        )
+        assert _notification_to_dict(n, "gh")["thread_id"] == ""
+
+    def test_custom_prefix(self):
+        assert _notification_to_dict(_notification(), "work")["id"] == "work:2984571234"
+
+
+class TestSearchItemToDict:
+    def test_builds_issue_ref(self):
+        d = _search_item_to_dict(SEARCH_RESPONSE["items"][0], "gh")
+        assert d["id"] == "gh:peterdrier/ts4k#42"
+        assert d["from"] == "peterdrier"
+        assert d["subject"] == "Add GitHub adapter"
+
+    def test_flags_pull_requests(self):
+        d = _search_item_to_dict(SEARCH_RESPONSE["items"][1], "gh")
+        assert d["is_pull_request"] is True
+        assert d["id"] == "gh:peterdrier/ts4k#43"
+
+    def test_unparseable_item_is_dropped(self):
+        assert _search_item_to_dict({"url": "", "repository_url": ""}, "gh") == {}
+
+
+# ---------------------------------------------------------------------------
+# whatsnew
+# ---------------------------------------------------------------------------
+
+
+class TestWhatsnew:
+    @pytest.mark.asyncio
+    async def test_returns_normalised_notifications(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(NOTIFICATIONS))
+        results = await adapter.whatsnew(since="2026-08-01T00:00:00Z")
+        assert [r["id"] for r in results] == ["gh:2984571234", "gh:2984571235"]
+        assert [r["category"] for r in results] == ["review", "ci"]
+
+    @pytest.mark.asyncio
+    async def test_passes_since(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response([]))
+        await adapter.whatsnew(since="2026-08-01T00:00:00Z")
+        path, kwargs = adapter._client.get.call_args[0][0], adapter._client.get.call_args[1]
+        assert path == "/notifications"
+        assert kwargs["params"]["since"] == "2026-08-01T00:00:00Z"
+        assert kwargs["params"]["all"] == "false"
+
+    @pytest.mark.asyncio
+    async def test_default_since_is_last_day(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response([]))
+        await adapter.whatsnew()
+        assert adapter._client.get.call_args[1]["params"]["since"].endswith("Z")
+
+    @pytest.mark.asyncio
+    async def test_sorted_newest_first(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            return_value=_mock_response(list(reversed(NOTIFICATIONS)))
+        )
+        results = await adapter.whatsnew()
+        assert results[0]["date"] > results[1]["date"]
+
+    @pytest.mark.asyncio
+    async def test_paginates_until_count(self):
+        adapter = _make_adapter()
+        full_page = [_notification(nid=str(i)) for i in range(50)]
+        adapter._client.get = AsyncMock(
+            side_effect=[_mock_response(full_page), _mock_response(NOTIFICATIONS)]
+        )
+        results = await adapter.whatsnew(count=60)
+        assert adapter._client.get.call_count == 2
+        assert len(results) == 52
+
+    @pytest.mark.asyncio
+    async def test_stops_on_short_page(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(NOTIFICATIONS))
+        await adapter.whatsnew(count=200)
+        assert adapter._client.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_truncates_to_count(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(NOTIFICATIONS))
+        assert len(await adapter.whatsnew(count=1)) == 1
+
+    @pytest.mark.asyncio
+    async def test_sender_filter_returns_nothing(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(NOTIFICATIONS))
+        assert await adapter.whatsnew(sender="alice@example.com") == []
+        adapter._client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_domain_filter_returns_nothing(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(NOTIFICATIONS))
+        assert await adapter.whatsnew(domain="example.com") == []
+        adapter._client.get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# list_messages
+# ---------------------------------------------------------------------------
+
+
+class TestListMessages:
+    @pytest.mark.asyncio
+    async def test_searches_issues(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(SEARCH_RESPONSE))
+        results = await adapter.list_messages(query="repo:peterdrier/ts4k is:open")
+        assert adapter._client.get.call_args[0][0] == "/search/issues"
+        assert adapter._client.get.call_args[1]["params"]["q"] == "repo:peterdrier/ts4k is:open"
+        assert [r["id"] for r in results] == ["gh:peterdrier/ts4k#42", "gh:peterdrier/ts4k#43"]
+
+    @pytest.mark.asyncio
+    async def test_no_query_falls_back_to_notifications(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(NOTIFICATIONS))
+        results = await adapter.list_messages()
+        assert adapter._client.get.call_args[0][0] == "/notifications"
+        assert results[0]["id"] == "gh:2984571234"
+
+    @pytest.mark.asyncio
+    async def test_page_token_selects_page(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(SEARCH_RESPONSE))
+        await adapter.list_messages(query="x", page_token="3")
+        assert adapter._client.get.call_args[1]["params"]["page"] == 3
+
+    @pytest.mark.asyncio
+    async def test_next_page_token_when_more_results(self):
+        adapter = _make_adapter()
+        data = dict(SEARCH_RESPONSE, total_count=50)
+        adapter._client.get = AsyncMock(return_value=_mock_response(data))
+        results = await adapter.list_messages(query="x", count=2)
+        assert results[-1]["_next_page_token"] == "2"
+
+    @pytest.mark.asyncio
+    async def test_no_next_page_token_on_last_page(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(SEARCH_RESPONSE))
+        results = await adapter.list_messages(query="x", count=20)
+        assert "_next_page_token" not in results[-1]
+
+    @pytest.mark.asyncio
+    async def test_sender_filter_returns_nothing(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(SEARCH_RESPONSE))
+        assert await adapter.list_messages(query="x", sender="a@b.com") == []
+
+
+# ---------------------------------------------------------------------------
+# read_message / read_thread
+# ---------------------------------------------------------------------------
+
+
+class TestReadMessage:
+    @pytest.mark.asyncio
+    async def test_reads_issue_by_ref(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(ISSUE))
+        msg = await adapter.read_message("gh:peterdrier/ts4k#42")
+        assert adapter._client.get.call_args[0][0] == "/repos/peterdrier/ts4k/issues/42"
+        assert msg["id"] == "gh:peterdrier/ts4k#42"
+        assert msg["from"] == "peterdrier"
+        assert msg["body"] == "We should surface notifications in ts4k."
+
+    @pytest.mark.asyncio
+    async def test_flags_pull_requests(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(PULL_REQUEST))
+        msg = await adapter.read_message("gh:peterdrier/ts4k#42")
+        assert msg["is_pull_request"] is True
+
+    @pytest.mark.asyncio
+    async def test_resolves_notification_id_to_its_issue(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            side_effect=[_mock_response(_notification()), _mock_response(ISSUE)]
+        )
+        msg = await adapter.read_message("gh:2984571234")
+        calls = [c[0][0] for c in adapter._client.get.call_args_list]
+        assert calls == [
+            "/notifications/threads/2984571234",
+            "/repos/peterdrier/ts4k/issues/42",
+        ]
+        assert msg["id"] == "gh:peterdrier/ts4k#42"
+
+    @pytest.mark.asyncio
+    async def test_notification_without_issue_subject_raises(self):
+        adapter = _make_adapter()
+        release = _notification(
+            subject_type="Release",
+            url="https://api.github.com/repos/peterdrier/ts4k/releases/9",
+        )
+        adapter._client.get = AsyncMock(return_value=_mock_response(release))
+        with pytest.raises(ValueError, match="is a Release"):
+            await adapter.read_message("gh:2984571234")
+
+    @pytest.mark.asyncio
+    async def test_discussion_notification_reports_the_limit(self):
+        adapter = _make_adapter()
+        discussion = _notification(
+            subject_type="Discussion",
+            url="https://github.com/peterdrier/ts4k/discussions/7",
+        )
+        adapter._client.get = AsyncMock(return_value=_mock_response(discussion))
+        with pytest.raises(ValueError, match="is a Discussion"):
+            await adapter.read_message("gh:2984571234")
+
+    @pytest.mark.asyncio
+    async def test_reads_a_comment(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(COMMENTS[0]))
+        msg = await adapter.read_message("gh:peterdrier/ts4k/comments/991")
+        assert adapter._client.get.call_args[0][0] == (
+            "/repos/peterdrier/ts4k/issues/comments/991"
+        )
+        assert msg["from"] == "alice"
+        assert msg["id"] == "gh:peterdrier/ts4k/comments/991"
+
+    @pytest.mark.asyncio
+    async def test_bad_id_raises(self):
+        adapter = _make_adapter()
+        with pytest.raises(ValueError, match="Unrecognised GitHub ID"):
+            await adapter.read_message("gh:nonsense")
+
+
+class TestReadThread:
+    @pytest.mark.asyncio
+    async def test_issue_plus_comments(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            side_effect=[_mock_response(ISSUE), _mock_response(COMMENTS)]
+        )
+        thread = await adapter.read_thread("gh:peterdrier/ts4k#42")
+        assert thread["thread_id"] == "gh:peterdrier/ts4k#42"
+        assert thread["subject"] == "Add GitHub adapter"
+        assert thread["message_count"] == 3
+        assert [m["from"] for m in thread["messages"]] == ["peterdrier", "alice", "bob"]
+
+    @pytest.mark.asyncio
+    async def test_comment_ids_are_unique_and_native(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            side_effect=[_mock_response(ISSUE), _mock_response(COMMENTS)]
+        )
+        thread = await adapter.read_thread("gh:peterdrier/ts4k#42")
+        assert [m["id"] for m in thread["messages"][1:]] == [
+            "gh:peterdrier/ts4k/comments/991",
+            "gh:peterdrier/ts4k/comments/992",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_no_comments(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            side_effect=[_mock_response(ISSUE), _mock_response([])]
+        )
+        thread = await adapter.read_thread("gh:peterdrier/ts4k#42")
+        assert thread["message_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_resolves_notification_id(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            side_effect=[
+                _mock_response(_notification()),
+                _mock_response(ISSUE),
+                _mock_response([]),
+            ]
+        )
+        thread = await adapter.read_thread("gh:2984571234")
+        assert thread["thread_id"] == "gh:peterdrier/ts4k#42"
+
+    @pytest.mark.asyncio
+    async def test_comment_id_rejected(self):
+        adapter = _make_adapter()
+        with pytest.raises(ValueError, match="is a comment, not a thread"):
+            await adapter.read_thread("gh:peterdrier/ts4k/comments/991")
+
+
+# ---------------------------------------------------------------------------
+# mark_read — MUTATING.  Mocked transport only; never a live call.
+# ---------------------------------------------------------------------------
+
+
+class TestMarkRead:
+    @pytest.mark.asyncio
+    async def test_patches_the_notification_thread(self):
+        adapter = _make_adapter(level="modify")
+        adapter._client.patch = AsyncMock(
+            return_value=_mock_response(None, status_code=205)
+        )
+        result = await adapter.mark_read("gh:2984571234")
+        adapter._client.patch.assert_awaited_once_with(
+            "/notifications/threads/2984571234"
+        )
+        assert result == {"id": "gh:2984571234", "status": "marked_read"}
+
+    @pytest.mark.asyncio
+    async def test_readonly_source_is_refused(self):
+        adapter = _make_adapter()
+        adapter._client.patch = AsyncMock()
+        with pytest.raises(PermissionError):
+            await adapter.mark_read("gh:2984571234")
+        adapter._client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_issue_id_is_refused(self):
+        adapter = _make_adapter(level="modify")
+        adapter._client.patch = AsyncMock()
+        with pytest.raises(ValueError, match="not a notification"):
+            await adapter.mark_read("gh:peterdrier/ts4k#42")
+        adapter._client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_patch_raises(self):
+        adapter = _make_adapter(level="modify")
+        adapter._client.patch = AsyncMock(
+            return_value=_mock_response(
+                None, status_code=403, headers={"X-RateLimit-Remaining": "0"}
+            )
+        )
+        with pytest.raises(RuntimeError, match="rate limit"):
+            await adapter.mark_read("gh:2984571234")
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    @pytest.mark.asyncio
+    async def test_401_names_the_token(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            return_value=_mock_response(None, status_code=401)
+        )
+        with pytest.raises(RuntimeError, match="rejected the token"):
+            await adapter.whatsnew()
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_reports_reset_time(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            return_value=_mock_response(
+                None,
+                status_code=403,
+                headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1786000000"},
+            )
+        )
+        with pytest.raises(RuntimeError, match="rate limit exceeded .resets 20"):
+            await adapter.whatsnew()
+
+    @pytest.mark.asyncio
+    async def test_429_without_remaining_header_is_a_plain_http_error(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            return_value=_mock_response(None, status_code=429)
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.whatsnew()
+
+    @pytest.mark.asyncio
+    async def test_403_that_is_not_a_rate_limit_is_a_plain_http_error(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            return_value=_mock_response(
+                None, status_code=403, headers={"X-RateLimit-Remaining": "42"}
+            )
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.whatsnew()
+
+    @pytest.mark.asyncio
+    async def test_404_raises(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(
+            return_value=_mock_response(None, status_code=404)
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.read_message("gh:peterdrier/ts4k#999")
+
+    @pytest.mark.asyncio
+    async def test_non_json_body_raises_a_named_error(self):
+        adapter = _make_adapter()
+        adapter._client.get = AsyncMock(return_value=_mock_response(json_error=True))
+        with pytest.raises(RuntimeError, match="non-JSON response"):
+            await adapter.whatsnew()
+
+    @pytest.mark.asyncio
+    async def test_not_connected_raises(self):
+        adapter = GitHubAdapter(GitHubAdapterConfig(token="x"))
+        with pytest.raises(RuntimeError, match="not connected"):
+            await adapter.whatsnew()
+
+    @pytest.mark.asyncio
+    async def test_connect_without_token_raises(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        adapter = GitHubAdapter(GitHubAdapterConfig())
+        with pytest.raises(RuntimeError, match="No GitHub token configured"):
+            await adapter.connect()
+
+
+class TestAdapterBasics:
+    def test_default_prefix(self):
+        assert GitHubAdapter(GitHubAdapterConfig(token="x")).source_prefix == "gh"
+
+    def test_custom_prefix(self):
+        adapter = GitHubAdapter(GitHubAdapterConfig(token="x"), prefix="work")
+        assert adapter.source_prefix == "work"
+
+    def test_default_level_is_readonly(self):
+        from ts4k.core.levels import AccessLevel
+        assert GitHubAdapter(GitHubAdapterConfig(token="x")).access_level == AccessLevel.READONLY
+
+    @pytest.mark.asyncio
+    async def test_connect_sets_auth_header(self, monkeypatch):
+        adapter = GitHubAdapter(GitHubAdapterConfig(token="test-token-not-real"))
+        await adapter.connect()
+        try:
+            assert adapter._client.headers["Authorization"] == "Bearer test-token-not-real"
+            assert adapter._client.headers["X-GitHub-Api-Version"]
+        finally:
+            await adapter.disconnect()
+        assert adapter._client is None

--- a/tests/test_github_commands.py
+++ b/tests/test_github_commands.py
@@ -320,3 +320,101 @@ class TestNoLiveCalls:
         adapter = GitHubAdapter(GitHubAdapterConfig(token="x", level="modify"))
         with pytest.raises(RuntimeError, match="not connected"):
             await adapter.mark_read("gh:1")
+
+
+class TestPreloadRejectsGitHub:
+    """cache.CACHEABLE_SOURCES only recognizes 'g'/'o' — GitHub must be
+    rejected up front rather than silently reporting a fake success."""
+
+    @pytest.mark.asyncio
+    async def test_preload_returns_an_explicit_error(self, monkeypatch, ts4k_config):
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"gh": dict(GITHUB_CFG)}
+        )
+        result = await commands.preload(source="gh")
+        assert result.startswith("Error:")
+        assert "preload" in result
+
+    @pytest.mark.asyncio
+    async def test_preload_never_creates_a_job(self, monkeypatch, ts4k_config):
+        from ts4k.state import batch
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"gh": dict(GITHUB_CFG)}
+        )
+        create_job = AsyncMock()
+        monkeypatch.setattr(batch, "create_job", create_job)
+
+        await commands.preload(source="gh")
+        create_job.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_prefix_colliding_with_cacheable_sources_is_still_rejected(
+        self, monkeypatch, ts4k_config
+    ):
+        """Source prefixes are user-chosen, so a GitHub source can be named
+        "g" or "o" — the same prefixes cache.CACHEABLE_SOURCES uses for
+        Gmail/O365. The guard must key off the provider, not the prefix, or
+        this collision lets the unsupported GitHub preload path run."""
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"g": dict(GITHUB_CFG)}
+        )
+        result = await commands.preload(source="g")
+        assert result.startswith("Error:")
+        assert "preload" in result
+
+    @pytest.mark.asyncio
+    async def test_prefix_collision_never_creates_a_job(self, monkeypatch, ts4k_config):
+        from ts4k.state import batch
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"o": dict(GITHUB_CFG)}
+        )
+        create_job = AsyncMock()
+        monkeypatch.setattr(batch, "create_job", create_job)
+
+        await commands.preload(source="o")
+        create_job.assert_not_called()
+
+
+class TestCacheDoesNotStoreGitHub:
+    """GitHub messages must not create cache entries — including orphan
+    body files, since store_body (unlike store_header) has no source
+    guard of its own."""
+
+    @pytest.mark.asyncio
+    async def test_get_message_is_not_cached(self, monkeypatch, ts4k_config):
+        adapter = AsyncMock()
+        adapter.__aenter__.return_value = adapter
+        adapter.__aexit__.return_value = None
+        adapter.read_message.return_value = {
+            "id": "gh:peterdrier/ts4k#42", "source": "gh", "from": "peterdrier",
+            "subject": "Add GitHub adapter", "date": "2026-08-09T14:30:00Z",
+            "body": "We should surface notifications in ts4k.",
+        }
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"gh": dict(GITHUB_CFG)}
+        )
+        monkeypatch.setattr(commands, "_make_adapter", lambda p, c: adapter)
+
+        await commands.get_message("gh:peterdrier/ts4k#42")
+
+        from ts4k.state import cache
+        assert cache.get_message("gh:peterdrier/ts4k#42") is None
+
+    @pytest.mark.asyncio
+    async def test_list_messages_is_not_cached(self, monkeypatch, ts4k_config):
+        adapter = AsyncMock()
+        adapter.__aenter__.return_value = adapter
+        adapter.__aexit__.return_value = None
+        adapter.list_messages.return_value = [{
+            "id": "gh:peterdrier/ts4k#42", "source": "gh", "from": "peterdrier",
+            "subject": "Add GitHub adapter", "date": "2026-08-09T14:30:00Z",
+        }]
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"gh": dict(GITHUB_CFG)}
+        )
+        monkeypatch.setattr(commands, "_make_adapter", lambda p, c: adapter)
+
+        await commands.list_messages(source="gh", query="is:open")
+
+        from ts4k.state import cache
+        assert cache.get_message("gh:peterdrier/ts4k#42") is None

--- a/tests/test_github_commands.py
+++ b/tests/test_github_commands.py
@@ -1,0 +1,322 @@
+"""Tests for GitHub provider registration in commands.py and the CLI.
+
+No test here touches the network: adapter construction is inspected, not
+connected, and every command path is driven with a mock adapter.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ts4k import cli, commands
+from ts4k.adapters.github import GitHubAdapter
+
+GITHUB_CFG = {"provider": "github", "token": "test-token-not-real", "level": "modify"}
+
+
+@pytest.fixture(autouse=True)
+def no_ambient_token(monkeypatch):
+    """A developer's real GITHUB_TOKEN must not leak into these tests."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+
+class TestMakeAdapter:
+    def test_builds_github_adapter(self):
+        adapter = commands._make_adapter("gh", dict(GITHUB_CFG))
+        assert isinstance(adapter, GitHubAdapter)
+        assert adapter.source_prefix == "gh"
+
+    def test_level_is_carried_through(self):
+        from ts4k.core.levels import AccessLevel
+        adapter = commands._make_adapter("gh", dict(GITHUB_CFG))
+        assert adapter.access_level == AccessLevel.MODIFY
+
+    def test_defaults_to_readonly(self):
+        from ts4k.core.levels import AccessLevel
+        cfg = dict(GITHUB_CFG)
+        del cfg["level"]
+        assert commands._make_adapter("gh", cfg).access_level == AccessLevel.READONLY
+
+    def test_no_token_returns_none(self):
+        assert commands._make_adapter("gh", {"provider": "github"}) is None
+
+    def test_token_file_is_enough(self, tmp_path):
+        path = tmp_path / "pat"
+        path.write_text("test-token-not-real", encoding="utf-8")
+        cfg = {"provider": "github", "token_file": str(path)}
+        assert isinstance(commands._make_adapter("gh", cfg), GitHubAdapter)
+
+    def test_env_token_is_enough(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "test-token-not-real")
+        assert isinstance(
+            commands._make_adapter("gh", {"provider": "github"}), GitHubAdapter
+        )
+
+
+class TestResolvePrefixes:
+    def test_gh_alias_resolves_to_github_sources(self, monkeypatch):
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"work": dict(GITHUB_CFG)}
+        )
+        assert commands._resolve_prefixes("gh") == ["work"]
+
+    def test_provider_name_resolves(self, monkeypatch):
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"work": dict(GITHUB_CFG)}
+        )
+        assert commands._resolve_prefixes("github") == ["work"]
+
+    def test_exact_prefix_wins_over_alias(self, monkeypatch):
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all",
+            lambda: {"gh": dict(GITHUB_CFG), "work": dict(GITHUB_CFG)},
+        )
+        assert commands._resolve_prefixes("gh") == ["gh"]
+
+
+class TestTokenHealth:
+    def test_configured_token_is_ok(self):
+        health = commands.check_token_health("gh", dict(GITHUB_CFG))
+        assert health.status == "ok"
+
+    def test_missing_token_needs_auth(self):
+        health = commands.check_token_health("gh", {"provider": "github"})
+        assert health.status == "auth"
+        assert "ts4k src add gh github" in health.detail
+
+    def test_detail_never_echoes_the_token(self):
+        health = commands.check_token_health("gh", dict(GITHUB_CFG))
+        assert "test-token-not-real" not in health.detail
+
+
+class TestWhatsnewFanOut:
+    """GitHub rows flow through the shared pipeline like any other source."""
+
+    @pytest.mark.asyncio
+    async def test_notifications_reach_the_listing(self, monkeypatch, ts4k_config):
+        adapter = AsyncMock()
+        adapter.__aenter__.return_value = adapter
+        adapter.__aexit__.return_value = None
+        adapter.whatsnew.return_value = [
+            {
+                "id": "gh:1",
+                "source": "gh",
+                "thread_id": "gh:peterdrier/ts4k#42",
+                "from": "peterdrier/ts4k",
+                "subject": "[review] Add GitHub adapter",
+                "date": "2026-08-09T14:30:00Z",
+                "category": "review",
+            },
+            {
+                "id": "gh:2",
+                "source": "gh",
+                "thread_id": "",
+                "from": "peterdrier/ts4k",
+                "subject": "[ci] build failed",
+                "date": "2026-08-09T13:00:00Z",
+                "category": "ci",
+            },
+        ]
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"gh": dict(GITHUB_CFG)}
+        )
+        monkeypatch.setattr(commands, "_make_adapter", lambda p, c: adapter)
+
+        result = await commands.whatsnew(key="dev")
+        assert "[review] Add GitHub adapter" in result.output
+        assert "[ci] build failed" in result.output
+
+    @pytest.mark.asyncio
+    async def test_ci_is_filterable_without_losing_reviews(
+        self, monkeypatch, ts4k_config
+    ):
+        from ts4k.state import filters
+        filters.add_category("ci")
+
+        adapter = AsyncMock()
+        adapter.__aenter__.return_value = adapter
+        adapter.__aexit__.return_value = None
+        adapter.whatsnew.return_value = [
+            {
+                "id": "gh:1", "source": "gh", "from": "peterdrier/ts4k",
+                "subject": "[review] Add GitHub adapter", "category": "review",
+                "date": "2026-08-09T14:30:00Z",
+            },
+            {
+                "id": "gh:2", "source": "gh", "from": "peterdrier/ts4k",
+                "subject": "[ci] build failed", "category": "ci",
+                "date": "2026-08-09T13:00:00Z",
+            },
+        ]
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all", lambda: {"gh": dict(GITHUB_CFG)}
+        )
+        monkeypatch.setattr(commands, "_make_adapter", lambda p, c: adapter)
+
+        result = await commands.whatsnew(key="dev", filter=True)
+        assert "[review] Add GitHub adapter" in result.output
+        assert "[ci] build failed" not in result.output
+
+    @pytest.mark.asyncio
+    async def test_a_broken_github_source_does_not_break_the_others(
+        self, monkeypatch, ts4k_config
+    ):
+        broken = AsyncMock()
+        broken.__aenter__.side_effect = RuntimeError("GitHub rejected the token (401)")
+
+        working = AsyncMock()
+        working.__aenter__.return_value = working
+        working.__aexit__.return_value = None
+        working.whatsnew.return_value = [{
+            "id": "o:1", "source": "o", "from": "alice@contoso.com",
+            "subject": "Budget", "date": "2026-08-09T12:00:00Z",
+        }]
+
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all",
+            lambda: {"gh": dict(GITHUB_CFG), "o": {"provider": "o365"}},
+        )
+        monkeypatch.setattr(
+            commands, "_make_adapter",
+            lambda p, c: broken if p == "gh" else working,
+        )
+
+        result = await commands.whatsnew(key="dev")
+        assert result.error is None
+        assert "Budget" in result.output
+
+
+class TestManageMarkRead:
+    @pytest.mark.asyncio
+    async def test_manage_read_calls_mark_read(self, monkeypatch):
+        adapter = AsyncMock()
+        adapter.__aenter__.return_value = adapter
+        adapter.__aexit__.return_value = None
+        adapter.mark_read.return_value = {"id": "gh:1", "status": "marked_read"}
+
+        monkeypatch.setattr("ts4k.state.sources.get", lambda p: dict(GITHUB_CFG))
+        monkeypatch.setattr(commands, "_make_adapter", lambda p, c: adapter)
+
+        out = await commands.manage_message("read", "gh:1")
+        adapter.mark_read.assert_awaited_once_with("gh:1")
+        assert out == "gh:1: marked_read"
+
+    @pytest.mark.asyncio
+    async def test_dry_run_does_not_touch_github(self, monkeypatch):
+        adapter = AsyncMock()
+        monkeypatch.setattr("ts4k.state.sources.get", lambda p: dict(GITHUB_CFG))
+        monkeypatch.setattr(commands, "_make_adapter", lambda p, c: adapter)
+
+        out = await commands.manage_message("read", "gh:1", dry_run=True)
+        assert out == "gh:1: would read"
+        adapter.mark_read.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_readonly_source_reports_the_permission_error(self, monkeypatch):
+        adapter = AsyncMock()
+        adapter.__aenter__.return_value = adapter
+        adapter.__aexit__.return_value = None
+        adapter.mark_read.side_effect = PermissionError("requires level='modify'")
+
+        monkeypatch.setattr(
+            "ts4k.state.sources.get", lambda p: {"provider": "github", "token": "x"}
+        )
+        monkeypatch.setattr(commands, "_make_adapter", lambda p, c: adapter)
+
+        out = await commands.manage_message("read", "gh:1")
+        assert "requires level='modify'" in out
+
+
+class TestSrcAddCli:
+    def _add(self, params: list[str]) -> argparse.Namespace:
+        return argparse.Namespace(
+            action="add", prefix="gh", provider="github", params=params
+        )
+
+    def test_stores_token_file(self, ts4k_config, capsys, tmp_path):
+        path = tmp_path / "pat"
+        path.write_text("test-token-not-real", encoding="utf-8")
+        cli._cmd_sources(self._add([f"token_file={path}"]))
+
+        from ts4k.state import sources
+        assert sources.get("gh") == {
+            "provider": "github", "token_file": str(path)
+        }
+
+    def test_token_value_is_stored_but_never_printed(self, ts4k_config, capsys):
+        cli._cmd_sources(self._add(["token=ghp_secretvalue"]))
+
+        from ts4k.state import sources
+        assert sources.get("gh")["token"] == "ghp_secretvalue"
+        out = capsys.readouterr().out
+        assert "ghp_secretvalue" not in out
+        assert "<redacted>" in out
+
+    def test_missing_token_is_refused(self, ts4k_config, capsys):
+        cli._cmd_sources(self._add([]))
+
+        from ts4k.state import sources
+        assert sources.get("gh") is None
+        assert "personal access token is required" in capsys.readouterr().out
+
+    def test_level_modify_is_stored(self, ts4k_config):
+        cli._cmd_sources(self._add(["token=ghp_x", "level=modify"]))
+
+        from ts4k.state import sources
+        assert sources.get("gh")["level"] == "modify"
+
+
+class TestFilterCli:
+    def test_add_category(self, ts4k_config, capsys):
+        cli._cmd_filter(argparse.Namespace(action="add-category", value="ci"))
+        assert "skip_categories: ci" in capsys.readouterr().out
+
+        from ts4k.state import filters
+        assert filters.get_config()["skip_categories"] == ["ci"]
+
+    def test_rm_category(self, ts4k_config, capsys):
+        from ts4k.state import filters
+        filters.add_category("ci")
+        cli._cmd_filter(argparse.Namespace(action="rm-category", value="ci"))
+        assert "skip_categories: (empty)" in capsys.readouterr().out
+
+    def test_show_lists_categories(self, ts4k_config, capsys):
+        from ts4k.state import filters
+        filters.add_category("dependabot")
+        cli._cmd_filter(argparse.Namespace(action="show", value=None))
+        assert "skip_categories: dependabot" in capsys.readouterr().out
+
+    def test_parser_accepts_category_actions(self):
+        parser = cli._build_parser()
+        args = parser.parse_args(["filter", "add-category", "ci"])
+        assert args.action == "add-category"
+        assert args.value == "ci"
+
+
+class TestHelpText:
+    def test_llm_help_documents_github_setup(self, ts4k_config):
+        text = commands.llm_help()
+        assert "ts4k src add gh github" in text
+        assert "filter add-category ci" in text
+
+    def test_skill_more_lists_category_actions(self):
+        more = commands.skill_reference("more")
+        assert "add-category" in more
+        assert "dependabot" in more
+
+    def test_skill_template_mentions_github(self):
+        assert "GitHub" in commands.skill_template()
+
+
+class TestNoLiveCalls:
+    @pytest.mark.asyncio
+    async def test_mark_read_without_a_client_cannot_reach_github(self):
+        """An unconnected adapter fails loudly rather than dialling out."""
+        from ts4k.adapters.github import GitHubAdapterConfig
+        adapter = GitHubAdapter(GitHubAdapterConfig(token="x", level="modify"))
+        with pytest.raises(RuntimeError, match="not connected"):
+            await adapter.mark_read("gh:1")


### PR DESCRIPTION
Closes #22.

New `GitHubAdapter` over the GitHub REST API via `httpx`, following the O365 adapter pattern. Source prefix `gh:`.

## Surface
- **`whatsnew`** — `/notifications` filtered by `since`.
- **`read_thread`** — an issue or PR with its comments.
- **`mark_read`** — marks a notification thread done.
- **Categories** — `ci`, `review`, `mention`, `assignment`, `dependabot`, `release`, filterable through the **existing** filter config, so CI spam is suppressible without losing review requests. No parallel filtering mechanism was introduced.

Out of scope per the issue and not implemented: creating issues/PRs, Actions management, repo operations.

## Mutation safety
`mark_read` is the only call in this adapter that changes anything, and it changes only the notification inbox — the issue, its comments and the repository are untouched. It is gated behind the project's existing `AccessLevel.MODIFY` check rather than being available by default, so a source registered read-only cannot invoke it.

Every test mocks HTTP; there are no live calls to `api.github.com` anywhere in the test suite, and no real notification state was touched during development.

## Auth
PAT via the existing `ts4k src add` flow, with `token_file` support so the credential can stay out of `sources.json`.

## Token budget
Skill text went into **tier 2** (`more` 1197 → 1291 bytes, ceiling 1400), leaving tier 1 untouched at 2874 — deliberately avoiding the tier-1 headroom that #76/PR #84 just re-established, since tier 1 rides in every agent call.

## Tests
`1312 passed, 4 skipped` (baseline 1195/4 — 117 new). `ruff check .` clean.

## Note
This branch predates PR #84, so the byte-budget guards aren't in its test run; both ceilings were verified manually against post-#84 numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)