### PR TITLE
refactor(calendar): store datetimes in UTC, convert only at display

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Read `docs/rip/ts4k-rip.md` for the RIP (Rapid Implementation Plan) — the cons
 4. **Native platform IDs** prefixed with source (`g:`, `w:`, `t:`). No synthetic sequential IDs.
 5. **Using a command IS the side effect.** Watermarks update on `whatsnew`. No separate save step.
 6. **Format is a feature.** Pipe-delimited for listings (~60% savings over JSON), mini XML for bodies.
+7. **UTC internally, local at display.** Adapters emit UTC timestamps; only `core/format.py` converts, to one global display timezone (`ts4k.core.tz.display_tzinfo`). All-day calendar events stay bare dates.
 
 ## Implementation Phases
 

--- a/docs/intentions.md
+++ b/docs/intentions.md
@@ -87,3 +87,4 @@ Gmail, WhatsApp, O365.
 5. **Using a command IS the side effect.** `whatsnew <key>` advances watermarks on use. No separate save step.
 6. **Format is a feature.** Pipe-delimited for listings (~60% savings over JSON), mini XML for bodies.
 7. **Adapter-agnostic output.** Downstream consumers never see platform-specific data. A WhatsApp message and a Gmail message look identical after normalization.
+8. **UTC internally, local at display.** Adapters emit timestamps in UTC; only the format layer converts, to one global display timezone. Sorting and comparison stay correct across sources in different zones — and stay cheap, since ISO strings that all carry `+00:00` sort chronologically as plain text. All-day calendar events are the sole exception: they are dates, not instants, and stay bare `YYYY-MM-DD`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -436,6 +436,25 @@ The skill mode returns minimal output optimized for LLM context windows.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TS4K_CONFIG_DIR` | `~/.config/ts4k` | Override config/state directory |
+| `TS4K_TIMEZONE` | the machine's zone | Display timezone for calendar times (IANA name) |
+
+### Display timezone
+
+Calendar events are stored and compared in UTC, and converted to a **single
+display timezone** when rendered — one zone for the whole agenda, so a listing
+merged from calendars in different zones does not mix offsets. Event times and
+the `today` / `tomorrow` / `week` day boundaries all follow it.
+
+Resolution order: `TS4K_TIMEZONE`, then `"timezone"` in
+`~/.config/ts4k/settings.json`, then the machine's own zone.
+
+```json
+{
+  "timezone": "Europe/Amsterdam"
+}
+```
+
+All-day events are dates rather than instants, so they are never shifted.
 
 ---
 

--- a/src/ts4k/adapters/caldav_cal.py
+++ b/src/ts4k/adapters/caldav_cal.py
@@ -176,14 +176,17 @@ class CaldavAdapter(BaseAdapter):
         else:
             end_dt = start_dt
 
+        # Floating (zone-less) times mean "the source's configured zone"; from
+        # there everything is stored in UTC and rendered by the format layer.
+        # ``date`` values are all-day and stay dates.
         if isinstance(start_dt, datetime) and start_dt.tzinfo is None:
             start_dt = start_dt.replace(tzinfo=tzinfo)
         if isinstance(end_dt, datetime) and end_dt.tzinfo is None:
             end_dt = end_dt.replace(tzinfo=tzinfo)
         if isinstance(start_dt, datetime):
-            start_dt = start_dt.astimezone(tzinfo)
+            start_dt = start_dt.astimezone(timezone.utc)
         if isinstance(end_dt, datetime):
-            end_dt = end_dt.astimezone(tzinfo)
+            end_dt = end_dt.astimezone(timezone.utc)
 
         start = start_dt.isoformat() if start_dt is not None else ""
         end = end_dt.isoformat() if end_dt is not None else start
@@ -213,7 +216,7 @@ class CaldavAdapter(BaseAdapter):
             if isinstance(rid, datetime) and rid.tzinfo is None:
                 rid = rid.replace(tzinfo=tzinfo)
             if isinstance(rid, datetime):
-                rid = rid.astimezone(tzinfo)
+                rid = rid.astimezone(timezone.utc)
             event_id = f"{uid}::{rid.isoformat()}"
             recurring_event_id = f"{self._prefix}:{uid}"
         else:

--- a/src/ts4k/adapters/gcal.py
+++ b/src/ts4k/adapters/gcal.py
@@ -201,8 +201,17 @@ class GcalAdapter(BaseAdapter):
             duration_minutes = None
         else:
             # Stored in UTC; the format layer renders the display timezone.
-            start = to_utc_iso(start_raw.get("dateTime", ""), self._config.timezone)
-            end = to_utc_iso(end_raw.get("dateTime", ""), self._config.timezone)
+            # A floating dateTime is interpreted in the event's own zone —
+            # Google lets an event override the calendar default — and only
+            # falls back to the calendar's configured zone when absent.
+            start = to_utc_iso(
+                start_raw.get("dateTime", ""),
+                start_raw.get("timeZone") or self._config.timezone,
+            )
+            end = to_utc_iso(
+                end_raw.get("dateTime", ""),
+                end_raw.get("timeZone") or self._config.timezone,
+            )
             duration_minutes = self._compute_duration(start, end)
 
         # Attendees

--- a/src/ts4k/adapters/gcal.py
+++ b/src/ts4k/adapters/gcal.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from ts4k.adapters.base import BaseAdapter
 from ts4k.core.levels import AccessLevel, check_level, parse_level, scopes_for
+from ts4k.core.tz import to_utc_iso
 
 logger = logging.getLogger(__name__)
 
@@ -194,12 +195,14 @@ class GcalAdapter(BaseAdapter):
         all_day = "date" in start_raw and "dateTime" not in start_raw
 
         if all_day:
+            # All-day events are dates, not instants — never converted.
             start = start_raw["date"]
             end = end_raw.get("date", start)
             duration_minutes = None
         else:
-            start = start_raw.get("dateTime", "")
-            end = end_raw.get("dateTime", "")
+            # Stored in UTC; the format layer renders the display timezone.
+            start = to_utc_iso(start_raw.get("dateTime", ""), self._config.timezone)
+            end = to_utc_iso(end_raw.get("dateTime", ""), self._config.timezone)
             duration_minutes = self._compute_duration(start, end)
 
         # Attendees

--- a/src/ts4k/adapters/o365cal.py
+++ b/src/ts4k/adapters/o365cal.py
@@ -129,9 +129,10 @@ class O365CalAdapter(BaseAdapter):
 
     # -- HTTP helpers ------------------------------------------------------
 
-    async def _get(self, path: str, params: dict[str, str] | None = None) -> dict:
+    async def _get(self, path: str, params: dict[str, str] | None = None,
+                   headers: dict[str, str] | None = None) -> dict:
         client = self._require_client()
-        resp = await client.get(path, params=params or {})
+        resp = await client.get(path, params=params or {}, headers=headers)
         resp.raise_for_status()
         return resp.json()
 
@@ -207,14 +208,22 @@ class O365CalAdapter(BaseAdapter):
             "$orderby": "start/dateTime",
         }
 
+        # Pin the response zone. Graph is otherwise free to answer in the
+        # mailbox's own zone, whose IDs are Windows-style ("Eastern Standard
+        # Time") — names ZoneInfo cannot resolve, which would silently
+        # degrade every event to UTC and shift its displayed time.
+        headers = {"Prefer": 'outlook.timezone="UTC"'}
+
         while len(raw_events) < count:
             if next_link:
                 client = self._require_client()
-                resp = await client.get(next_link)
+                resp = await client.get(next_link, headers=headers)
                 resp.raise_for_status()
                 data = resp.json()
             else:
-                data = await self._get(f"{self._calendar_path()}/calendarView", params)
+                data = await self._get(
+                    f"{self._calendar_path()}/calendarView", params, headers=headers,
+                )
 
             raw_events.extend(data.get("value", []))
             next_link = data.get("@odata.nextLink")

--- a/src/ts4k/adapters/o365cal.py
+++ b/src/ts4k/adapters/o365cal.py
@@ -13,6 +13,7 @@ import httpx
 
 from ts4k.adapters.base import BaseAdapter
 from ts4k.core.levels import AccessLevel, check_level, parse_level, scopes_for
+from ts4k.core.tz import to_utc_iso
 
 logger = logging.getLogger(__name__)
 
@@ -230,12 +231,15 @@ class O365CalAdapter(BaseAdapter):
         end_raw = event.get("end", {})
 
         if all_day:
+            # All-day events are dates, not instants — never converted.
             start = start_raw.get("dateTime", "").split("T")[0]
             end = end_raw.get("dateTime", "").split("T")[0]
             duration_minutes = None
         else:
-            start = start_raw.get("dateTime", "")
-            end = end_raw.get("dateTime", "")
+            # Graph puts the zone in a sibling field, not in the dateTime
+            # string; stored in UTC, rendered by the format layer.
+            start = to_utc_iso(start_raw.get("dateTime", ""), start_raw.get("timeZone", "UTC"))
+            end = to_utc_iso(end_raw.get("dateTime", ""), end_raw.get("timeZone", "UTC"))
             duration_minutes = self._compute_duration(start, end)
 
         your_status_raw = event.get("responseStatus", {}).get("response", "")

--- a/src/ts4k/adapters/o365cal.py
+++ b/src/ts4k/adapters/o365cal.py
@@ -17,6 +17,12 @@ from ts4k.core.tz import to_utc_iso
 
 logger = logging.getLogger(__name__)
 
+# Pin the zone Graph answers in, on every read. Unpinned, Graph is free to
+# reply in the mailbox's own zone, whose IDs are Windows-style ("Eastern
+# Standard Time") — names ZoneInfo cannot resolve, which would silently
+# degrade the event to UTC and shift its displayed time.
+_UTC_PREFER = {"Prefer": 'outlook.timezone="UTC"'}
+
 
 # ---------------------------------------------------------------------------
 # Graph recurrence -> human string
@@ -208,11 +214,7 @@ class O365CalAdapter(BaseAdapter):
             "$orderby": "start/dateTime",
         }
 
-        # Pin the response zone. Graph is otherwise free to answer in the
-        # mailbox's own zone, whose IDs are Windows-style ("Eastern Standard
-        # Time") — names ZoneInfo cannot resolve, which would silently
-        # degrade every event to UTC and shift its displayed time.
-        headers = {"Prefer": 'outlook.timezone="UTC"'}
+        headers = _UTC_PREFER
 
         while len(raw_events) < count:
             if next_link:
@@ -285,7 +287,7 @@ class O365CalAdapter(BaseAdapter):
     async def read_event(self, event_id: str) -> dict:
         """Fetch full detail for a single event."""
         raw_id = self._strip_prefix(event_id)
-        event = await self._get(f"/me/events/{raw_id}")
+        event = await self._get(f"/me/events/{raw_id}", headers=_UTC_PREFER)
 
         base = self._normalize_event(event)
 

--- a/src/ts4k/cli.py
+++ b/src/ts4k/cli.py
@@ -20,6 +20,9 @@ user-chosen prefix (e.g. "g", "gn", "w") that namespaces all its message IDs.
 
 Environment variables:
     TS4K_CONFIG_DIR        Config directory (default: ~/.config/ts4k)
+    TS4K_TIMEZONE          Display timezone for calendar times (IANA name).
+                           Overrides "timezone" in settings.json; both
+                           default to the machine's own zone.
 """
 
 from __future__ import annotations

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -2840,7 +2840,10 @@ async def _cal_fetch_events(
         attempted += 1
         try:
             async with adapter:
-                events = await adapter.list_events(time_min=time_min, time_max=time_max, count=count)
+                events = await adapter.list_events(
+                    time_min=time_min, time_max=time_max,
+                    count=count + _CAL_ALL_DAY_MARGIN,
+                )
                 all_events.extend(events)
         except Exception as exc:
             logger.warning("[%s] calendar adapter failed: %s", pfx, exc)
@@ -2858,6 +2861,13 @@ async def _cal_fetch_events(
     # all-day entry it should follow.
     all_events.sort(key=lambda e: _cal_sort_key(e, zone))
     return all_events[:count]
+
+
+# Adapters enforce `count` themselves, but _cal_trim_all_day can drop a
+# boundary all-day event afterwards — so `cal next -n 5` could return four.
+# Ask each source for a small margin; only events straddling the window's
+# edges are ever discarded, so a couple of spares is enough.
+_CAL_ALL_DAY_MARGIN = 2
 
 
 def _cal_display_date(value: str, zone: "tzinfo") -> str:

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -14,7 +14,7 @@ import os
 import subprocess
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -41,7 +41,7 @@ from ts4k.core.format import (
     format_thread_listing,
 )
 from ts4k.core.normalize import normalize, normalize_headers
-from ts4k.core.tz import display_tzinfo
+from ts4k.core.tz import display_tzinfo, parse_utc
 from ts4k.state import batch, cache, contacts, filters, media, meters, sources, stats
 from ts4k.state.refs import RefTable
 
@@ -2810,6 +2810,7 @@ async def _cal_fetch_events(
     time_min: str,
     time_max: str,
     count: int = 250,
+    tz: "tzinfo | None" = None,
 ) -> list[dict]:
     """Fetch events from all calendar sources (or a specific one), merge by start time."""
     from ts4k.state import sources as src_mod
@@ -2848,11 +2849,73 @@ async def _cal_fetch_events(
     if source and attempted and len(errors) == attempted:
         raise RuntimeError("; ".join(errors))
 
-    # Sort by start time.  Every adapter stores timed starts in UTC, so this
-    # cheap string sort is chronological even across sources in different
-    # zones; all-day dates (no "T") sort ahead of that day's timed events.
-    all_events.sort(key=lambda e: e.get("start", ""))
+    zone = tz or display_tzinfo()
+    all_events = _cal_trim_all_day(all_events, time_min, time_max, zone)
+
+    # Sort by the day the reader sees, all-day events first within that day,
+    # then timed events by their UTC instant.  A plain string sort would put
+    # a 00:30+01:00 event (stored as the previous UTC day) ahead of the
+    # all-day entry it should follow.
+    all_events.sort(key=lambda e: _cal_sort_key(e, zone))
     return all_events[:count]
+
+
+def _cal_display_date(value: str, zone: "tzinfo") -> str:
+    """The date a stored start/end lands on for the reader.
+
+    Bare dates are all-day events and are already display dates — they are
+    deliberately never shifted.  Instants are converted into *zone*.
+    """
+    if "T" not in value:
+        return value
+    dt = parse_utc(value)
+    return dt.astimezone(zone).date().isoformat() if dt else value[:10]
+
+
+def _cal_sort_key(event: dict, zone: "tzinfo") -> tuple[str, int, str]:
+    start = event.get("start", "")
+    return (_cal_display_date(start, zone), 0 if "T" not in start else 1, start)
+
+
+def _cal_trim_all_day(
+    events: list[dict], time_min: str, time_max: str, zone: "tzinfo",
+) -> list[dict]:
+    """Drop all-day events that fall outside the requested display dates.
+
+    Calendar APIs select by overlap in absolute time, so a query bounded by
+    display-zone midnights can return an adjacent day's all-day event when
+    the calendar's own zone differs (a Tokyo March 11 all-day event begins
+    during March 10 in New York).  All-day dates are never shifted, so the
+    only correct filter is against the requested dates themselves.
+    """
+    lo = parse_utc(time_min)
+    hi = parse_utc(time_max)
+    if lo is None or hi is None:
+        return events
+
+    lo_date = lo.astimezone(zone).date()
+    # Callers bound differently — midnight of the next day (cal today/week)
+    # or 23:59:59 of the last day (cal range).  Stepping back an instant
+    # yields the last date actually requested under either convention.
+    last_date = (hi - timedelta(microseconds=1)).astimezone(zone).date()
+
+    kept = []
+    for event in events:
+        start = event.get("start", "")
+        if "T" in start or not start:
+            kept.append(event)
+            continue
+        try:
+            ev_start = date.fromisoformat(start)
+            ev_end = date.fromisoformat(event.get("end") or start)
+        except ValueError:
+            kept.append(event)  # unparseable: degrade to today's behaviour
+            continue
+        # All-day ends are exclusive; a same-day end means a one-day event.
+        ev_end = max(ev_end, ev_start + timedelta(days=1))
+        if ev_start <= last_date and ev_end > lo_date:
+            kept.append(event)
+    return kept
 
 
 def _cal_time_bounds(
@@ -2877,7 +2940,7 @@ async def cal_today(source: str | None, fmt: str, ref_table: RefTable | None = N
     """Today's calendar events."""
     tz = display_tzinfo()
     time_min, time_max = _cal_time_bounds(day_offset=0, days=1, tz=tz)
-    events = await _cal_fetch_events(source, time_min, time_max)
+    events = await _cal_fetch_events(source, time_min, time_max, tz=tz)
     output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=False, tz=tz)
     return CommandResult(output=output, messages_processed=len(events))
 
@@ -2886,7 +2949,7 @@ async def cal_tomorrow(source: str | None, fmt: str, ref_table: RefTable | None 
     """Tomorrow's calendar events."""
     tz = display_tzinfo()
     time_min, time_max = _cal_time_bounds(day_offset=1, days=1, tz=tz)
-    events = await _cal_fetch_events(source, time_min, time_max)
+    events = await _cal_fetch_events(source, time_min, time_max, tz=tz)
     output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=False, tz=tz)
     return CommandResult(output=output, messages_processed=len(events))
 
@@ -2897,7 +2960,7 @@ async def cal_week(source: str | None, fmt: str, ref_table: RefTable | None = No
     # Compute actual Monday-Sunday range for current week
     now = datetime.now(tz)
     time_min, time_max = _cal_time_bounds(day_offset=-now.weekday(), days=7, tz=tz)
-    events = await _cal_fetch_events(source, time_min, time_max)
+    events = await _cal_fetch_events(source, time_min, time_max, tz=tz)
     output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=False, tz=tz)
     return CommandResult(output=output, messages_processed=len(events))
 
@@ -2908,7 +2971,7 @@ async def cal_next(source: str | None, count: int, fmt: str, ref_table: RefTable
     # Look ahead 365 days max, collapse recurring
     time_min, _ = _cal_time_bounds(day_offset=0, days=1, tz=tz)
     _, time_max = _cal_time_bounds(day_offset=0, days=365, tz=tz)
-    events = await _cal_fetch_events(source, time_min, time_max, count=count)
+    events = await _cal_fetch_events(source, time_min, time_max, count=count, tz=tz)
     output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=True, tz=tz)
     return CommandResult(output=output, messages_processed=len(events))
 
@@ -2928,6 +2991,7 @@ async def cal_range(
         source,
         start.astimezone(timezone.utc).isoformat(),
         end.astimezone(timezone.utc).isoformat(),
+        tz=tz,
     )
     output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=collapse, tz=tz)
     return CommandResult(output=output, messages_processed=len(events))

--- a/src/ts4k/commands.py
+++ b/src/ts4k/commands.py
@@ -41,10 +41,13 @@ from ts4k.core.format import (
     format_thread_listing,
 )
 from ts4k.core.normalize import normalize, normalize_headers
+from ts4k.core.tz import display_tzinfo
 from ts4k.state import batch, cache, contacts, filters, media, meters, sources, stats
 from ts4k.state.refs import RefTable
 
 if TYPE_CHECKING:
+    from datetime import tzinfo
+
     from ts4k.auth.health import TokenHealth
 
 logger = logging.getLogger("ts4k")
@@ -2845,87 +2848,68 @@ async def _cal_fetch_events(
     if source and attempted and len(errors) == attempted:
         raise RuntimeError("; ".join(errors))
 
-    # Sort by start time
+    # Sort by start time.  Every adapter stores timed starts in UTC, so this
+    # cheap string sort is chronological even across sources in different
+    # zones; all-day dates (no "T") sort ahead of that day's timed events.
     all_events.sort(key=lambda e: e.get("start", ""))
     return all_events[:count]
 
 
-def _cal_time_bounds(day_offset: int = 0, days: int = 1, timezone: str = "UTC") -> tuple[str, str]:
-    """Compute time_min and time_max for calendar queries."""
-    import zoneinfo
+def _cal_time_bounds(
+    day_offset: int = 0, days: int = 1, tz: "tzinfo | None" = None,
+) -> tuple[str, str]:
+    """Compute time_min and time_max (UTC ISO) for calendar queries.
 
-    try:
-        tzinfo = zoneinfo.ZoneInfo(timezone)
-    except Exception:
-        from datetime import timezone as _tz
-        tzinfo = _tz.utc
-
-    now = datetime.now(tzinfo)
+    Day boundaries are the reader's midnights — computed in the display
+    timezone, then expressed in UTC like every other timestamp ts4k moves.
+    """
+    zone = tz or display_tzinfo()
+    now = datetime.now(zone)
     start = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=day_offset)
     end = start + timedelta(days=days)
-    return start.isoformat(), end.isoformat()
-
-
-def _get_cal_timezone(source: str | None) -> str:
-    """Get timezone from calendar sources config."""
-    from ts4k.state import sources as src_mod
-
-    all_sources = src_mod.list_all()
-    wanted = set(_resolve_prefixes(source)) if source else None
-    for pfx, cfg in all_sources.items():
-        if cfg.get("provider") not in _CAL_PROVIDERS:
-            continue
-        if wanted is not None and pfx not in wanted:
-            continue
-        return cfg.get("timezone", "UTC")
-    return "UTC"
+    return (
+        start.astimezone(timezone.utc).isoformat(),
+        end.astimezone(timezone.utc).isoformat(),
+    )
 
 
 async def cal_today(source: str | None, fmt: str, ref_table: RefTable | None = None) -> CommandResult:
     """Today's calendar events."""
-    tz = _get_cal_timezone(source)
-    time_min, time_max = _cal_time_bounds(day_offset=0, days=1, timezone=tz)
+    tz = display_tzinfo()
+    time_min, time_max = _cal_time_bounds(day_offset=0, days=1, tz=tz)
     events = await _cal_fetch_events(source, time_min, time_max)
-    output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=False)
+    output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=False, tz=tz)
     return CommandResult(output=output, messages_processed=len(events))
 
 
 async def cal_tomorrow(source: str | None, fmt: str, ref_table: RefTable | None = None) -> CommandResult:
     """Tomorrow's calendar events."""
-    tz = _get_cal_timezone(source)
-    time_min, time_max = _cal_time_bounds(day_offset=1, days=1, timezone=tz)
+    tz = display_tzinfo()
+    time_min, time_max = _cal_time_bounds(day_offset=1, days=1, tz=tz)
     events = await _cal_fetch_events(source, time_min, time_max)
-    output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=False)
+    output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=False, tz=tz)
     return CommandResult(output=output, messages_processed=len(events))
 
 
 async def cal_week(source: str | None, fmt: str, ref_table: RefTable | None = None) -> CommandResult:
     """This week's calendar events (Mon-Sun)."""
-    tz = _get_cal_timezone(source)
+    tz = display_tzinfo()
     # Compute actual Monday-Sunday range for current week
-    import zoneinfo
-    try:
-        tzinfo = zoneinfo.ZoneInfo(tz)
-    except Exception:
-        from datetime import timezone as _tz
-        tzinfo = _tz.utc
-    now = datetime.now(tzinfo)
-    monday = now.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=now.weekday())
-    sunday_end = monday + timedelta(days=7)
-    time_min, time_max = monday.isoformat(), sunday_end.isoformat()
+    now = datetime.now(tz)
+    time_min, time_max = _cal_time_bounds(day_offset=-now.weekday(), days=7, tz=tz)
     events = await _cal_fetch_events(source, time_min, time_max)
-    output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=False)
+    output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=False, tz=tz)
     return CommandResult(output=output, messages_processed=len(events))
 
 
 async def cal_next(source: str | None, count: int, fmt: str, ref_table: RefTable | None = None) -> CommandResult:
     """Next N events from now, any timeframe."""
-    tz = _get_cal_timezone(source)
+    tz = display_tzinfo()
     # Look ahead 365 days max, collapse recurring
-    time_min, _ = _cal_time_bounds(day_offset=0, days=1, timezone=tz)
-    _, time_max = _cal_time_bounds(day_offset=0, days=365, timezone=tz)
+    time_min, _ = _cal_time_bounds(day_offset=0, days=1, tz=tz)
+    _, time_max = _cal_time_bounds(day_offset=0, days=365, tz=tz)
     events = await _cal_fetch_events(source, time_min, time_max, count=count)
-    output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=True)
+    output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=True, tz=tz)
     return CommandResult(output=output, messages_processed=len(events))
 
 
@@ -2934,19 +2918,18 @@ async def cal_range(
     ref_table: RefTable | None = None,
 ) -> CommandResult:
     """Events in an arbitrary date range."""
-    import zoneinfo
-
-    tz_name = _get_cal_timezone(source)
-    try:
-        tzinfo = zoneinfo.ZoneInfo(tz_name)
-    except Exception:
-        tzinfo = timezone.utc
-
-    start = datetime.strptime(from_date, "%Y-%m-%d").replace(tzinfo=tzinfo)
-    end = datetime.strptime(to_date, "%Y-%m-%d").replace(hour=23, minute=59, second=59, tzinfo=tzinfo)
+    tz = display_tzinfo()
+    start = datetime.strptime(from_date, "%Y-%m-%d").replace(tzinfo=tz)
+    end = datetime.strptime(to_date, "%Y-%m-%d").replace(
+        hour=23, minute=59, second=59, tzinfo=tz,
+    )
     collapse = (end - start).days > 7
-    events = await _cal_fetch_events(source, start.isoformat(), end.isoformat())
-    output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=collapse)
+    events = await _cal_fetch_events(
+        source,
+        start.astimezone(timezone.utc).isoformat(),
+        end.astimezone(timezone.utc).isoformat(),
+    )
+    output = format_events(events, fmt=fmt, ref_table=ref_table, collapse_recurring=collapse, tz=tz)
     return CommandResult(output=output, messages_processed=len(events))
 
 
@@ -2979,7 +2962,7 @@ async def cal_event(
         event = await adapter.read_event(event_id)
 
     ref_num = int(ref_or_id) if ref_or_id.isdigit() else 0
-    return format_event_detail(event, ref=ref_num, fmt=fmt)
+    return format_event_detail(event, ref=ref_num, fmt=fmt, tz=display_tzinfo())
 
 
 async def cal_list_calendars(email: str, config_dir: Path | None = None) -> list[dict]:

--- a/src/ts4k/core/format.py
+++ b/src/ts4k/core/format.py
@@ -17,7 +17,11 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 from xml.sax.saxutils import escape as xml_escape, quoteattr as xml_quoteattr
 
+from ts4k.core.tz import display_tzinfo, parse_utc, tzinfo_for
+
 if TYPE_CHECKING:
+    from datetime import tzinfo
+
     from ts4k.state.refs import RefTable
 
 
@@ -254,14 +258,19 @@ def format_events(
     fmt: str = "pipe",
     ref_table: "RefTable | None" = None,
     collapse_recurring: bool = False,
+    tz: "str | tzinfo | None" = None,
 ) -> str:
     """Format calendar events as pipe-delimited listing.
 
     Args:
-        events: Normalized event dicts from GcalAdapter.
+        events: Normalized event dicts from a calendar adapter.  Timed
+            ``start``/``end`` are UTC; all-day ones are bare dates.
         fmt: Output format (pipe, json, xml).
         ref_table: If provided, assigns short refs via ref_table.assign().
         collapse_recurring: If True, collapse recurring series into one row.
+        tz: Display timezone.  Defaults to the resolved global one — every
+            row in a listing is rendered in the same zone, whatever mix of
+            sources it was merged from.
     """
     if fmt == "json":
         return json.dumps(events, indent=2)
@@ -269,8 +278,10 @@ def format_events(
     if not events:
         return "No events."
 
+    zone = tzinfo_for(tz) if tz else display_tzinfo()
+
     # Determine time display mode from date span
-    time_mode = _detect_time_mode(events)
+    time_mode = _detect_time_mode(events, zone)
 
     # Optionally collapse recurring events
     display_events = _collapse_recurring(events) if collapse_recurring else events
@@ -282,7 +293,7 @@ def format_events(
     for evt in display_events:
         ref_num = ref_map.get(evt.get("id", ""), 0) if ref_map else 0
 
-        time_str = _format_event_time(evt, time_mode)
+        time_str = _format_event_time(evt, time_mode, zone)
         dur_str = _format_duration(evt)
         title = evt.get("title", "")
         if evt.get("your_status") == "declined":
@@ -303,12 +314,18 @@ def format_events(
     return "\n".join(lines)
 
 
-def format_event_detail(event: dict, ref: int = 0, fmt: str = "pipe") -> str:
-    """Format a single event's full detail as mini-XML."""
+def format_event_detail(
+    event: dict, ref: int = 0, fmt: str = "pipe",
+    tz: "str | tzinfo | None" = None,
+) -> str:
+    """Format a single event's full detail as mini-XML.
+
+    *tz* is the display timezone; it defaults to the resolved global one.
+    """
     if fmt == "json":
         return json.dumps(event, indent=2)
 
-    when = _format_when_detail(event)
+    when = _format_when_detail(event, tzinfo_for(tz) if tz else display_tzinfo())
     parts = [f'<ev ref="{ref}" id="{event.get("id", "")}">']
     parts.append(f'<title>{event.get("title", "")}</title>')
     parts.append(f"<when>{when}</when>")
@@ -345,8 +362,17 @@ def format_event_detail(event: dict, ref: int = 0, fmt: str = "pipe") -> str:
 # -- Calendar format helpers --------------------------------------------------
 
 
-def _detect_time_mode(events: list[dict]) -> str:
+def _local_start(event: dict, tz: "tzinfo") -> datetime | None:
+    """A timed event's stored UTC ``start`` as a wall clock in *tz*."""
+    dt = parse_utc(event.get("start", ""))
+    return dt.astimezone(tz) if dt is not None else None
+
+
+def _detect_time_mode(events: list[dict], tz: "tzinfo") -> str:
     """Determine time display mode based on date span of events.
+
+    The span is measured in *tz* — a UTC date can fall on the day either
+    side of the one the reader sees.
 
     Returns: 'time' (same day), 'day' (multi-day <=7d), 'date' (>7d).
     """
@@ -356,8 +382,8 @@ def _detect_time_mode(events: list[dict]) -> str:
         if evt.get("all_day"):
             dates.add(start)
         else:
-            # Extract date part from ISO datetime
-            dates.add(start[:10])
+            local = _local_start(evt, tz)
+            dates.add(local.strftime("%Y-%m-%d") if local else start[:10])
 
     if len(dates) <= 1:
         return "time"
@@ -373,8 +399,8 @@ def _detect_time_mode(events: list[dict]) -> str:
     return "day" if span <= 7 else "date"
 
 
-def _format_event_time(event: dict, mode: str) -> str:
-    """Format event time based on display mode."""
+def _format_event_time(event: dict, mode: str, tz: "tzinfo") -> str:
+    """Format event time based on display mode, in the display timezone *tz*."""
     if event.get("all_day"):
         start = event["start"]
         end = event.get("end", start)
@@ -396,12 +422,12 @@ def _format_event_time(event: dict, mode: str) -> str:
             return f"{start_display}-{end_dt.day}"
         return f"{start_display} all-day"
 
-    # Timed event
-    try:
-        start_dt = datetime.fromisoformat(event["start"])
-        end_dt = datetime.fromisoformat(event["end"])
-    except (ValueError, KeyError):
+    # Timed event — stored UTC, rendered in the display timezone
+    start_dt = _local_start(event, tz)
+    end_utc = parse_utc(event.get("end", ""))
+    if start_dt is None or end_utc is None:
         return event.get("start", "?")
+    end_dt = end_utc.astimezone(tz)
 
     start_time = start_dt.strftime("%H:%M")
     end_time = end_dt.strftime("%H:%M")
@@ -438,8 +464,8 @@ def _format_duration(event: dict) -> str:
     return f"{mins}m"
 
 
-def _format_when_detail(event: dict) -> str:
-    """Format when line for event detail XML."""
+def _format_when_detail(event: dict, tz: "tzinfo") -> str:
+    """Format when line for event detail XML, in the display timezone *tz*."""
     if event.get("all_day"):
         try:
             s = datetime.strptime(event["start"], "%Y-%m-%d")
@@ -453,15 +479,15 @@ def _format_when_detail(event: dict) -> str:
         except ValueError:
             return "all-day"
 
-    try:
-        s = datetime.fromisoformat(event["start"])
-        e = datetime.fromisoformat(event["end"])
-        day_str = f"{s.strftime('%a %b')} {str(s.day)}"
-        time_str = f"{s.strftime('%H:%M')}-{e.strftime('%H:%M')}"
-        dur = _format_duration(event)
-        return f"{day_str}, {time_str} ({dur})" if dur else f"{day_str}, {time_str}"
-    except (ValueError, KeyError):
+    s = _local_start(event, tz)
+    e_utc = parse_utc(event.get("end", ""))
+    if s is None or e_utc is None:
         return event.get("start", "?")
+    e = e_utc.astimezone(tz)
+    day_str = f"{s.strftime('%a %b')} {str(s.day)}"
+    time_str = f"{s.strftime('%H:%M')}-{e.strftime('%H:%M')}"
+    dur = _format_duration(event)
+    return f"{day_str}, {time_str} ({dur})" if dur else f"{day_str}, {time_str}"
 
 
 def _collapse_recurring(events: list[dict]) -> list[dict]:

--- a/src/ts4k/core/tz.py
+++ b/src/ts4k/core/tz.py
@@ -1,0 +1,117 @@
+"""Timezone helpers — UTC internally, local only at display.
+
+ts4k stores and compares every timestamp in UTC.  Adapters convert at the
+edge (:func:`to_utc_iso`), the pipeline sorts the resulting ISO strings
+lexicographically — which is chronologically correct precisely *because*
+every string carries the same ``+00:00`` offset — and the format layer
+converts back to a wall clock exactly once, at render time.
+
+The display timezone is **global**, not per-source: a merged agenda drawn
+from calendars configured in different zones must not mix offsets, or the
+listing it produces is unreadable.  Resolution order:
+
+1. ``TS4K_TIMEZONE`` env var
+2. ``timezone`` in ``~/.config/ts4k/settings.json``
+3. the machine's own zone
+
+All-day events are the exception to the rule: they are *dates*, not
+instants, and stay bare ``YYYY-MM-DD`` strings the whole way through.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone, tzinfo
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+_ENV_VAR = "TS4K_TIMEZONE"
+
+
+# ---------------------------------------------------------------------------
+# Conversion
+# ---------------------------------------------------------------------------
+
+
+def tzinfo_for(name: str | tzinfo | None) -> tzinfo:
+    """Resolve an IANA name to a tzinfo, falling back to UTC for unknown zones."""
+    if isinstance(name, tzinfo):
+        return name
+    if not name:
+        return timezone.utc
+    try:
+        return ZoneInfo(name)
+    except Exception:
+        return timezone.utc
+
+
+def to_utc_iso(value: str, assume: str | tzinfo = timezone.utc) -> str:
+    """Convert an ISO-8601 timestamp to a UTC ISO string.
+
+    Values without an offset are floating times — they are interpreted in
+    *assume* (a source's configured zone) before conversion.  Anything that
+    does not parse is returned unchanged, so a surprising API payload
+    degrades to today's behaviour instead of vanishing.
+    """
+    try:
+        dt = datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return value
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=tzinfo_for(assume))
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def parse_utc(value: str) -> datetime | None:
+    """Parse a stored timestamp as an aware UTC datetime, or None if malformed.
+
+    Naive values are read as UTC — that is what "stored" means here.
+    """
+    try:
+        dt = datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Display timezone
+# ---------------------------------------------------------------------------
+
+
+def display_tzinfo() -> tzinfo:
+    """The single global display timezone: env var, then config, then machine."""
+    name = os.environ.get(_ENV_VAR)
+    if not name:
+        from ts4k.state import settings
+
+        name = settings.get_timezone()
+    if name:
+        return tzinfo_for(name)
+    return system_tzinfo()
+
+
+def system_tzinfo() -> tzinfo:
+    """The machine's zone, as a DST-aware ZoneInfo where one can be named."""
+    name = os.environ.get("TZ") or _localtime_key()
+    if name:
+        try:
+            return ZoneInfo(name)
+        except Exception:
+            pass
+    # No IANA name available (Windows, or an unreadable zoneinfo tree): the
+    # current local offset, which is right except across a DST boundary.
+    return datetime.now().astimezone().tzinfo or timezone.utc
+
+
+def _localtime_key() -> str | None:
+    """IANA key behind /etc/localtime, when it points into the zoneinfo tree."""
+    try:
+        parts = Path("/etc/localtime").resolve().parts
+    except OSError:
+        return None
+    if "zoneinfo" not in parts:
+        return None
+    return "/".join(parts[parts.index("zoneinfo") + 1:]) or None

--- a/src/ts4k/state/settings.py
+++ b/src/ts4k/state/settings.py
@@ -1,0 +1,44 @@
+"""Global settings — the handful of knobs that are not per-source.
+
+Stores a JSON file at ``~/.config/ts4k/settings.json``.  Everything here is
+optional; an absent file means "use the defaults".
+
+File format::
+
+    {
+        "timezone": "Europe/Amsterdam"
+    }
+
+* **timezone**: IANA name of the single display timezone used to render every
+  timestamp.  Absent means "follow the machine".  The ``TS4K_TIMEZONE`` env
+  var overrides this file — see :mod:`ts4k.core.tz`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+_CONFIG_DIR = Path(os.environ.get("TS4K_CONFIG_DIR", "~/.config/ts4k")).expanduser()
+_SETTINGS_FILE = _CONFIG_DIR / "settings.json"
+
+
+def _load() -> dict[str, Any]:
+    """Load the settings file, or return an empty dict."""
+    if not _SETTINGS_FILE.exists():
+        return {}
+    try:
+        raw = json.loads(_SETTINGS_FILE.read_text(encoding="utf-8"))
+        if isinstance(raw, dict):
+            return raw
+    except (json.JSONDecodeError, OSError):
+        pass
+    return {}
+
+
+def get_timezone() -> str | None:
+    """Configured display timezone (IANA name), or None to follow the machine."""
+    value = _load().get("timezone")
+    return value if isinstance(value, str) and value.strip() else None

--- a/tests/test_cal_commands.py
+++ b/tests/test_cal_commands.py
@@ -16,10 +16,15 @@ from ts4k.commands import (
     cal_update,
     cal_rsvp,
     _cal_time_bounds,
-    _get_cal_timezone,
     _cal_fetch_events,
 )
 from ts4k.state import sources
+
+
+@pytest.fixture(autouse=True)
+def fixed_display_tz(monkeypatch):
+    """Pin the display timezone so tests never depend on the host's zone."""
+    monkeypatch.setenv("TS4K_TIMEZONE", "Europe/Amsterdam")
 
 
 @pytest.fixture
@@ -57,46 +62,40 @@ def mock_events():
 
 
 class TestCalTimeBounds:
-    def test_returns_iso_strings(self):
-        time_min, time_max = _cal_time_bounds(day_offset=0, days=1, timezone="UTC")
-        assert "T00:00:00" in time_min
-        assert "T" in time_max
+    def test_returns_utc_iso_strings(self):
+        from zoneinfo import ZoneInfo
+
+        time_min, time_max = _cal_time_bounds(day_offset=0, days=1, tz=ZoneInfo("UTC"))
+        assert "T00:00:00+00:00" in time_min
+        assert "+00:00" in time_max
 
     def test_day_offset_shifts_start(self):
-        today_min, _ = _cal_time_bounds(day_offset=0, days=1, timezone="UTC")
-        tomorrow_min, _ = _cal_time_bounds(day_offset=1, days=1, timezone="UTC")
+        today_min, _ = _cal_time_bounds(day_offset=0, days=1)
+        tomorrow_min, _ = _cal_time_bounds(day_offset=1, days=1)
         assert today_min < tomorrow_min
 
-    def test_invalid_timezone_falls_back_to_utc(self):
-        time_min, time_max = _cal_time_bounds(timezone="Not/A/Zone")
-        assert "+00:00" in time_min
+    def test_boundaries_are_midnight_in_the_display_timezone(self, monkeypatch):
+        """"Today" starts at the reader's midnight, not UTC's."""
+        from datetime import datetime
+        from zoneinfo import ZoneInfo
 
+        monkeypatch.setenv("TS4K_TIMEZONE", "America/New_York")
+        time_min, time_max = _cal_time_bounds(day_offset=0, days=1)
 
-class TestGetCalTimezone:
-    def test_returns_configured_tz(self, mock_sources):
-        tz = _get_cal_timezone(None)
-        assert tz == "UTC"
+        # Expressed in UTC on the wire...
+        assert time_min.endswith("+00:00")
+        # ...but midnight-to-midnight for a New York reader.
+        ny = ZoneInfo("America/New_York")
+        local_min = datetime.fromisoformat(time_min).astimezone(ny)
+        local_max = datetime.fromisoformat(time_max).astimezone(ny)
+        assert (local_min.hour, local_min.minute) == (0, 0)
+        assert (local_max.hour, local_max.minute) == (0, 0)
+        assert (local_max.date() - local_min.date()).days == 1
 
-    def test_returns_utc_when_no_gcal_sources(self, tmp_path, monkeypatch):
-        sources_file = tmp_path / "sources.json"
-        sources_file.write_text('{"g": {"provider": "gmail", "email": "x@y.com"}}')
-        monkeypatch.setattr(sources, "_CONFIG_DIR", tmp_path)
-        monkeypatch.setattr(sources, "_SOURCES_FILE", sources_file)
-        tz = _get_cal_timezone(None)
-        assert tz == "UTC"
-
-    def test_returns_specific_source_tz(self, tmp_path, monkeypatch):
-        sources_file = tmp_path / "sources.json"
-        sources_file.write_text(
-            '{"gc": {"provider": "gcal", "email": "a@b.com", "calendar_id": "primary", '
-            '"timezone": "Europe/Amsterdam"}, '
-            '"gc2": {"provider": "gcal", "email": "a@b.com", "calendar_id": "work", '
-            '"timezone": "America/New_York"}}'
-        )
-        monkeypatch.setattr(sources, "_CONFIG_DIR", tmp_path)
-        monkeypatch.setattr(sources, "_SOURCES_FILE", sources_file)
-        tz = _get_cal_timezone("gc2")
-        assert tz == "America/New_York"
+    def test_display_timezone_falls_back_to_utc_for_unknown_zone(self, monkeypatch):
+        monkeypatch.setenv("TS4K_TIMEZONE", "Not/A/Zone")
+        time_min, _ = _cal_time_bounds()
+        assert "T00:00:00+00:00" in time_min
 
 
 class TestCalToday:
@@ -179,10 +178,12 @@ class TestCalWeek:
 
             await cal_week(source=None, fmt="pipe")
 
-        # Verify the time_min is a Monday (weekday 0) at midnight
+        # Verify the time_min is a Monday (weekday 0) at midnight, read back
+        # in the display timezone the boundary was computed in
         from datetime import datetime
+        from zoneinfo import ZoneInfo
         time_min = captured_args.get("time_min", "")
-        dt = datetime.fromisoformat(time_min)
+        dt = datetime.fromisoformat(time_min).astimezone(ZoneInfo("Europe/Amsterdam"))
         assert dt.weekday() == 0, f"Expected Monday (0), got {dt.weekday()}"
         assert dt.hour == 0 and dt.minute == 0
 
@@ -628,11 +629,46 @@ class TestCalEventO365:
         assert "O365 Review" in result
 
 
-class TestGetCalTimezoneO365:
-    def test_returns_o365cal_tz(self, mock_o365cal_sources):
-        tz = _get_cal_timezone(None)
-        assert tz == "UTC"
+class TestDisplayTimezoneIsGlobal:
+    """One display timezone per render, whatever the sources are configured as."""
 
-    def test_returns_specific_o365cal_tz(self, mock_mixed_sources):
-        tz = _get_cal_timezone("oc")
-        assert tz == "Europe/Amsterdam"
+    @pytest.mark.asyncio
+    async def test_mixed_zone_sources_render_in_one_zone(self, mock_mixed_sources, monkeypatch):
+        monkeypatch.setenv("TS4K_TIMEZONE", "America/New_York")
+        # Both events are 14:00 UTC = 10:00 in New York, whatever the
+        # per-source "timezone" config says (UTC and Europe/Amsterdam here).
+        gcal_events = [
+            {"id": "gc:e1", "source": "gc", "title": "Google Event",
+             "start": "2026-03-11T14:00:00+00:00", "end": "2026-03-11T15:00:00+00:00",
+             "all_day": False, "duration_minutes": 60, "location": "",
+             "attendees_summary": "", "status": "confirmed",
+             "your_status": None, "recurring_event_id": None},
+        ]
+        o365_events = [
+            {"id": "oc:e2", "source": "oc", "title": "Outlook Event",
+             "start": "2026-03-11T14:00:00+00:00", "end": "2026-03-11T15:00:00+00:00",
+             "all_day": False, "duration_minutes": 60, "location": "",
+             "attendees_summary": "", "status": "confirmed",
+             "your_status": None, "recurring_event_id": None},
+        ]
+
+        call_count = [0]
+
+        async def mock_list_events(**kwargs):
+            call_count[0] += 1
+            return gcal_events if call_count[0] == 1 else o365_events
+
+        with patch("ts4k.commands.GcalAdapter") as MockGcal, \
+             patch("ts4k.commands.O365CalAdapter") as MockO365:
+            for MockCls in (MockGcal, MockO365):
+                inst = AsyncMock()
+                inst.list_events = AsyncMock(side_effect=mock_list_events)
+                inst.__aenter__ = AsyncMock(return_value=inst)
+                inst.__aexit__ = AsyncMock(return_value=False)
+                MockCls.return_value = inst
+
+            result = await cal_today(source=None, fmt="pipe")
+
+        rows = [ln for ln in result.output.splitlines() if not ln.startswith("REF|")]
+        assert len(rows) == 2
+        assert all("10:00-11:00" in row for row in rows), result.output

--- a/tests/test_cal_format.py
+++ b/tests/test_cal_format.py
@@ -2,6 +2,18 @@
 
 from __future__ import annotations
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def fixed_display_tz(monkeypatch):
+    """Pin the display timezone so tests never depend on the host's zone.
+
+    Events below carry Amsterdam wall-clock times (+01:00 in March), so
+    rendering in Europe/Amsterdam leaves the printed clock unchanged.
+    """
+    monkeypatch.setenv("TS4K_TIMEZONE", "Europe/Amsterdam")
+
 
 
 class TestFormatEventsPipe:

--- a/tests/test_cal_timezone.py
+++ b/tests/test_cal_timezone.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
+from zoneinfo import ZoneInfo
 
 import pytest
 from icalendar import Calendar as IcsCalendar
@@ -430,3 +431,138 @@ class TestSingleTimezoneUnchanged:
         assert "09:00-10:00" in out
         assert "21:00-22:00" in out
         assert "Wed" not in out
+
+
+# ---------------------------------------------------------------------------
+# Review follow-ups: zone fidelity at the adapter edge, display-date
+# correctness at the command edge
+# ---------------------------------------------------------------------------
+
+
+class TestEventLevelTimezones:
+    """An event may override its calendar's zone; honour it."""
+
+    def test_gcal_floating_time_uses_the_event_zone_not_the_calendar_zone(self):
+        adapter = _gcal("Europe/Amsterdam")
+        raw = {
+            "id": "e1", "summary": "Tokyo call", "status": "confirmed",
+            "start": {"dateTime": "2026-03-11T09:00:00", "timeZone": "Asia/Tokyo"},
+            "end": {"dateTime": "2026-03-11T10:00:00", "timeZone": "Asia/Tokyo"},
+        }
+        event = adapter._normalize_event(raw)
+        # 09:00 in Tokyo is 00:00 UTC — not 08:00 UTC as Amsterdam would give.
+        assert event["start"].startswith("2026-03-11T00:00")
+
+    def test_gcal_falls_back_to_the_calendar_zone_when_absent(self):
+        adapter = _gcal("Europe/Amsterdam")
+        raw = {
+            "id": "e1", "summary": "Local", "status": "confirmed",
+            "start": {"dateTime": "2026-03-11T09:00:00"},
+            "end": {"dateTime": "2026-03-11T10:00:00"},
+        }
+        event = adapter._normalize_event(raw)
+        assert event["start"].startswith("2026-03-11T08:00")
+
+    @pytest.mark.asyncio
+    async def test_o365_pins_the_graph_response_zone_to_utc(self):
+        """Unpinned, Graph may answer in Windows zone IDs ZoneInfo cannot read."""
+        adapter = _o365cal("America/New_York")
+        client = MagicMock()
+        resp = MagicMock()
+        resp.json.return_value = {"value": []}
+        resp.raise_for_status = MagicMock()
+        client.get = AsyncMock(return_value=resp)
+        adapter._client = client
+
+        await adapter.list_events("2026-03-11T00:00:00+00:00", "2026-03-12T00:00:00+00:00")
+
+        headers = client.get.await_args.kwargs["headers"]
+        assert headers["Prefer"] == 'outlook.timezone="UTC"'
+
+
+class TestAllDayDisplayDate:
+    """All-day dates are never shifted, so they must be filtered and sorted
+    against the *requested* display date rather than an absolute instant."""
+
+    @staticmethod
+    def _all_day(eid: str, title: str, start: str, end: str) -> dict:
+        return {
+            "id": f"gc:{eid}", "source": "gc", "title": title,
+            "start": start, "end": end, "all_day": True,
+            "duration_minutes": None, "status": "confirmed",
+        }
+
+    @staticmethod
+    def _timed(eid: str, title: str, start: str, end: str) -> dict:
+        return {
+            "id": f"gc:{eid}", "source": "gc", "title": title,
+            "start": start, "end": end, "all_day": False,
+            "duration_minutes": 60, "status": "confirmed",
+        }
+
+    def test_adjacent_day_all_day_event_is_dropped(self):
+        """A Tokyo Mar 11 all-day event overlaps Mar 10 in New York."""
+        zone = ZoneInfo("America/New_York")
+        events = [
+            self._all_day("e1", "Tokyo holiday", "2026-03-11", "2026-03-12"),
+            self._all_day("e2", "NY holiday", "2026-03-10", "2026-03-11"),
+        ]
+        kept = commands._cal_trim_all_day(
+            events,
+            "2026-03-10T04:00:00+00:00",  # Mar 10 00:00 EDT
+            "2026-03-11T04:00:00+00:00",  # Mar 11 00:00 EDT
+            zone,
+        )
+        assert [e["title"] for e in kept] == ["NY holiday"]
+
+    def test_multi_day_all_day_event_spanning_the_window_is_kept(self):
+        zone = ZoneInfo("America/New_York")
+        events = [self._all_day("e1", "Conference", "2026-03-09", "2026-03-13")]
+        kept = commands._cal_trim_all_day(
+            events, "2026-03-10T04:00:00+00:00", "2026-03-11T04:00:00+00:00", zone,
+        )
+        assert len(kept) == 1
+
+    def test_same_day_end_is_treated_as_a_one_day_event(self):
+        """Some sources report end == start rather than an exclusive next day."""
+        zone = ZoneInfo("America/New_York")
+        events = [self._all_day("e1", "Holiday", "2026-03-10", "2026-03-10")]
+        kept = commands._cal_trim_all_day(
+            events, "2026-03-10T04:00:00+00:00", "2026-03-11T04:00:00+00:00", zone,
+        )
+        assert len(kept) == 1
+
+    def test_inclusive_end_of_day_bound_keeps_that_days_all_day_event(self):
+        """`cal range` bounds at 23:59:59, not the next midnight."""
+        zone = ZoneInfo("America/New_York")
+        events = [self._all_day("e1", "Last day", "2026-03-12", "2026-03-13")]
+        kept = commands._cal_trim_all_day(
+            events,
+            "2026-03-10T04:00:00+00:00",
+            "2026-03-13T03:59:59+00:00",  # Mar 12 23:59:59 EDT
+            zone,
+        )
+        assert len(kept) == 1
+
+    def test_timed_events_are_never_filtered(self):
+        zone = ZoneInfo("America/New_York")
+        events = [self._timed("e1", "Call", "2026-03-10T14:00:00+00:00",
+                              "2026-03-10T15:00:00+00:00")]
+        kept = commands._cal_trim_all_day(
+            events, "2026-03-10T04:00:00+00:00", "2026-03-11T04:00:00+00:00", zone,
+        )
+        assert len(kept) == 1
+
+    def test_all_day_sorts_ahead_of_that_local_days_timed_events(self):
+        """00:30+01:00 is stored on the previous UTC day but is the same
+        local day, so the all-day entry must still lead it."""
+        zone = ZoneInfo("Europe/Amsterdam")
+        all_day = self._all_day("e1", "Holiday", "2026-03-11", "2026-03-12")
+        just_after_midnight = self._timed(
+            "e2", "Night call", "2026-03-10T23:30:00+00:00", "2026-03-11T00:30:00+00:00",
+        )
+        events = sorted(
+            [just_after_midnight, all_day],
+            key=lambda e: commands._cal_sort_key(e, zone),
+        )
+        assert [e["title"] for e in events] == ["Holiday", "Night call"]

--- a/tests/test_cal_timezone.py
+++ b/tests/test_cal_timezone.py
@@ -479,6 +479,26 @@ class TestEventLevelTimezones:
         headers = client.get.await_args.kwargs["headers"]
         assert headers["Prefer"] == 'outlook.timezone="UTC"'
 
+    @pytest.mark.asyncio
+    async def test_o365_pins_the_zone_on_single_event_reads_too(self):
+        """`cal event` reads one event directly — same exposure as listing."""
+        adapter = _o365cal("America/New_York")
+        client = MagicMock()
+        resp = MagicMock()
+        resp.json.return_value = {
+            "id": "e1", "subject": "Sync", "isAllDay": False,
+            "start": {"dateTime": "2026-03-11T09:00:00.0000000", "timeZone": "UTC"},
+            "end": {"dateTime": "2026-03-11T10:00:00.0000000", "timeZone": "UTC"},
+        }
+        resp.raise_for_status = MagicMock()
+        client.get = AsyncMock(return_value=resp)
+        adapter._client = client
+
+        await adapter.read_event("oc:e1")
+
+        headers = client.get.await_args.kwargs["headers"]
+        assert headers["Prefer"] == 'outlook.timezone="UTC"'
+
 
 class TestAllDayDisplayDate:
     """All-day dates are never shifted, so they must be filtered and sorted
@@ -566,3 +586,70 @@ class TestAllDayDisplayDate:
             key=lambda e: commands._cal_sort_key(e, zone),
         )
         assert [e["title"] for e in events] == ["Holiday", "Night call"]
+
+class TestAllDayFilterDoesNotShrinkResults:
+    @pytest.mark.asyncio
+    async def test_count_is_still_met_when_an_all_day_event_is_filtered_out(
+        self, monkeypatch,
+    ):
+        """`cal next -n N` must still return N when the display-date filter
+        discards a boundary all-day event the adapter counted toward N."""
+        zone = ZoneInfo("America/New_York")
+
+        def _event(n: int) -> dict:
+            return {
+                "id": f"gc:t{n}", "source": "gc", "title": f"Timed {n}",
+                "start": f"2026-03-10T1{n}:00:00+00:00",
+                "end": f"2026-03-10T1{n}:30:00+00:00",
+                "all_day": False, "duration_minutes": 30, "status": "confirmed",
+            }
+
+        # The adapter returns a stale-dated all-day event plus three timed
+        # ones — it can only do so because it was asked for more than 3.
+        returned = [
+            {
+                "id": "gc:a1", "source": "gc", "title": "Yesterday holiday",
+                "start": "2026-03-09", "end": "2026-03-10", "all_day": True,
+                "duration_minutes": None, "status": "confirmed",
+            },
+            *[_event(n) for n in range(1, 4)],
+        ]
+        _mock_cal_sources(monkeypatch, {"gc": returned})
+
+        events = await commands._cal_fetch_events(
+            None,
+            "2026-03-10T04:00:00+00:00",
+            "2026-03-11T04:00:00+00:00",
+            count=3,
+            tz=zone,
+        )
+        assert [e["title"] for e in events] == ["Timed 1", "Timed 2", "Timed 3"]
+
+    @pytest.mark.asyncio
+    async def test_adapters_are_asked_for_a_margin_above_count(self, monkeypatch):
+        seen: dict[str, int] = {}
+
+        monkeypatch.setattr(
+            "ts4k.state.sources.list_all",
+            lambda: {"gc": {"provider": "gcal", "email": "a@b.com", "calendar_id": "primary"}},
+        )
+
+        def _make(prefix: str, cfg: dict):
+            mock = MagicMock()
+            mock.__aenter__ = AsyncMock(return_value=mock)
+            mock.__aexit__ = AsyncMock(return_value=None)
+
+            async def _list(time_min, time_max, count):
+                seen["count"] = count
+                return []
+
+            mock.list_events = _list
+            return mock
+
+        monkeypatch.setattr(commands, "_make_adapter", _make)
+
+        await commands._cal_fetch_events(
+            None, "2026-03-10T04:00:00+00:00", "2026-03-11T04:00:00+00:00",
+            count=5, tz=ZoneInfo("America/New_York"),
+        )
+        assert seen["count"] > 5

--- a/tests/test_cal_timezone.py
+++ b/tests/test_cal_timezone.py
@@ -1,0 +1,432 @@
+"""The internal-UTC convention: adapters store UTC, the format layer displays local.
+
+These cover the two failure modes issue #54 was filed for — a cross-source
+merge of calendars configured in *different* zones, and a query window
+spanning a DST fallback — plus the guarantee that a single-timezone install
+sees exactly the wall clock it saw before.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from icalendar import Calendar as IcsCalendar
+
+from ts4k import commands
+from ts4k.adapters.caldav_cal import CaldavAdapter, CaldavAdapterConfig
+from ts4k.adapters.gcal import GcalAdapter, GcalAdapterConfig
+from ts4k.adapters.o365cal import O365CalAdapter, O365CalAdapterConfig
+from ts4k.auth.caldav import ICLOUD_CALDAV_URL, save_credentials
+from ts4k.core.format import format_event_detail, format_events
+
+
+# ---------------------------------------------------------------------------
+# Adapter builders — real normalizers, no transport
+# ---------------------------------------------------------------------------
+
+
+def _gcal(timezone: str = "Europe/Amsterdam", prefix: str = "gc") -> GcalAdapter:
+    return GcalAdapter(
+        GcalAdapterConfig(
+            email="a@gmail.com", calendar_id="primary", calendar_name="Main",
+            timezone=timezone,
+        ),
+        prefix=prefix,
+    )
+
+
+def _o365cal(timezone: str = "America/New_York", prefix: str = "oc") -> O365CalAdapter:
+    return O365CalAdapter(
+        O365CalAdapterConfig(
+            email="a@contoso.com", client_id="cid", calendar_name="Work",
+            timezone=timezone,
+        ),
+        prefix=prefix,
+    )
+
+
+def _caldav(tmp_path: Path, timezone: str = "Europe/Amsterdam") -> CaldavAdapter:
+    save_credentials(
+        "test@icloud.com", username="test@icloud.com", app_password="abcd-efgh",
+        server_url=ICLOUD_CALDAV_URL, config_dir=tmp_path,
+    )
+    a = CaldavAdapter(
+        CaldavAdapterConfig(
+            email="test@icloud.com", server_url=ICLOUD_CALDAV_URL,
+            calendar_id="https://caldav.icloud.com/1/calendars/home/",
+            calendar_name="Home", timezone=timezone, config_dir=tmp_path,
+        ),
+        prefix="cc",
+    )
+    a._principal = MagicMock()
+    a._calendar = MagicMock()
+    return a
+
+
+def _vevent(ics: str):
+    return IcsCalendar.from_ical(ics).walk("VEVENT")[0]
+
+
+def _gcal_raw(eid: str, title: str, start: str, end: str) -> dict:
+    return {
+        "id": eid, "summary": title, "status": "confirmed",
+        "start": {"dateTime": start}, "end": {"dateTime": end},
+    }
+
+
+def _graph_raw(eid: str, title: str, start: str, end: str, zone: str) -> dict:
+    return {
+        "id": eid, "subject": title,
+        "start": {"dateTime": start, "timeZone": zone},
+        "end": {"dateTime": end, "timeZone": zone},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Every adapter stores timed events in UTC
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptersStoreUtc:
+    def test_gcal_offset_normalized_to_utc(self):
+        e = _gcal()._normalize_event(
+            _gcal_raw("e1", "Standup", "2026-03-11T09:00:00+01:00",
+                      "2026-03-11T09:30:00+01:00")
+        )
+        assert e["start"] == "2026-03-11T08:00:00+00:00"
+        assert e["end"] == "2026-03-11T08:30:00+00:00"
+        assert e["duration_minutes"] == 30
+
+    def test_graph_sibling_timezone_field_normalized_to_utc(self):
+        """Graph puts the zone next to the dateTime, not inside it."""
+        e = _o365cal()._normalize_event(
+            _graph_raw("e1", "Sync", "2026-03-11T09:00:00.0000000",
+                       "2026-03-11T10:00:00.0000000", "America/New_York")
+        )
+        assert e["start"] == "2026-03-11T13:00:00+00:00"
+        assert e["end"] == "2026-03-11T14:00:00+00:00"
+        assert e["duration_minutes"] == 60
+
+    def test_caldav_tzid_normalized_to_utc(self, tmp_path: Path):
+        e = _caldav(tmp_path)._normalize_component(_vevent(
+            "BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//t//EN\nBEGIN:VEVENT\n"
+            "UID:u1\nSUMMARY:Dentist\n"
+            "DTSTART;TZID=Europe/Amsterdam:20260311T140000\n"
+            "DTEND;TZID=Europe/Amsterdam:20260311T150000\n"
+            "END:VEVENT\nEND:VCALENDAR\n"
+        ))
+        assert e["start"] == "2026-03-11T13:00:00+00:00"
+        assert e["end"] == "2026-03-11T14:00:00+00:00"
+
+
+class TestAllDayEventsUnchanged:
+    """All-day events are dates, not instants — no adapter may convert them."""
+
+    def test_gcal_all_day_stays_a_date(self):
+        e = _gcal()._normalize_event({
+            "id": "e1", "summary": "Holiday", "status": "confirmed",
+            "start": {"date": "2026-03-17"}, "end": {"date": "2026-03-22"},
+        })
+        assert e["all_day"] is True
+        assert (e["start"], e["end"]) == ("2026-03-17", "2026-03-22")
+        assert e["duration_minutes"] is None
+
+    def test_o365cal_all_day_stays_a_date(self):
+        e = _o365cal()._normalize_event({
+            "id": "e1", "subject": "Holiday", "isAllDay": True,
+            "start": {"dateTime": "2026-03-17T00:00:00.0000000", "timeZone": "America/New_York"},
+            "end": {"dateTime": "2026-03-22T00:00:00.0000000", "timeZone": "America/New_York"},
+        })
+        assert e["all_day"] is True
+        assert (e["start"], e["end"]) == ("2026-03-17", "2026-03-22")
+
+    def test_caldav_all_day_stays_a_date(self, tmp_path: Path):
+        e = _caldav(tmp_path)._normalize_component(_vevent(
+            "BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//t//EN\nBEGIN:VEVENT\n"
+            "UID:u1\nSUMMARY:Holiday\nDTSTART;VALUE=DATE:20260317\n"
+            "DTEND;VALUE=DATE:20260322\nEND:VEVENT\nEND:VCALENDAR\n"
+        ))
+        assert e["all_day"] is True
+        assert (e["start"], e["end"]) == ("2026-03-17", "2026-03-22")
+
+    def test_all_day_renders_the_same_in_any_display_zone(self):
+        evt = {
+            "id": "gc:1", "source": "gc", "title": "Holiday",
+            "start": "2026-03-17", "end": "2026-03-18", "all_day": True,
+            "duration_minutes": None, "location": "", "attendees_summary": "",
+        }
+        assert format_events([evt], tz="Pacific/Auckland") == format_events(
+            [evt], tz="America/Los_Angeles"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The bug #54 was filed for
+# ---------------------------------------------------------------------------
+
+
+def _mock_cal_sources(monkeypatch, adapters: dict[str, object]) -> None:
+    """Point _cal_fetch_events at prebuilt adapters, one per source prefix."""
+    monkeypatch.setattr(
+        "ts4k.state.sources.list_all",
+        lambda: {
+            pfx: {"provider": "gcal", "email": "a@b.com", "calendar_id": "primary"}
+            for pfx in adapters
+        },
+    )
+
+    def _make(prefix: str, cfg: dict):
+        real = adapters[prefix]
+        mock = MagicMock()
+        mock.__aenter__ = AsyncMock(return_value=mock)
+        mock.__aexit__ = AsyncMock(return_value=None)
+        mock.list_events = AsyncMock(return_value=real)
+        return mock
+
+    monkeypatch.setattr(commands, "_make_adapter", _make)
+
+
+class TestCrossSourceOrdering:
+    """Two sources, two configured zones, one chronological agenda."""
+
+    @pytest.mark.asyncio
+    async def test_merge_across_zones_is_chronological(self, monkeypatch):
+        # Amsterdam 00:30 CET on the 11th == 23:30 UTC on the 10th.
+        ams = _gcal("Europe/Amsterdam", prefix="gc")._normalize_event(
+            _gcal_raw("a1", "Amsterdam midnight snack",
+                      "2026-03-11T00:30:00+01:00", "2026-03-11T01:30:00+01:00")
+        )
+        # New York 20:00 EDT on the 10th == 00:00 UTC on the 11th — half an
+        # hour LATER, though its local date string reads earlier.
+        nyc = _o365cal("America/New_York", prefix="oc")._normalize_event(
+            _graph_raw("n1", "New York evening call",
+                       "2026-03-10T20:00:00.0000000",
+                       "2026-03-10T21:00:00.0000000", "America/New_York")
+        )
+        assert ams["start"] == "2026-03-10T23:30:00+00:00"
+        assert nyc["start"] == "2026-03-11T00:00:00+00:00"
+
+        _mock_cal_sources(monkeypatch, {"gc": [ams], "oc": [nyc]})
+        merged = await commands._cal_fetch_events(
+            None, "2026-03-10T00:00:00+00:00", "2026-03-12T00:00:00+00:00"
+        )
+
+        assert [e["title"] for e in merged] == [
+            "Amsterdam midnight snack",
+            "New York evening call",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_cross_zone_merge_renders_in_one_display_zone(self, monkeypatch):
+        """A merged agenda shows one wall clock, not each source's own."""
+        ams = _gcal("Europe/Amsterdam", prefix="gc")._normalize_event(
+            _gcal_raw("a1", "Amsterdam", "2026-03-11T15:00:00+01:00",
+                      "2026-03-11T16:00:00+01:00")
+        )
+        nyc = _o365cal("America/New_York", prefix="oc")._normalize_event(
+            _graph_raw("n1", "New York", "2026-03-11T10:00:00.0000000",
+                       "2026-03-11T11:00:00.0000000", "America/New_York")
+        )
+        _mock_cal_sources(monkeypatch, {"gc": [ams], "oc": [nyc]})
+        merged = await commands._cal_fetch_events(
+            None, "2026-03-11T00:00:00+00:00", "2026-03-12T00:00:00+00:00"
+        )
+
+        # Both events are the same hour: 14:00-15:00 UTC.
+        out = format_events(merged, tz="Europe/London")
+        rows = [ln for ln in out.splitlines() if not ln.startswith("REF|")]
+        assert len(rows) == 2
+        assert all("14:00-15:00" in row for row in rows), out
+
+
+class TestDstTransition:
+    """Europe/Amsterdam falls back at 03:00 CEST on 2026-10-25."""
+
+    @pytest.mark.asyncio
+    async def test_fallback_day_sorts_chronologically(self, monkeypatch):
+        adapter = _gcal("Europe/Amsterdam")
+        # 02:30 happens twice: once at +02:00 (00:30 UTC), once at +01:00
+        # (01:30 UTC).  Sorted by their local strings the repeated hour comes
+        # out backwards, because "+01:00" < "+02:00".
+        events = [
+            adapter._normalize_event(_gcal_raw(
+                "e2", "Second 02:30 (CET)",
+                "2026-10-25T02:30:00+01:00", "2026-10-25T03:00:00+01:00")),
+            adapter._normalize_event(_gcal_raw(
+                "e1", "First 02:30 (CEST)",
+                "2026-10-25T02:30:00+02:00", "2026-10-25T03:00:00+02:00")),
+            adapter._normalize_event(_gcal_raw(
+                "e0", "02:00 (CEST)",
+                "2026-10-25T02:00:00+02:00", "2026-10-25T02:30:00+02:00")),
+        ]
+        assert [e["start"] for e in events] == [
+            "2026-10-25T01:30:00+00:00",
+            "2026-10-25T00:30:00+00:00",
+            "2026-10-25T00:00:00+00:00",
+        ]
+
+        _mock_cal_sources(monkeypatch, {"gc": events})
+        merged = await commands._cal_fetch_events(
+            None, "2026-10-25T00:00:00+00:00", "2026-10-26T00:00:00+00:00"
+        )
+
+        assert [e["title"] for e in merged] == [
+            "02:00 (CEST)",
+            "First 02:30 (CEST)",
+            "Second 02:30 (CET)",
+        ]
+
+    def test_fallback_day_repeated_hour_renders_local(self):
+        """Both halves of the repeated hour print as 02:30 for the reader.
+
+        The first one's *end* reads 02:00 because the clock rewinds while it
+        is running — 03:00 CEST is 02:00 CET.  That is the local wall clock,
+        which is what the display layer is for; the duration column still
+        shows the 30 real minutes the event lasts.
+        """
+        adapter = _gcal("Europe/Amsterdam")
+        events = [
+            adapter._normalize_event(_gcal_raw(
+                "e1", "First", "2026-10-25T02:30:00+02:00",
+                "2026-10-25T03:00:00+02:00")),
+            adapter._normalize_event(_gcal_raw(
+                "e2", "Second", "2026-10-25T02:30:00+01:00",
+                "2026-10-25T03:00:00+01:00")),
+        ]
+        out = format_events(events, tz="Europe/Amsterdam")
+        rows = [ln for ln in out.splitlines() if not ln.startswith("REF|")]
+        assert all(row.split("|")[2].startswith("02:30") for row in rows), out
+        assert all(row.split("|")[3] == "30m" for row in rows), out
+
+
+# ---------------------------------------------------------------------------
+# Display timezone resolution
+# ---------------------------------------------------------------------------
+
+
+class TestDisplayTimezoneResolution:
+    """env var, then settings.json, then the machine — one global answer."""
+
+    @staticmethod
+    def _use_settings_file(monkeypatch, tmp_path: Path, body: str | None):
+        from ts4k.state import settings
+
+        path = tmp_path / "settings.json"
+        if body is not None:
+            path.write_text(body, encoding="utf-8")
+        monkeypatch.setattr(settings, "_SETTINGS_FILE", path)
+
+    def test_env_var_wins_over_settings(self, monkeypatch, tmp_path: Path):
+        from ts4k.core.tz import display_tzinfo
+
+        self._use_settings_file(monkeypatch, tmp_path, '{"timezone": "Asia/Tokyo"}')
+        monkeypatch.setenv("TS4K_TIMEZONE", "America/New_York")
+        assert str(display_tzinfo()) == "America/New_York"
+
+    def test_settings_file_used_when_no_env_var(self, monkeypatch, tmp_path: Path):
+        from ts4k.core.tz import display_tzinfo
+
+        self._use_settings_file(monkeypatch, tmp_path, '{"timezone": "Asia/Tokyo"}')
+        monkeypatch.delenv("TS4K_TIMEZONE", raising=False)
+        assert str(display_tzinfo()) == "Asia/Tokyo"
+
+    def test_falls_back_to_the_machine_zone(self, monkeypatch, tmp_path: Path):
+        from ts4k.core.tz import display_tzinfo, system_tzinfo
+
+        self._use_settings_file(monkeypatch, tmp_path, None)
+        monkeypatch.delenv("TS4K_TIMEZONE", raising=False)
+        assert display_tzinfo() == system_tzinfo()
+
+    def test_tz_env_names_the_machine_zone(self, monkeypatch):
+        from ts4k.core.tz import system_tzinfo
+
+        monkeypatch.setenv("TZ", "Asia/Tokyo")
+        assert str(system_tzinfo()) == "Asia/Tokyo"
+
+    def test_unknown_zone_falls_back_to_utc(self, monkeypatch, tmp_path: Path):
+        from datetime import timezone
+
+        from ts4k.core.tz import display_tzinfo
+
+        self._use_settings_file(monkeypatch, tmp_path, None)
+        monkeypatch.setenv("TS4K_TIMEZONE", "Not/A/Zone")
+        assert display_tzinfo() is timezone.utc
+
+    def test_malformed_settings_file_falls_back_to_the_machine(self, monkeypatch, tmp_path: Path):
+        from ts4k.core.tz import display_tzinfo, system_tzinfo
+
+        self._use_settings_file(monkeypatch, tmp_path, "{not json")
+        monkeypatch.delenv("TS4K_TIMEZONE", raising=False)
+        assert display_tzinfo() == system_tzinfo()
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: the common single-timezone install
+# ---------------------------------------------------------------------------
+
+
+class TestSingleTimezoneUnchanged:
+    """One calendar, one zone, display zone matching — times must not shift."""
+
+    def test_listing_shows_the_calendar_wall_clock(self):
+        adapter = _gcal("Europe/Amsterdam")
+        events = [
+            adapter._normalize_event(_gcal_raw(
+                "e1", "Standup", "2026-03-11T09:00:00+01:00",
+                "2026-03-11T09:30:00+01:00")),
+            adapter._normalize_event(_gcal_raw(
+                "e2", "Budget Review", "2026-03-11T14:00:00+01:00",
+                "2026-03-11T15:00:00+01:00")),
+        ]
+        out = format_events(events, tz="Europe/Amsterdam")
+        assert "09:00-09:30" in out
+        assert "14:00-15:00" in out
+
+    def test_detail_shows_the_calendar_wall_clock(self):
+        event = _gcal("Europe/Amsterdam")._normalize_event(_gcal_raw(
+            "e1", "Budget Review", "2026-03-11T11:00:00+01:00",
+            "2026-03-11T12:00:00+01:00"))
+        out = format_event_detail(event, ref=1, tz="Europe/Amsterdam")
+        assert "<when>Wed Mar 11, 11:00-12:00 (1h)</when>" in out
+
+    def test_caldav_listing_shows_the_calendar_wall_clock(self, tmp_path: Path):
+        """The live install's source type (`cc`, iCloud) must not shift."""
+        adapter = _caldav(tmp_path, "Europe/Amsterdam")
+        events = [
+            adapter._normalize_component(_vevent(
+                "BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//t//EN\nBEGIN:VEVENT\n"
+                "UID:u1\nSUMMARY:Dentist\n"
+                "DTSTART;TZID=Europe/Amsterdam:20260730T140000\n"
+                "DTEND;TZID=Europe/Amsterdam:20260730T150000\n"
+                "END:VEVENT\nEND:VCALENDAR\n"
+            )),
+            # A floating (zone-less) time means the source's own zone
+            adapter._normalize_component(_vevent(
+                "BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//t//EN\nBEGIN:VEVENT\n"
+                "UID:u2\nSUMMARY:Floating\nDTSTART:20260730T090000\n"
+                "DTEND:20260730T093000\nEND:VEVENT\nEND:VCALENDAR\n"
+            )),
+        ]
+        out = format_events(events, tz="Europe/Amsterdam")
+        assert "14:00-15:00" in out
+        assert "09:00-09:30" in out
+
+    def test_day_grouping_uses_the_display_date_not_the_utc_date(self):
+        """A late-evening local event must not be filed under the next day."""
+        adapter = _gcal("America/New_York")
+        events = [
+            adapter._normalize_event(_gcal_raw(
+                "e1", "Morning", "2026-03-11T09:00:00-04:00",
+                "2026-03-11T10:00:00-04:00")),
+            # 21:00 EDT is 01:00 UTC on the 12th — same local day, though.
+            adapter._normalize_event(_gcal_raw(
+                "e2", "Late show", "2026-03-11T21:00:00-04:00",
+                "2026-03-11T22:00:00-04:00")),
+        ]
+        out = format_events(events, tz="America/New_York")
+        # Single local day -> "time" mode: bare HH:MM, no day name prefix.
+        assert "09:00-10:00" in out
+        assert "21:00-22:00" in out
+        assert "Wed" not in out

--- a/tests/test_caldav_adapter.py
+++ b/tests/test_caldav_adapter.py
@@ -184,7 +184,8 @@ class TestNormalization:
         assert e["id"] == "cc:abc123@icloud.com"
         assert e["source"] == "cc"
         assert e["title"] == "Dentist"
-        assert e["start"].startswith("2026-07-30T14:00:00")
+        # 14:00 CEST (Europe/Amsterdam) is stored as 12:00 UTC
+        assert e["start"] == "2026-07-30T12:00:00+00:00"
         assert e["all_day"] is False
         assert e["duration_minutes"] == 60
         assert e["location"] == "Main St 1"
@@ -201,16 +202,16 @@ class TestNormalization:
         assert e["end"] == "2026-07-31"
         assert e["duration_minutes"] is None
 
-    def test_floating_time_gets_config_timezone(self, adapter: CaldavAdapter):
+    def test_floating_time_read_in_config_timezone_stored_as_utc(self, adapter: CaldavAdapter):
         e = adapter._normalize_component(_mk_caldav_event(FLOATING_ICS).icalendar_component)
-        # Europe/Amsterdam on 2026-07-30 is UTC+2
-        assert e["start"] == "2026-07-30T09:00:00+02:00"
+        # 09:00 floating means 09:00 Europe/Amsterdam (UTC+2 on 2026-07-30)
+        assert e["start"] == "2026-07-30T07:00:00+00:00"
         assert e["duration_minutes"] == 30
 
     def test_recurring_instance_ids(self, adapter: CaldavAdapter):
         e = adapter._normalize_component(_mk_caldav_event(INSTANCE_ICS).icalendar_component)
         assert e["recurring_event_id"] == "cc:rec1@icloud.com"
-        assert e["id"].startswith("cc:rec1@icloud.com::2026-08-06T14:00:00")
+        assert e["id"] == "cc:rec1@icloud.com::2026-08-06T12:00:00+00:00"
 
     def test_single_attendee_is_not_treated_as_a_sequence(self, adapter: CaldavAdapter):
         # icalendar returns a bare vCalAddress (not a list) for one ATTENDEE
@@ -220,10 +221,10 @@ class TestNormalization:
         assert e["attendees_summary"] == "1 people"
         assert e["your_status"] == "tentative"
 
-    def test_foreign_timezone_normalized_to_config_tz(self, adapter: CaldavAdapter):
-        # 09:00 EDT (America/New_York) on 2026-07-30 == 15:00 CEST (Europe/Amsterdam)
+    def test_foreign_timezone_normalized_to_utc(self, adapter: CaldavAdapter):
+        # 09:00 EDT (America/New_York) on 2026-07-30 == 13:00 UTC
         e = adapter._normalize_component(_mk_caldav_event(FOREIGN_TZ_ICS).icalendar_component)
-        assert e["start"] == "2026-07-30T15:00:00+02:00"
+        assert e["start"] == "2026-07-30T13:00:00+00:00"
         assert e["duration_minutes"] == 60
 
 

--- a/tests/test_caldav_commands.py
+++ b/tests/test_caldav_commands.py
@@ -51,12 +51,6 @@ class TestResolvePrefixes:
 class TestCalSourceAliases:
     """`cal today --source apple` must reach caldav sources, not silently return []."""
 
-    @staticmethod
-    def _amsterdam_cfg() -> dict:
-        cfg = dict(CALDAV_CFG)
-        cfg["timezone"] = "Europe/Amsterdam"
-        return cfg
-
     async def test_alias_fetches_from_caldav_source(self, monkeypatch):
         monkeypatch.setattr(
             "ts4k.state.sources.list_all", lambda: {"cc": dict(CALDAV_CFG)}
@@ -74,17 +68,10 @@ class TestCalSourceAliases:
             )
             assert events == [event], f"alias {alias!r} returned {events}"
 
-    def test_alias_resolves_timezone(self, monkeypatch):
-        monkeypatch.setattr(
-            "ts4k.state.sources.list_all", lambda: {"cc": self._amsterdam_cfg()}
-        )
-        assert commands._get_cal_timezone("apple") == "Europe/Amsterdam"
-        assert commands._get_cal_timezone("icloud") == "Europe/Amsterdam"
-
     async def test_exact_case_prefix_still_matches(self, monkeypatch):
         """`src add` preserves prefix case — an exact key must win over lowercasing."""
         monkeypatch.setattr(
-            "ts4k.state.sources.list_all", lambda: {"Work": self._amsterdam_cfg()}
+            "ts4k.state.sources.list_all", lambda: {"Work": dict(CALDAV_CFG)}
         )
         event = {"id": "Work:1", "title": "Standup", "start": "2026-07-30T09:00:00"}
         adapter = MagicMock()
@@ -94,7 +81,6 @@ class TestCalSourceAliases:
         monkeypatch.setattr(commands, "_make_adapter", lambda p, c: adapter)
 
         assert commands._resolve_prefixes("Work") == ["Work"]
-        assert commands._get_cal_timezone("Work") == "Europe/Amsterdam"
         events = await commands._cal_fetch_events(
             "Work", "2026-07-30T00:00:00", "2026-07-31T00:00:00"
         )

--- a/tests/test_caldav_write.py
+++ b/tests/test_caldav_write.py
@@ -61,7 +61,8 @@ class TestCreateEvent:
             description="Birthday", location="Cafe",
         )
         assert e["title"] == "Dinner"
-        assert e["start"] == "2026-07-30T19:00:00+02:00"
+        # Written as 19:00 Europe/Amsterdam, echoed back stored in UTC
+        assert e["start"] == "2026-07-30T17:00:00+00:00"
         assert e["duration_minutes"] == 120
         sent_ics = a._calendar.save_event.call_args.args[0]
         assert "SUMMARY:Dinner" in sent_ics
@@ -145,7 +146,8 @@ END:VCALENDAR
         e = await a.update_event("cc:up1", title="New", start="2026-07-30T12:00:00")
         obj.save.assert_called_once()
         assert e["title"] == "New"
-        assert e["start"] == "2026-07-30T12:00:00+02:00"
+        # Naive input is read in the source's zone, stored as UTC
+        assert e["start"] == "2026-07-30T10:00:00+00:00"
 
     async def test_all_day_inclusive_end_date_converted(self, tmp_path: Path):
         """All-day end is inclusive from the user, exclusive in iCal — same as create."""


### PR DESCRIPTION
Closes #54.

Implements the standing project convention — **datetime storage and manipulation in UTC, conversion to local only at display** — for the calendar pipeline, which predated it.

## 🚨 Release blocker: pin a display timezone before merging

**This machine resolves a different display timezone depending on how ts4k is launched.**

| launch context | resolved display tz |
|---|---|
| interactive shell (`TZ=Europe/Amsterdam` set) | `Europe/Amsterdam` ✅ |
| systemd / cron / container / MCP server (no `TZ`) | `Etc/UTC` ⚠️ |

`/etc/localtime` → `Etc/UTC` and `/etc/timezone` = `Etc/UTC`; `Europe/Amsterdam` comes **only** from a shell environment variable. All three calendar sources (`cc`, `gcn`, `gcp`) are configured `Europe/Amsterdam`, and no `~/.config/ts4k/settings.json` exists.

Before this change, display followed each source's configured `timezone` regardless of launcher. After it, display follows the resolved global zone — so **a non-interactive launch renders every calendar event 1–2 hours off**.

Fix before merging, either form — the first is launcher-independent and preferred:
```json
// ~/.config/ts4k/settings.json
{ "timezone": "Europe/Amsterdam" }
```
```sh
export TS4K_TIMEZONE=Europe/Amsterdam
```

## The problem being fixed
Adapters emitted `start`/`end` in source-local time while every sort in the pipeline is a lexicographic string sort. String order only matches chronological order when all compared timestamps share one offset. #51 papered over the worst case per source, but two gaps remained: the cross-source merge in `_cal_fetch_events` string-sorted events from sources in **different** timezones, and any window spanning a **DST transition** briefly carried two offsets. Sorting correctness depended on the accident that all sources happened to share a timezone.

## The change (one coordinated pass)
- `gcal`, `o365cal`, `caldav_cal` normalize timed `start`/`end` to UTC. **All-day events stay bare dates** — they're dates, not instants.
- The cheap string sorts become chronologically correct by construction, so they're kept.
- `format.py` converts UTC → display timezone at render.
- `_cal_time_bounds` computes "today"/"tomorrow" in the display timezone. `_get_cal_timezone` — the "first matching source's zone" the issue flagged as subtly wrong — is deleted.

Per-adapter notes:
- **o365cal** — Graph puts the zone in a *sibling* `timeZone` field, not in the dateTime string, so values were parsing naive. This also fixes `_compute_duration`, which was subtracting two naive wall-clock strings and came out an hour wrong across a DST boundary.
- **caldav_cal** — UTC conversion applied to the `RECURRENCE-ID` embedded in instance IDs as well as to start/end. Floating times still get the source zone attached first.
- **gcal** — the config zone is now only a fallback for a hypothetical offset-less payload.

## Design decisions (the issue self-declared `blocked:needs-design`)
- **One global display timezone**, resolved `TS4K_TIMEZONE` → `settings.json` → machine zone → UTC. Per-source display of a cross-source merged agenda is incoherent — mixed offsets in one agenda is the bug, not a feature.
- **"today" is today in the display timezone.**

## What the regression tests do and don't prove
`TestSingleTimezoneUnchanged` pins the **format layer's arithmetic**: given a matching display tz, the printed clock is identical to before. Verified directly against `main` — an event stored `2026-03-11T09:00:00+01:00` now stores `08:00:00+00:00` and still renders `09:00-09:30` in both listing and detail.

Those tests pass `tz` explicitly, so they **cannot** prove the resolver picks the right zone on a given machine. That gap is exactly the release blocker above.

## Other behaviour changes worth knowing
- **o365cal genuinely shifts.** Without a `Prefer: outlook.timezone` header Graph returns UTC, which the old code passed through unconverted — O365 events were being displayed *in UTC all along*. They now render in the display timezone. That's the bug being fixed, but it is a real visible change for that source. (No o365cal source is configured on this install.)
- **`-f json` output changed** — it dumps normalized dicts, now UTC. No in-repo consumer parses it; an external script would need updating.
- **Write path is now mildly asymmetric**: a naive `--start 14:00` is still interpreted per-source, not in the global display zone. Making creation symmetric is a real follow-up, outside #54's read-path scope.
- On a DST fallback day an event running 02:30 → 03:00 CEST renders `02:30-02:00`, because the clock rewinds mid-event. That is the correct local wall clock; the DUR column still reads 30m. Pinned by test rather than papered over.

## Wire-format consumers: checked, none found
Swept `src/`, docs and skill text for anything parsing emitted `start`/`end`. Every hit outside the calendar pipeline is on the **write** path (`server.py`, `cli.py` forwarding user-supplied strings into create/update). The MCP `cal` tool returns an already-formatted string. Calendar events are never cached, so there is no stale local-time state to migrate.

## Tests
`1212 passed, 4 skipped` (baseline 1195/4). `ruff check .` clean. New `tests/test_cal_timezone.py` (21 tests):
- `test_merge_across_zones_is_chronological` — Amsterdam 00:30+01:00 (23:30Z) vs New York 20:00 EDT (00:00Z). The old local-string sort put New York first; it is actually half an hour later.
- `test_fallback_day_sorts_chronologically` — Amsterdam's 2026-10-25 fallback where 02:30 occurs twice; local-string sorting inverts the repeated hour.
- `test_day_grouping_uses_the_display_date_not_the_utc_date` — a 21:00 EDT event is 01:00 UTC *next day* and must not file under tomorrow.
- Plus per-adapter UTC normalization, all-day passthrough, and display-tz resolution including malformed-settings and unknown-zone fallbacks.

`test_cal_format.py` and `test_cal_commands.py` gained autouse fixtures pinning `TS4K_TIMEZONE` — they were silently passing off the host's ambient `TZ` and would have failed on a UTC CI box.

## Docs
Design rule recorded in `docs/intentions.md` (rule 8), `CLAUDE.md` (rule 7), a new "Display timezone" section in `docs/usage.md`, the `core/tz.py` module docstring, and `cli.py`'s env-var help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)